### PR TITLE
INGK-543 - Remove registers with address_type=NVM_NONE or access!=rw from the xcf file

### DIFF
--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -1,5 +1,5 @@
 from ingenialink.register import Register
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY
+from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 
 class CanopenRegister(Register):
@@ -23,6 +23,7 @@ class CanopenRegister(Register):
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
             internal_use (int, optional): Internal use.
+            address_type (REG_ADDRESS_TYPE): Address Type.
 
         Raises:
             TypeError: If any of the parameters has invalid type.
@@ -34,11 +35,11 @@ class CanopenRegister(Register):
     def __init__(self, identifier, units, cyclic, idx, subidx, dtype,
                  access, phy=REG_PHY.NONE, subnode=1, storage=None,
                  reg_range=(None, None), labels=None, enums=None, enums_count=0,
-                 cat_id=None, scat_id=None, internal_use=0):
+                 cat_id=None, scat_id=None, internal_use=0, address_type=None):
 
         super().__init__(dtype, access, identifier, units, cyclic,
                          phy, subnode, storage, reg_range, labels, enums,
-                         enums_count, cat_id, scat_id, internal_use)
+                         enums_count, cat_id, scat_id, internal_use, address_type)
 
         self.__idx = idx
         self.__subidx = subidx

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -279,9 +279,9 @@ class Dictionary(ABC):
 
         Raises:
             KeyError: If the register doesn't have an identifier.
-            ILValueError: If the register data type is invalid.
-            ILAccessError: If the register access type is invalid.
-            ILUnsupportedRegisterValue: If the register address type is invalid.
+            ValueError: If the register data type is invalid.
+            ValueError: If the register access type is invalid.
+            ValueError: If the register address type is invalid.
             KeyError: If some attribute is missing.
 
         """
@@ -309,8 +309,8 @@ class Dictionary(ABC):
             if dtype_aux in self.dtype_xdf_options:
                 current_read_register[self.AttrRegDict.DTYPE] = self.dtype_xdf_options[dtype_aux]
             else:
-                raise exc.ILValueError(f'The data type {dtype_aux} does not exist for the register: '
-                                       f'{current_read_register["identifier"]}')
+                raise ValueError(f'The data type {dtype_aux} does not exist for the register: '
+                                 f'{current_read_register["identifier"]}')
 
             # Access type
             access_aux = register.attrib['access']
@@ -318,8 +318,8 @@ class Dictionary(ABC):
             if access_aux in self.access_xdf_options:
                 current_read_register[self.AttrRegDict.ACCESS] = self.access_xdf_options[access_aux]
             else:
-                raise exc.ILAccessError(f'The access type {access_aux} does not exist for the register: '
-                                        f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')
+                raise ValueError(f'The access type {access_aux} does not exist for the register: '
+                                 f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')
 
             # Address type
             address_type_aux = register.attrib['address_type']
@@ -327,8 +327,8 @@ class Dictionary(ABC):
             if address_type_aux in self.address_type_xdf_options:
                 current_read_register[self.AttrRegDict.ADDRESS_TYPE] = self.address_type_xdf_options[address_type_aux]
             else:
-                raise exc.ILUnsupportedRegisterValue(f'The address type {address_type_aux} does not exist for the register: '
-                                        f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')                            
+                raise ValueError(f'The address type {address_type_aux} does not exist for the register: '
+                                 f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')                            
 
             # Subnode
             current_read_register[self.AttrRegDict.SUBNODE] = int(register.attrib.get('subnode', 1))

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -277,6 +277,13 @@ class Dictionary(ABC):
             dict: The current register which it has been reading
             None: When at least a mandatory attribute is not in a xdf file
 
+        Raises:
+            KeyError: If the register doesn't have an identifier.
+            ILValueError: If the register data type is invalid.
+            ILAccessError: If the register access type is invalid.
+            ILUnsupportedRegisterValue: If the register address type is invalid.
+            KeyError: If some attribute is missing.
+
         """
         try:
             # Dictionary where the current register attributes will be saved
@@ -320,7 +327,7 @@ class Dictionary(ABC):
             if address_type_aux in self.address_type_xdf_options:
                 current_read_register[self.AttrRegDict.ADDRESS_TYPE] = self.address_type_xdf_options[address_type_aux]
             else:
