### PR TITLE
INGK-541 Implement stop eoe service feature

### DIFF
--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -54,15 +54,7 @@ class EoENetwork(EthernetNetwork):
         Returns:
             EthernetServo: Instance of the servo connected.
 
-        Raises:
-            ILError: If a connection is attempted on a slave with an ID
-            greater than the number of connected slaves.
-
         """
-        _num_conn_slaves = self.scan_slaves()
-        if slave_id > _num_conn_slaves:
-            raise ILError(f'Cannot connect with slave {slave_id}. '
-                          f'Found {_num_conn_slaves} slaves')
         self._configure_slave(slave_id, ip_address)
         if not self._eoe_service_started:
             self._start_eoe_service()

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -29,7 +29,7 @@ class EoENetwork(EthernetNetwork):
         super().__init__()
         self.ifname = ifname
         self._eoe_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        self._eoe_socket.settimeout(connection_timeout)
+        #self._eoe_socket.settimeout(connection_timeout)
         self._initialize_eoe_service()
         self._eoe_service_started = False
 
@@ -56,6 +56,8 @@ class EoENetwork(EthernetNetwork):
 
         """
         self._configure_slave(slave_id, ip_address)
+        if not self._eoe_service_started:
+            self._start_eoe_service()
         return super().connect_to_slave(ip_address, dictionary,
                                         port, connection_timeout,
                                         servo_status_listener,
@@ -182,7 +184,7 @@ class EoENetwork(EthernetNetwork):
             raise ILError(f"Failed to configure slave {slave_id} with IP "
                           f"{ip_address}.") from e
 
-    def start_eoe_service(self):
+    def _start_eoe_service(self):
         """Starts the EoE service
 
          Raises:

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -29,7 +29,7 @@ class EoENetwork(EthernetNetwork):
         super().__init__()
         self.ifname = ifname
         self._eoe_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        #self._eoe_socket.settimeout(connection_timeout)
+        self._eoe_socket.settimeout(connection_timeout)
         self._initialize_eoe_service()
         self._eoe_service_started = False
 
@@ -54,7 +54,15 @@ class EoENetwork(EthernetNetwork):
         Returns:
             EthernetServo: Instance of the servo connected.
 
+        Raises:
+            ILError: If a connection is attempted on a slave with an ID
+            greater than the number of connected slaves.
+
         """
+        _num_conn_slaves = self.scan_slaves()
+        if slave_id > _num_conn_slaves:
+            raise ILError(f'Cannot connect with slave {slave_id}. '
+                          f'Found {_num_conn_slaves} slaves')
         self._configure_slave(slave_id, ip_address)
         if not self._eoe_service_started:
             self._start_eoe_service()
@@ -65,7 +73,6 @@ class EoENetwork(EthernetNetwork):
 
     def disconnect_from_slave(self, servo):
         super().disconnect_from_slave(servo)
-        # TODO: stop the EoE service once it's implemented
         if len(self.servos) == 0:
             self._eoe_socket.shutdown(socket.SHUT_RDWR)
             self._eoe_socket.close()
@@ -197,17 +204,3 @@ class EoENetwork(EthernetNetwork):
             self._send_command(msg)
         except (ILIOError, ILTimeoutError) as e:
             raise ILError("Failed to start the EoE service.") from e
-
-    def _stop_eoe_service(self):
-        """Stops the EoE service
-
-        Raises:
-            ILError: If the EoE service fails to stop.
-
-        """
-        self._eoe_service_started = False
-        msg = self._build_eoe_command_msg(EoECommand.STOP.value)
-        try:
-            self._send_command(msg)
-        except (ILIOError, ILTimeoutError) as e:
-            raise ILError("Failed to stop the EoE service.") from e


### PR DESCRIPTION
There is no need to stop the service. 

The solution is to just perform the following operations the first time the service is started:

- Initialize the network interfaces
-  Create the virtual adapter
-  Initialize the SOEM library
-  Start the forwarder
-  Start the EtherCAT master

Then, each time the service is started again only perform the configuration of the slaves.