### PR TITLE
INGK-547 Define enums_count as len(enums) at the Register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+### Added
+
+### Changed
+- Remove enums_count as an argument to create a Register.
+- Convert enums type from list[dict] to dict.
+
 ## [6.4.0] - 2022-07-13
 ### Added
 - Support monitoring/disturbance with CANopen protocol.

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -18,7 +18,7 @@ class CanopenRegister(Register):
             storage (any, optional): Storage.
             reg_range (tuple, optional): Range (min, max).
             labels (dict, optional): Register labels.
-            enums (list): Enumeration registers.
+            enums (dict): Enumeration registers.
             enums_count (int): Number of enumeration registers.
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
@@ -33,12 +33,12 @@ class CanopenRegister(Register):
 
     def __init__(self, identifier, units, cyclic, idx, subidx, dtype,
                  access, phy=REG_PHY.NONE, subnode=1, storage=None,
-                 reg_range=(None, None), labels=None, enums=None, enums_count=0,
+                 reg_range=(None, None), labels=None, enums=None,
                  cat_id=None, scat_id=None, internal_use=0):
 
         super().__init__(dtype, access, identifier, units, cyclic,
                          phy, subnode, storage, reg_range, labels, enums,
-                         enums_count, cat_id, scat_id, internal_use)
+                         cat_id, scat_id, internal_use)
 
         self.__idx = idx
         self.__subidx = subidx

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -331,7 +331,7 @@ class Dictionary(ABC):
 
             # Enumerations
             enums_elem = register.findall(self.DICT_ENUMERATIONS_ENUMERATION)
-            current_read_register[self.AttrRegDict.ENUMS] = [{enum.attrib['value']: enum.text} for enum in enums_elem]
+            current_read_register[self.AttrRegDict.ENUMS] = {enum.attrib['value']: enum.text for enum in enums_elem} 
 
             return current_read_register
 

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -17,7 +17,7 @@ class EthernetRegister(Register):
             storage (any, optional): Storage.
             reg_range (tuple, optional): Range (min, max).
             labels (dict, optional): Register labels.
-            enums (list): Enumeration registers.
+            enums (dict): Enumeration registers.
             enums_count (int): Number of enumeration registers.
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
@@ -32,11 +32,11 @@ class EthernetRegister(Register):
 
     def __init__(self, address, dtype, access, identifier=None, units=None, cyclic="CONFIG",
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=(None, None),
-                 labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
+                 labels=None, enums=None, cat_id=None, scat_id=None,
                  internal_use=0):
 
         super().__init__(dtype, access, identifier, units, cyclic, phy, subnode,
-                         storage, reg_range, labels, enums, enums_count, cat_id,
+                         storage, reg_range, labels, enums, cat_id,
                          scat_id, internal_use)
 
         self.__address = address

--- a/ingenialink/ipb/register.py
+++ b/ingenialink/ipb/register.py
@@ -157,15 +157,15 @@ class IPBRegister(Register):
 
     def __init__(self, identifier, units, cyclic, dtype, access, address,
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=None,
-                 labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
+                 labels=None, enums=None, cat_id=None, scat_id=None,
                  internal_use=0, c_reg=None):
         if labels is None:
             labels = {}
         if enums is None:
-            enums = []
+            enums = {}
         super(IPBRegister, self).__init__(
             identifier, units, cyclic, dtype, access, phy, subnode, storage,
-            reg_range, labels, enums, enums_count, cat_id, scat_id, internal_use)
+            reg_range, labels, enums, cat_id, scat_id, internal_use)
 
         if not isinstance(dtype, REG_DTYPE):
             raise TypeError('Invalid data type')

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -109,7 +109,6 @@ class Register(ABC):
 
     def __config_enums(self):
         aux_enums = []