-                raise exc.ILAccessError(f'The address type {address_type_aux} does not exist for the register: '
+                raise exc.ILUnsupportedRegisterValue(f'The address type {address_type_aux} does not exist for the register: '
                                         f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')                            
 
             # Subnode

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -3,7 +3,7 @@ import ingenialogger
 
 from abc import ABC, abstractmethod
 from ingenialink.constants import SINGLE_AXIS_MINIMUM_SUBNODES
-from ingenialink.register import REG_DTYPE, REG_ACCESS
+from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
 from ingenialink import exceptions as exc
 
 logger = ingenialogger.get_logger(__name__)
@@ -143,6 +143,7 @@ class Dictionary(ABC):
         ENUMS = 'enums'
         CAT_ID = 'cat_id'
         INT_USE = 'internal_use'
+        ADDRESS_TYPE = 'address_type'
 
     dtype_xdf_options = {
         "float": REG_DTYPE.FLOAT,
@@ -161,6 +162,14 @@ class Dictionary(ABC):
         "r": REG_ACCESS.RO,
         "w": REG_ACCESS.WO,
         "rw": REG_ACCESS.RW
+    }
+
+    address_type_xdf_options = {
+        "NVM": REG_ADDRESS_TYPE.NVM,
+        "NVM_NONE": REG_ADDRESS_TYPE.NVM_NONE,
+        "NVM_CFG": REG_ADDRESS_TYPE.NVM_CFG,
+        "NVM_LOCK": REG_ADDRESS_TYPE.NVM_LOCK,
+        "NVM_HW": REG_ADDRESS_TYPE.NVM_HW,
     }
 
     def __init__(self, dictionary_path):
@@ -304,6 +313,15 @@ class Dictionary(ABC):
             else:
                 raise exc.ILAccessError(f'The access type {access_aux} does not exist for the register: '
                                         f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')
+
+            # Address type
+            address_type_aux = register.attrib['address_type']
+
+            if address_type_aux in self.address_type_xdf_options:
+                current_read_register[self.AttrRegDict.ADDRESS_TYPE] = self.address_type_xdf_options[address_type_aux]
+            else:
+                raise exc.ILAccessError(f'The address type {address_type_aux} does not exist for the register: '
+                                        f'{current_read_register[self.AttrRegDict.IDENTIFIER]}')                            
 
             # Subnode
             current_read_register[self.AttrRegDict.SUBNODE] = int(register.attrib.get('subnode', 1))

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -53,3 +53,12 @@ class REG_PHY(Enum):
     """Relative voltage (DC)."""
     RAD = 6
     """Radians."""
+
+
+class REG_ADDRESS_TYPE(Enum):
+    """Address Type."""
+    NVM = 0
+    NVM_NONE = 1
+    NVM_CFG = 2
+    NVM_LOCK = 3
+    NVM_HW = 4

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -1,5 +1,5 @@
 from ingenialink.register import Register
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY
+from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 
 class EthernetRegister(Register):
@@ -22,6 +22,7 @@ class EthernetRegister(Register):
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
             internal_use (int, optional): Internal use.
+            address_type (REG_ADDRESS_TYPE): Address Type.
 
         Raises:
             TypeError: If any of the parameters has invalid type.
@@ -33,11 +34,11 @@ class EthernetRegister(Register):
     def __init__(self, address, dtype, access, identifier=None, units=None, cyclic="CONFIG",
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=(None, None),
                  labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
-                 internal_use=0):
+                 internal_use=0, address_type=None):
 
         super().__init__(dtype, access, identifier, units, cyclic, phy, subnode,
                          storage, reg_range, labels, enums, enums_count, cat_id,
-                         scat_id, internal_use)
+                         scat_id, internal_use, address_type)
 
         self.__address = address
 

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -1,5 +1,5 @@
 from ingenialink import exceptions as exc
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY
+from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 from abc import ABC
 
@@ -38,6 +38,7 @@ class Register(ABC):
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
             internal_use (int, optional): Internal use.
+            address_type (REG_ADDRESS_TYPE): Address tpye.
 
         Raises:
             TypeError: If any of the parameters has invalid type.
@@ -49,7 +50,7 @@ class Register(ABC):
     def __init__(self, dtype, access, identifier=None, units=None, cyclic="CONFIG",
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=(None, None),
                  labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
-                 internal_use=0):
+                 internal_use=0, address_type=None):
 
         if labels is None:
             labels = {}
@@ -74,6 +75,7 @@ class Register(ABC):
         self._scat_id = scat_id
         self._internal_use = internal_use
         self._storage_valid = 0 if not storage else 1
+        self._address_type = address_type
 
         self.__config_range(reg_range)
         self._enums = self.__config_enums()
@@ -227,3 +229,8 @@ class Register(ABC):
     def internal_use(self):
         """int: Defines if the register is only for internal uses."""
         return self._internal_use
+
+    @property
+    def address_type(self):
+        """REG_ADDRESS_TYPE: Address type of the register."""
+        return REG_ADDRESS_TYPE(self._address_type)

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -381,7 +381,7 @@ class Servo:
         for subnode in subnodes:
             registers_dict = self.dictionary.registers(subnode=subnode)
             for reg_id, register in registers_dict.items():
-                if (register.address_type == REG_ADDRESS_TYPE.NVM_NONE) | (register.access != REG_ACCESS.RW):
+                if (register.address_type == REG_ADDRESS_TYPE.NVM_NONE) or (register.access != REG_ACCESS.RW):
                     continue
                 register_xml = ET.SubElement(registers, "Register")
                 register_xml.set("access", access_ops[register.access])

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -387,8 +387,7 @@ class Servo:
                 register_xml.set("access", access_ops[register.access])
                 register_xml.set("dtype", dtype_ops[register.dtype])
                 register_xml.set("id", reg_id)