-        #for enum in self._enums:
         for key, value in self._enums.items():
             dictionary = {
                 'label': value,

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -33,7 +33,7 @@ class Register(ABC):
             storage (any, optional): Storage.
             reg_range (tuple, optional): Range (min, max).
             labels (dict, optional): Register labels.
-            enums (list): Enumeration registers.
+            enums (dict): Enumeration registers.
             enums_count (int): Number of enumeration registers.
             cat_id (str, optional): Category ID.
             scat_id (str, optional): Sub-category ID.
@@ -48,13 +48,12 @@ class Register(ABC):
 
     def __init__(self, dtype, access, identifier=None, units=None, cyclic="CONFIG",
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=(None, None),
-                 labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
-                 internal_use=0):
+                 labels=None, enums=None, cat_id=None, scat_id=None, internal_use=0):
 
         if labels is None:
             labels = {}
         if enums is None:
-            enums = []
+            enums = {}
 
         self.__type_errors(dtype, access, phy)
 
@@ -69,7 +68,7 @@ class Register(ABC):
         self._range = (None, None) if not reg_range else reg_range
         self._labels = labels
         self._enums = enums
-        self._enums_count = enums_count if enums_count != 0 else len(enums)
+        self._enums_count = len(enums)
         self._cat_id = cat_id
         self._scat_id = scat_id
         self._internal_use = internal_use
@@ -110,13 +109,13 @@ class Register(ABC):
 
     def __config_enums(self):
         aux_enums = []
-        for enum in self._enums:
-            for key, value in enum.items():
-                dictionary = {
-                    'label': value,
-                    'value': int(key)
-                }
-                aux_enums.append(dictionary)
+        #for enum in self._enums:
+        for key, value in self._enums.items():
+            dictionary = {
+                'label': value,
+                'value': int(key)
+            }
+            aux_enums.append(dictionary)
 
         return aux_enums
 

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -69,7 +69,7 @@ class Register(ABC):
         self._range = (None, None) if not reg_range else reg_range
         self._labels = labels
         self._enums = enums
-        self._enums_count = enums_count
+        self._enums_count = enums_count if enums_count != 0 else len(enums)
         self._cat_id = cat_id
         self._scat_id = scat_id
         self._internal_use = internal_use

--- a/ingenialink/register_deprecated.py
+++ b/ingenialink/register_deprecated.py
@@ -77,12 +77,12 @@ class Register(ABC):
     """
     def __init__(self, identifier, units, cyclic, dtype, access,
                  phy=REG_PHY.NONE, subnode=1, storage=None, reg_range=None,
-                 labels=None, enums=None, enums_count=0, cat_id=None, scat_id=None,
+                 labels=None, enums=None, cat_id=None, scat_id=None,
                  internal_use=0):
         if labels is None:
             labels = {}
         if enums is None:
-            enums = []
+            enums = {}
 
         if not isinstance(dtype, REG_DTYPE):
             raise TypeError('Invalid data type')
@@ -106,7 +106,7 @@ class Register(ABC):
         self._range = (None, None) if not reg_range else reg_range
         self._labels = labels
         self._enums = enums
-        self._enums_count = enums_count
+        self._enums_count = len(enums)
         self._cat_id = cat_id
         self._scat_id = scat_id
 

--- a/tests/register/test_canopen_register.py
+++ b/tests/register/test_canopen_register.py
@@ -18,14 +18,14 @@ def test_getters_canopen_register():
     test_storage = 1
     test_reg_range = (-20, 20)
     test_labels = "Monitoring trigger type"
-    test_enums = [{'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}]
+    test_enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
     test_enums_count = 2
     test_cat_id = "MONITORING"
     test_scat_id = "SUB_CATEGORY_TEST"
     test_internal_use = "No description (invent here)"
     register = CanopenRegister(test_identification, test_units, test_cyclic, test_idx, test_subidx,
                                test_dtype, test_access, test_phy, test_subnode, test_storage,
-                               test_reg_range, test_labels, test_enums, test_enums_count,
+                               test_reg_range, test_labels, test_enums,
                                test_cat_id, test_scat_id, test_internal_use)
 
     assert register.identifier == test_identification
@@ -42,10 +42,9 @@ def test_getters_canopen_register():
     assert register.labels == test_labels
 
     test_aux_enums = []
-    for test_enum in test_enums:
-        for key, value in test_enum.items():
-            test_dictionary = {'label': value, 'value': int(key)}
-            test_aux_enums.append(test_dictionary)
+    for key, value in test_enums.items():
+        test_dictionary = {'label': value, 'value': int(key)}
+        test_aux_enums.append(test_dictionary)
 
     assert register.enums == test_aux_enums
     assert register.enums_count == test_enums_count

--- a/tests/register/test_ethernet_register.py
+++ b/tests/register/test_ethernet_register.py
@@ -18,14 +18,14 @@ def test_getters_ethernet_register():
     test_storage = 1
     test_reg_range = (-20, 20)
     test_labels = "Monitoring trigger type"
-    test_enums = [{'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}]
+    test_enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
     test_enums_count = 2
     test_cat_id = "MONITORING"
     test_scat_id = "SUB_CATEGORY_TEST"
     test_internal_use = "No description (invent here)"
     register = EthernetRegister(test_addr, test_dtype, test_access, test_identification,
                                 test_units, test_cyclic, test_phy, test_subnode, test_storage,
-                                test_reg_range, test_labels, test_enums, test_enums_count,
+                                test_reg_range, test_labels, test_enums,
                                 test_cat_id, test_scat_id, test_internal_use)
 
     assert register.identifier == test_identification
@@ -41,10 +41,9 @@ def test_getters_ethernet_register():
     assert register.labels == test_labels
 
     test_aux_enums = []
-    for test_enum in test_enums:
-        for key, value in test_enum.items():
-            test_dictionary = {'label': value, 'value': int(key)}
-            test_aux_enums.append(test_dictionary)
+    for key, value in test_enums.items():
+        test_dictionary = {'label': value, 'value': int(key)}
+        test_aux_enums.append(test_dictionary)
 
     assert register.enums == test_aux_enums
     assert register.enums_count == test_enums_count
@@ -57,19 +56,19 @@ def test_getters_ethernet_register():
 @pytest.mark.parametrize("test2_dtype", [REG_DTYPE.S8, REG_DTYPE.FLOAT, REG_DTYPE.DOMAIN, "Other type"])
 @pytest.mark.parametrize("test2_storage", [None, 1])
 def test_storage_dtype(test2_dtype, test2_storage):
-    enums_count = [{'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}]
+    enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
     # dtype test conditional
     if not isinstance(test2_dtype, REG_DTYPE):
         with pytest.raises(exc.ILValueError):
             EthernetRegister(0x58F0, test2_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
                              "none", "CONFIG", REG_PHY.NONE, 1, test2_storage,
-                             (-20, 20), "Monitoring trigger type", enums_count,
+                             (-20, 20), "Monitoring trigger type", enums,
                              "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
 
     else:
         register = EthernetRegister(0x58F0, test2_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
                                     "none", "CONFIG", REG_PHY.NONE, 1, test2_storage,
-                                    (-20, 20), "Monitoring trigger type", enums_count,
+                                    (-20, 20), "Monitoring trigger type", enums,
                                     "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
         # storage test conditional
         if test2_dtype in [REG_DTYPE.S8, REG_DTYPE.U8, REG_DTYPE.S16,
@@ -84,10 +83,10 @@ def test_storage_dtype(test2_dtype, test2_storage):
 @pytest.mark.parametrize("test2_range", [(None, None), (-20, 20)])
 @pytest.mark.parametrize("test3_dtype", [REG_DTYPE.S8, REG_DTYPE.FLOAT])
 def test_range_ethernet_register(test2_range, test3_dtype):
-    enums = [{'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}]
+    enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
     register = EthernetRegister(0x58F0, test3_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
                                 "none", "CONFIG", REG_PHY.NONE, 1, 1,
-                                test2_range, "Monitoring trigger type", enums, len(enums),
+                                test2_range, "Monitoring trigger type", enums,
                                 "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
 
     if test2_range == (None, None):


### PR DESCRIPTION
Bugs: 

- `enums_count` is never defined when instancing the `Register` class. So, `Register.enums_count=0` even if `enums!=None`. 
- `enum` is a one-element list of dict where the dict is the enum dict. A simple dict should work.

Fix:
- Just define `enums_count=len(enums)` if the user doesn't define the value of `enums_count`
- Convert `enum` type from list of dict to dict.