-                if access_ops[register.access] == 'rw':
-                    self.__update_register_dict(register_xml, subnode)
+                self.__update_register_dict(register_xml, subnode)
                 register_xml.set("subnode", str(subnode))
 
         dom = minidom.parseString(ET.tostring(tree, encoding='utf-8'))

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -15,7 +15,7 @@ from ingenialink.utils._utils import get_drive_identification, cleanup_register,
 from ingenialink.constants import PASSWORD_RESTORE_ALL, PASSWORD_STORE_ALL, \
     DEFAULT_PDS_TIMEOUT, MONITORING_BUFFER_SIZE
 from ingenialink.utils import constants
-from ingenialink.register import REG_DTYPE
+from ingenialink.register import REG_DTYPE, REG_ADDRESS_TYPE, REG_ACCESS
 
 import ingenialogger
 
@@ -381,6 +381,8 @@ class Servo:
         for subnode in subnodes:
             registers_dict = self.dictionary.registers(subnode=subnode)
             for reg_id, register in registers_dict.items():
+                if (register.address_type == REG_ADDRESS_TYPE.NVM_NONE) | (register.access != REG_ACCESS.RW):
+                    continue
                 register_xml = ET.SubElement(registers, "Register")
                 register_xml.set("access", access_ops[register.access])
                 register_xml.set("dtype", dtype_ops[register.dtype])

--- a/tests/register/test_canopen_register.py
+++ b/tests/register/test_canopen_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.canopen.dictionary import CanopenDictionary
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_PHY
+from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 
 @pytest.mark.smoke
@@ -23,10 +23,11 @@ def test_getters_canopen_register():
     test_cat_id = "MONITORING"
     test_scat_id = "SUB_CATEGORY_TEST"
     test_internal_use = "No description (invent here)"
+    test_address_type = REG_ADDRESS_TYPE.NVM
     register = CanopenRegister(test_identification, test_units, test_cyclic, test_idx, test_subidx,
                                test_dtype, test_access, test_phy, test_subnode, test_storage,
                                test_reg_range, test_labels, test_enums, test_enums_count,
-                               test_cat_id, test_scat_id, test_internal_use)
+                               test_cat_id, test_scat_id, test_internal_use, test_address_type)
 
     assert register.identifier == test_identification
     assert register.units == test_units
@@ -40,6 +41,7 @@ def test_getters_canopen_register():
     assert register.storage == test_storage
     assert register.range == test_reg_range
     assert register.labels == test_labels
+    assert register.address_type == test_address_type
 
     test_aux_enums = []
     for test_enum in test_enums:

--- a/tests/register/test_ethernet_register.py
+++ b/tests/register/test_ethernet_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, dtypes_ranges
+from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE, dtypes_ranges
 from ingenialink.utils._utils import exc
 
 
@@ -23,10 +23,11 @@ def test_getters_ethernet_register():
     test_cat_id = "MONITORING"
     test_scat_id = "SUB_CATEGORY_TEST"
     test_internal_use = "No description (invent here)"
+    test_address_type = REG_ADDRESS_TYPE.NVM
     register = EthernetRegister(test_addr, test_dtype, test_access, test_identification,
                                 test_units, test_cyclic, test_phy, test_subnode, test_storage,
                                 test_reg_range, test_labels, test_enums, test_enums_count,
-                                test_cat_id, test_scat_id, test_internal_use)
+                                test_cat_id, test_scat_id, test_internal_use, test_address_type)
 
     assert register.identifier == test_identification
     assert register.units == test_units
@@ -39,6 +40,7 @@ def test_getters_ethernet_register():
     assert register.storage == test_storage
     assert register.range == test_reg_range
     assert register.labels == test_labels
+    assert register.address_type == test_address_type
 
     test_aux_enums = []
     for test_enum in test_enums:

--- a/tests/servo/test_servo.py
+++ b/tests/servo/test_servo.py
@@ -1,6 +1,7 @@
 import os
 import xml.etree.ElementTree as ET
 from ingenialink.utils._utils import get_drive_identification
+from ingenialink.register import REG_ADDRESS_TYPE
 
 
 def _clean(filename):
@@ -61,6 +62,9 @@ def test_save_configuration(connect_to_slave):
 
         dtype = saved_register.attrib.get('dtype')
         assert registers[reg_id].dtype == servo.dictionary.dtype_xdf_options[dtype]
+
+        assert access == "rw"
+        assert registers[reg_id].address_type != REG_ADDRESS_TYPE.NVM_NONE
 
     _clean(filename)
 


### PR DESCRIPTION
This PR:

- Defines a new attribute `Register.address_type`
- Creates a `REG_ADDRESS_TYPE `enum to define the list of possible `address_type`.
- Reads the `address_type `from the xdf file.
- When saving the xcf file, avoids the registers with `address_type=NVM_NONE` and `access != rw`
- Updates tests accordingly