### PR TITLE
INGK-559 Improve no-communication tests

### DIFF
--- a/ingenialink/ipb/register.py
+++ b/ingenialink/ipb/register.py
@@ -126,7 +126,7 @@ def ipb_register_from_cffi(cffi_register):
 
     return IPBRegister(identifier, units, cyclic, dtype, access,
                        address, phy, subnode, storage, reg_range,
-                       labels, enums, enums_count, cat_id, scat_id,
+                       labels, enums, cat_id, scat_id,
                        internal_use, cffi_register)
 
 

--- a/tests/canopen/test_canopen_dictionary.py
+++ b/tests/canopen/test_canopen_dictionary.py
@@ -1,51 +1,121 @@
 import pytest
-import xml.etree.ElementTree as ET
+from os.path import join as join_path
 
 from ingenialink.canopen.dictionary import CanopenDictionary
 
 
-@pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_registers", [
-    ("test_dict_can_1.xdf", 702),
-    ("test_dict_can_2.xdf", 698),
-    ("test_dict_can_axis_1.xdf", 16),
-    ("test_dict_can_no_attr_reg.xdf", 0)
-])
-def test_registers_dictionary(test_file_xdf, expected_num_registers):
-    # Count the number of registers in a CanopenDictionary instance
-    test_canopen_dict = CanopenDictionary(f'./tests/resources/canopen/{test_file_xdf}')
-    test_num_registers = 0
-    for current_subnode in range(test_canopen_dict.subnodes):
-        test_num_registers += len(test_canopen_dict.registers(current_subnode))
-
-    assert test_num_registers == expected_num_registers
-
-@pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_categories", [
-    ("test_dict_can_1.xdf", 20),
-    ("test_dict_can_2.xdf", 20),
-    ("test_dict_can_axis_1.xdf", 7)
-])
-def test_categories_dictionary(test_file_xdf, expected_num_categories):
-    # Count the number of categories in a CanopenDictionary instance
-    test_canopen_dict = CanopenDictionary(f'./tests/resources/canopen/{test_file_xdf}')
-    test_num_categories = len(test_canopen_dict.categories.category_ids)
-
-    assert test_num_categories == expected_num_categories
+path_resources = "./tests/resources/canopen/"
 
 
 @pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_errors", [
-    ("test_dict_can_1.xdf", 71),
-    ("test_dict_can_2.xdf", 71),
-    ("test_dict_can_axis_1.xdf", 8)
-])
-def test_errors_dictionary(test_file_xdf, expected_num_errors):
-    # Count the number of errors in a CanopenDictionary instance
-    test_canopen_dict = CanopenDictionary(f'./tests/resources/canopen/{test_file_xdf}')
-    test_num_errors = len(test_canopen_dict.errors.errors)
+def test_read_dictionary():
+    dictionary_path = join_path(path_resources, "test_dict_can.xdf")
+    expected_device_attr = {
+        "path" : dictionary_path,
+        "version" : "2",
+        "firmware_version" : "2.0.1",
+        "product_code" : 57745409,
+        "part_number" : "CAP-NET-C",
+        "revision_number" : 196635,
+        "interface" : "CAN",
+        "subnodes" : 2
+    }
 
-    assert test_num_errors == expected_num_errors
+    canopen_dict = CanopenDictionary(dictionary_path)
+    
+    for attr, value in expected_device_attr.items():
+        assert getattr(canopen_dict, attr) == value
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_file_not_found():
+    dictionary_path = "false.xdf"
+    
+    with pytest.raises(FileNotFoundError):
+        CanopenDictionary(dictionary_path)
+    
+
+@pytest.mark.no_connection
+def test_read_dictionary_registers():
+    dictionary_path = join_path(path_resources, "test_dict_can.xdf")
+    expected_regs_per_subnode = {
+        0: [
+            "DRV_DIAG_ERROR_LAST_COM",
+            "DIST_CFG_REG0_MAP",
+            "DRV_AXIS_NUMBER",
+            "COMMS_ETH_IP",
+            "COMMS_ETH_NET_MASK",
+        ],
+        1 : [
+            "COMMU_ANGLE_SENSOR"
+        ]
+    }
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+
+    for subnode in expected_regs_per_subnode.keys():
+        num_registers = len(canopen_dict.registers(subnode))
+        assert num_registers == len(expected_regs_per_subnode[subnode])
+        for register in canopen_dict.registers(subnode):
+            assert register in expected_regs_per_subnode[subnode]
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_registers_multiaxis():
+    expected_num_registers_per_subnode = {0: 6, 1: 5, 2: 5}
+    dictionary_path = join_path(path_resources, "test_dict_can_axis.xdf")
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+
+    for subnode in expected_num_registers_per_subnode.keys():
+        num_registers = len(canopen_dict.registers(subnode))
+        assert num_registers == expected_num_registers_per_subnode[subnode]
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_categories():
+    expected_categories = [
+        "IDENTIFICATION",
+        "COMMUNICATIONS",
+        "COMMUTATION",
+        "REPORTING",
+        "MONITORING"
+    ]
+    dictionary_path = join_path(path_resources, "test_dict_can.xdf")
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+
+    assert len(canopen_dict.categories.category_ids) == len(expected_categories)
+    for cat in expected_categories:
+        assert cat in canopen_dict.categories.category_ids
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_errors():
+    expected_errors = [
+        0x00003280,
+        0x00007380,
+        0x00007385,
+        0x06010000,
+    ]
+    dictionary_path = join_path(path_resources, "test_dict_can.xdf")
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+
+    assert len(canopen_dict.errors.errors) == len(expected_errors)
+    for error in expected_errors:
+        assert error in canopen_dict.errors.errors
+
+
+@pytest.mark.no_connection
+def test_read_xdf_register():
+    dictionary_path = join_path(path_resources, "test_dict_can.xdf")
+    idx = 0x580F
+    subidx = 0x00
+    reg_id = "DRV_DIAG_ERROR_LAST_COM"
+    subnode = 0
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+    
+    assert canopen_dict.registers(subnode)[reg_id].idx == idx
+    assert canopen_dict.registers(subnode)[reg_id].subidx == subidx

--- a/tests/canopen/test_canopen_dictionary.py
+++ b/tests/canopen/test_canopen_dictionary.py
@@ -54,11 +54,7 @@ def test_read_dictionary_registers():
     canopen_dict = CanopenDictionary(dictionary_path)
 
     for subnode in expected_regs_per_subnode.keys():
-        num_registers = len(canopen_dict.registers(subnode))
-        assert num_registers == len(expected_regs_per_subnode[subnode])
-        for register in canopen_dict.registers(subnode):
-            assert register in expected_regs_per_subnode[subnode]
-
+        assert expected_regs_per_subnode[subnode] == [reg for reg in canopen_dict.registers(subnode)]
 
 @pytest.mark.no_connection
 def test_read_dictionary_registers_multiaxis():
@@ -78,7 +74,7 @@ def test_read_dictionary_registers_attr_errors():
 
     canopen_dict = CanopenDictionary(dictionary_path)
 
-    for subnode in [0, 1]:
+    for subnode in range(2):
         num_registers = len(canopen_dict.registers(subnode))
         assert num_registers == 0
 
@@ -96,10 +92,7 @@ def test_read_dictionary_categories():
 
     canopen_dict = CanopenDictionary(dictionary_path)
 
-    assert len(canopen_dict.categories.category_ids) == len(expected_categories)
-    for cat in expected_categories:
-        assert cat in canopen_dict.categories.category_ids
-
+    assert canopen_dict.categories.category_ids == expected_categories
 
 @pytest.mark.no_connection
 def test_read_dictionary_errors():
@@ -113,10 +106,7 @@ def test_read_dictionary_errors():
 
     canopen_dict = CanopenDictionary(dictionary_path)
 
-    assert len(canopen_dict.errors.errors) == len(expected_errors)
-    for error in expected_errors:
-        assert error in canopen_dict.errors.errors
-
+    assert [error for error in canopen_dict.errors.errors] == expected_errors
 
 @pytest.mark.no_connection
 def test_read_xdf_register():

--- a/tests/canopen/test_canopen_dictionary.py
+++ b/tests/canopen/test_canopen_dictionary.py
@@ -73,6 +73,17 @@ def test_read_dictionary_registers_multiaxis():
 
 
 @pytest.mark.no_connection
+def test_read_dictionary_registers_attr_errors():
+    dictionary_path = join_path(path_resources, "test_dict_can_no_attr_reg.xdf")
+
+    canopen_dict = CanopenDictionary(dictionary_path)
+
+    for subnode in [0, 1]:
+        num_registers = len(canopen_dict.registers(subnode))
+        assert num_registers == 0
+
+
+@pytest.mark.no_connection
 def test_read_dictionary_categories():
     expected_categories = [
         "IDENTIFICATION",

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -7,51 +7,51 @@ from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS,
 @pytest.mark.no_connection
 @pytest.mark.smoke
 def test_getters_canopen_register():
-    test_identification = "MON_CFG_SOC_TYPE"
-    test_units = "none"
-    test_cyclic = "CONFIG"
-    test_idx = 0x58F0
-    test_subidx = 0x00
-    test_dtype = REG_DTYPE.U32
-    test_access = REG_ACCESS.RW
-    test_phy = REG_PHY.NONE
-    test_subnode = 0
-    test_storage = 1
-    test_reg_range = (-20, 20)
-    test_labels = "Monitoring trigger type"
-    test_enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
-    test_enums_count = 2
-    test_cat_id = "MONITORING"
-    test_scat_id = "SUB_CATEGORY_TEST"
-    test_internal_use = "No description (invent here)"
-    register = CanopenRegister(test_identification, test_units, test_cyclic, test_idx, test_subidx,
-                               test_dtype, test_access, test_phy, test_subnode, test_storage,
-                               test_reg_range, test_labels, test_enums,
-                               test_cat_id, test_scat_id, test_internal_use)
-
-    assert register.identifier == test_identification
-    assert register.units == test_units
-    assert register.cyclic == test_cyclic
-    assert register.idx == test_idx
-    assert register.subidx == test_subidx
-    assert register.dtype == test_dtype
-    assert register.access == test_access
-    assert register.phy == test_phy
-    assert register.subnode == test_subnode
-    assert register.storage == test_storage
-    assert register.range == test_reg_range
-    assert register.labels == test_labels
-
-    test_aux_enums = []
-    for key, value in test_enums.items():
+    reg_identifier = "MON_CFG_SOC_TYPE"
+    reg_units = "none"
+    reg_cyclic = "CONFIG"
+    reg_idx = 0x58F0
+    reg_subidx = 0x00
+    reg_dtype = REG_DTYPE.U32
+    reg_access = REG_ACCESS.RW
+    reg_kwargs = {
+        "phy": REG_PHY.NONE,
+        "subnode": 0,
+        "storage": 1,
+        "reg_range": (-20, 20),
+        "labels": "Monitoring trigger type",
+        "enums": {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'},
+        "cat_id": "MONITORING",
+        "scat_id": "SUB_CATEGORY_TEST",
+        "internal_use": "No description (invent here)",
+    }
+    aux_enums = []
+    for key, value in reg_kwargs["enums"].items():
         test_dictionary = {'label': value, 'value': int(key)}
-        test_aux_enums.append(test_dictionary)
+        aux_enums.append(test_dictionary)
 
-    assert register.enums == test_aux_enums
-    assert register.enums_count == test_enums_count
-    assert register.cat_id == test_cat_id
-    assert register.scat_id == test_scat_id
-    assert register.internal_use == test_internal_use
+    register = CanopenRegister(
+        reg_identifier, reg_units, reg_cyclic, reg_idx, reg_subidx, reg_dtype, reg_access, **reg_kwargs
+    )
+
+    assert register.identifier == reg_identifier
+    assert register.units == reg_units
+    assert register.cyclic == reg_cyclic
+    assert register.idx == reg_idx
+    assert register.subidx == reg_subidx
+    assert register.dtype == reg_dtype
+    assert register.access == reg_access
+    assert register.phy == reg_kwargs["phy"]
+    assert register.subnode == reg_kwargs["subnode"]
+    assert register.storage == reg_kwargs["storage"]
+    assert register.range == reg_kwargs["reg_range"]
+    assert register.labels == reg_kwargs["labels"]
+    assert register.cat_id == reg_kwargs["cat_id"]
+    assert register.scat_id == reg_kwargs["scat_id"]
+    assert register.internal_use == reg_kwargs["internal_use"]
+    assert register.enums == aux_enums
+    assert register.enums_count == 2
+    assert register.storage_valid == True
 
 
 @pytest.mark.canopen

--- a/tests/ethernet/test_ethernet_dictionary.py
+++ b/tests/ethernet/test_ethernet_dictionary.py
@@ -53,11 +53,7 @@ def test_read_dictionary_registers():
     ethernet_dict = EthernetDictionary(dictionary_path)
 
     for subnode in expected_regs_per_subnode.keys():
-        num_registers = len(ethernet_dict.registers(subnode))
-        assert num_registers == len(expected_regs_per_subnode[subnode])
-        for register in ethernet_dict.registers(subnode):
-            assert register in expected_regs_per_subnode[subnode]
-
+        assert expected_regs_per_subnode[subnode] == [reg for reg in ethernet_dict.registers(subnode)]
 
 @pytest.mark.no_connection
 def test_read_dictionary_registers_multiaxis():
@@ -84,10 +80,7 @@ def test_read_dictionary_categories():
 
     ethernet_dict = EthernetDictionary(dictionary_path)
 
-    assert len(ethernet_dict.categories.category_ids) == len(expected_categories)
-    for cat in expected_categories:
-        assert cat in ethernet_dict.categories.category_ids
-
+    assert ethernet_dict.categories.category_ids == expected_categories
 
 @pytest.mark.no_connection
 def test_read_dictionary_errors():
@@ -101,10 +94,7 @@ def test_read_dictionary_errors():
 
     ethernet_dict = EthernetDictionary(dictionary_path)
 
-    assert len(ethernet_dict.errors.errors) == len(expected_errors)
-    for error in expected_errors:
-        assert error in ethernet_dict.errors.errors
-
+    assert [error for error in ethernet_dict.errors.errors] == expected_errors
 
 @pytest.mark.no_connection
 def test_read_xdf_register():

--- a/tests/ethernet/test_ethernet_dictionary.py
+++ b/tests/ethernet/test_ethernet_dictionary.py
@@ -1,75 +1,118 @@
 import pytest
+from os.path import join as join_path
 
 from ingenialink.ethernet.dictionary import EthernetDictionary
 from ingenialink.constants import SINGLE_AXIS_MINIMUM_SUBNODES
-from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, dtypes_ranges
+
+
+path_resources = "./tests/resources/ethernet/"
 
 
 @pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_registers", [
-    ("test_dict_eth_1.xdf", 523),
-    ("test_dict_eth_2.xdf", 519),
-    ("test_dict_eth_axis_1.xdf", 78)
-])
-def test_registers_dictionary(test_file_xdf, expected_num_registers):
-    # Count the number of registers in a EthernetDictionary instance
-    test_ethernet_dict = EthernetDictionary(f'./tests/resources/ethernet/{test_file_xdf}')
-    test_num_registers = 0
-    for current_subnode in range(test_ethernet_dict.subnodes):
-        test_num_registers += len(test_ethernet_dict.registers(current_subnode))
+def test_read_dictionary():
+    dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
+    expected_device_attr = {
+        "path" : dictionary_path,
+        "version" : "2",
+        "firmware_version" : "2.0.1",
+        "product_code" : 57745409,
+        "part_number" : "CAP-NET-C",
+        "revision_number" : 196635,
+        "interface" : "ETH",
+        "subnodes" : SINGLE_AXIS_MINIMUM_SUBNODES
+    }
 
-    assert test_num_registers == expected_num_registers
+    ethernet_dict = EthernetDictionary(dictionary_path)
+    
+    for attr, value in expected_device_attr.items():
+        assert getattr(ethernet_dict, attr) == value
 
-@pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_categories", [
-    ("test_dict_eth_1.xdf", 19),
-    ("test_dict_eth_2.xdf", 19),
-    ("test_dict_eth_axis_1.xdf", 7)
-])
-def test_categories_dictionary(test_file_xdf, expected_num_categories):
-    # Count the number of categories in a EthernetDictionary instance
-    test_ethernet_dict = EthernetDictionary(f'./tests/resources/ethernet/{test_file_xdf}')
-    test_num_categories = len(test_ethernet_dict.categories.category_ids)
-
-    assert test_num_categories == expected_num_categories
 
 @pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test_file_xdf, expected_num_errors", [
-    ("test_dict_eth_1.xdf", 71),
-    ("test_dict_eth_2.xdf", 71),
-    ("test_dict_eth_axis_1.xdf", 13)
-])
-def test_errors_dictionary(test_file_xdf, expected_num_errors):
-    # Count the number of errors in a EthernetDictionary instance
-    test_ethernet_dict = EthernetDictionary(f'./tests/resources/ethernet/{test_file_xdf}')
-    test_num_errors = len(test_ethernet_dict.errors.errors)
-
-    assert test_num_errors == expected_num_errors
+def test_read_dictionary_file_not_found():
+    dictionary_path = "false.xdf"
+    
+    with pytest.raises(FileNotFoundError):
+        EthernetDictionary(dictionary_path)
+    
 
 @pytest.mark.no_connection
-@pytest.mark.smoke
-def test_instance_dictionary():
-    ethernet_dict = EthernetDictionary(f'./tests/resources/ethernet/test_dict_eth_1.xdf')
+def test_read_dictionary_registers():
+    dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
+    expected_regs_per_subnode = {
+        0: [
+            "DRV_DIAG_ERROR_LAST_COM",
+            "DIST_CFG_REG0_MAP",
+            "COMMS_ETH_IP",
+            "COMMS_ETH_NET_MASK",
+            "DRV_BOOT_COCO_VERSION",
+            "MON_CFG_EOC_TYPE"
+        ]
+    }
 
-    assert ethernet_dict.subnodes == SINGLE_AXIS_MINIMUM_SUBNODES
+    ethernet_dict = EthernetDictionary(dictionary_path)
 
-    regs_sub0 = ethernet_dict.registers(0)
-    assert len(regs_sub0) == 84
-    regs_sub1 = ethernet_dict.registers(1)
-    assert len(regs_sub1) == 439
+    for subnode in expected_regs_per_subnode.keys():
+        num_registers = len(ethernet_dict.registers(subnode))
+        assert num_registers == len(expected_regs_per_subnode[subnode])
+        for register in ethernet_dict.registers(subnode):
+            assert register in expected_regs_per_subnode[subnode]
 
-    test_id = "DRV_PROT_MAN_OVER_VOLT"
-    assert regs_sub1.get(test_id).identifier == "DRV_PROT_MAN_OVER_VOLT"
-    assert regs_sub1.get(test_id).units == "V"
-    assert regs_sub1.get(test_id).cyclic == "CONFIG"
-    assert regs_sub1.get(test_id).address == 0x0712
-    assert regs_sub1.get(test_id).dtype == REG_DTYPE.FLOAT
-    assert regs_sub1.get(test_id).access == REG_ACCESS.RO
-    assert regs_sub1.get(test_id).phy == REG_PHY.NONE
-    assert regs_sub1.get(test_id).subnode == 1
-    assert regs_sub1.get(test_id).storage is None
-    assert regs_sub1.get(test_id).range == (dtypes_ranges[REG_DTYPE.FLOAT]["min"],
-                                            dtypes_ranges[REG_DTYPE.FLOAT]["max"])
+
+@pytest.mark.no_connection
+def test_read_dictionary_registers_multiaxis():
+    expected_num_registers_per_subnode = {0: 2, 1: 2, 2: 2}
+    dictionary_path = join_path(path_resources, "test_dict_eth_axis.xdf")
+
+    ethernet_dict = EthernetDictionary(dictionary_path)
+
+    for subnode in expected_num_registers_per_subnode.keys():
+        num_registers = len(ethernet_dict.registers(subnode))
+        assert num_registers == expected_num_registers_per_subnode[subnode]
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_categories():
+    expected_categories = [
+        "IDENTIFICATION",
+        "COMMUTATION",
+        "COMMUNICATIONS",
+        "REPORTING",
+        "MONITORING"
+    ]
+    dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
+
+    ethernet_dict = EthernetDictionary(dictionary_path)
+
+    assert len(ethernet_dict.categories.category_ids) == len(expected_categories)
+    for cat in expected_categories:
+        assert cat in ethernet_dict.categories.category_ids
+
+
+@pytest.mark.no_connection
+def test_read_dictionary_errors():
+    expected_errors = [
+        0x00003280,
+        0x00007380,
+        0x00007385,
+        0x06010000,
+    ]
+    dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
+
+    ethernet_dict = EthernetDictionary(dictionary_path)
+
+    assert len(ethernet_dict.errors.errors) == len(expected_errors)
+    for error in expected_errors:
+        assert error in ethernet_dict.errors.errors
+
+
+@pytest.mark.no_connection
+def test_read_xdf_register():
+    dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
+    address = 0x000F
+    reg_id = "DRV_DIAG_ERROR_LAST_COM"
+    subnode = 0
+
+    ethernet_dict = EthernetDictionary(dictionary_path)
+
+    assert ethernet_dict.registers(subnode)[reg_id].address == address

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -8,107 +8,44 @@ from ingenialink.utils._utils import exc
 @pytest.mark.no_connection
 @pytest.mark.smoke
 def test_getters_ethernet_register():
-    test_cyclic = "CONFIG"
-    test_addr = 0x58F0
-    test_dtype = REG_DTYPE.U32
-    test_access = REG_ACCESS.RW
-    test_identification = "MON_CFG_SOC_TYPE"
-    test_units = "none"
-    test_phy = REG_PHY.NONE
-    test_subnode = 0
-    test_storage = 1
-    test_reg_range = (-20, 20)
-    test_labels = "Monitoring trigger type"
-    test_enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
-    test_enums_count = 2
-    test_cat_id = "MONITORING"
-    test_scat_id = "SUB_CATEGORY_TEST"
-    test_internal_use = "No description (invent here)"
-    register = EthernetRegister(test_addr, test_dtype, test_access, test_identification,
-                                test_units, test_cyclic, test_phy, test_subnode, test_storage,
-                                test_reg_range, test_labels, test_enums,
-                                test_cat_id, test_scat_id, test_internal_use)
-
-    assert register.identifier == test_identification
-    assert register.units == test_units
-    assert register.cyclic == test_cyclic
-    assert register.address == test_addr
-    assert register.dtype == test_dtype
-    assert register.access == test_access
-    assert register.phy == test_phy
-    assert register.subnode == test_subnode
-    assert register.storage == test_storage
-    assert register.range == test_reg_range
-    assert register.labels == test_labels
-
-    test_aux_enums = []
-    for key, value in test_enums.items():
+    reg_address = 0x58F0
+    reg_dtype = REG_DTYPE.U32
+    reg_access = REG_ACCESS.RW
+    reg_kwargs = {
+        "identifier": "MON_CFG_SOC_TYPE",
+        "units": "none",
+        "cyclic": "CONFIG",
+        "phy": REG_PHY.NONE,
+        "subnode": 0,
+        "storage": 1,
+        "reg_range": (-20, 20),
+        "labels": "Monitoring trigger type",
+        "enums": {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'},
+        "cat_id": "MONITORING",
+        "scat_id": "SUB_CATEGORY_TEST",
+        "internal_use": "No description (invent here)",
+    }
+    aux_enums = []
+    for key, value in reg_kwargs["enums"].items():
         test_dictionary = {'label': value, 'value': int(key)}
-        test_aux_enums.append(test_dictionary)
+        aux_enums.append(test_dictionary)
 
-    assert register.enums == test_aux_enums
-    assert register.enums_count == test_enums_count
-    assert register.cat_id == test_cat_id
-    assert register.scat_id == test_scat_id
-    assert register.internal_use == test_internal_use
+    register = EthernetRegister(reg_address, reg_dtype, reg_access, **reg_kwargs)
 
-
-@pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test2_dtype", [REG_DTYPE.S8, REG_DTYPE.FLOAT, REG_DTYPE.DOMAIN, "Other type"])
-@pytest.mark.parametrize("test2_storage", [None, 1])
-def test_storage_dtype(test2_dtype, test2_storage):
-    enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
-    # dtype test conditional
-    if not isinstance(test2_dtype, REG_DTYPE):
-        with pytest.raises(exc.ILValueError):
-            EthernetRegister(0x58F0, test2_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
-                             "none", "CONFIG", REG_PHY.NONE, 1, test2_storage,
-                             (-20, 20), "Monitoring trigger type", enums,
-                             "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
-
-    else:
-        register = EthernetRegister(0x58F0, test2_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
-                                    "none", "CONFIG", REG_PHY.NONE, 1, test2_storage,
-                                    (-20, 20), "Monitoring trigger type", enums,
-                                    "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
-        # storage test conditional
-        if test2_dtype in [REG_DTYPE.S8, REG_DTYPE.U8, REG_DTYPE.S16,
-                           REG_DTYPE.U16, REG_DTYPE.S32, REG_DTYPE.U32,
-                           REG_DTYPE.S64, REG_DTYPE.U64, REG_DTYPE.FLOAT]:
-            assert register.storage == test2_storage
-        else:
-            assert register.storage is None
-
-
-@pytest.mark.no_connection
-@pytest.mark.smoke
-@pytest.mark.parametrize("test2_range", [(None, None), (-20, 20)])
-@pytest.mark.parametrize("test3_dtype", [REG_DTYPE.S8, REG_DTYPE.FLOAT])
-def test_range_ethernet_register(test2_range, test3_dtype):
-    enums = {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'}
-    register = EthernetRegister(0x58F0, test3_dtype, REG_ACCESS.RW, "MON_CFG_SOC_TYPE",
-                                "none", "CONFIG", REG_PHY.NONE, 1, 1,
-                                test2_range, "Monitoring trigger type", enums,
-                                "MONITORING", "SUB_CATEGORY_TEST", "No description (invent here)")
-
-    if test2_range == (None, None):
-        test_aux_range = (
-            dtypes_ranges[test3_dtype]["min"],
-            dtypes_ranges[test3_dtype]["max"],
-        )
-    elif test3_dtype == REG_DTYPE.FLOAT:
-        test_aux_range = (
-            float(test2_range[0]),
-            float(test2_range[1])
-        )
-    else:
-        test_aux_range = (
-            int(test2_range[0]),
-            int(test2_range[1])
-        )
-
-    if len(register.range) == len(test_aux_range):
-        for i in range(len(test_aux_range)):
-            assert isinstance(register.range[i], type(test_aux_range[i])) is True
-    assert register.range == test_aux_range
+    assert register.address == reg_address
+    assert register.identifier == reg_kwargs["identifier"]
+    assert register.units == reg_kwargs["units"]
+    assert register.cyclic == reg_kwargs["cyclic"]
+    assert register.dtype == reg_dtype
+    assert register.access == reg_access
+    assert register.phy == reg_kwargs["phy"]
+    assert register.subnode == reg_kwargs["subnode"]
+    assert register.storage == reg_kwargs["storage"]
+    assert register.range == reg_kwargs["reg_range"]
+    assert register.labels == reg_kwargs["labels"]
+    assert register.cat_id == reg_kwargs["cat_id"]
+    assert register.scat_id == reg_kwargs["scat_id"]
+    assert register.internal_use == reg_kwargs["internal_use"]
+    assert register.enums == aux_enums
+    assert register.enums_count == 2
+    assert register.storage_valid == True

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,141 @@
+import pytest
+
+from ingenialink.register import Register
+from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, dtypes_ranges
+from ingenialink.utils._utils import exc
+
+
+@pytest.mark.no_connection
+def test_getters_register():
+    reg_dtype = REG_DTYPE.U32
+    reg_access = REG_ACCESS.RW
+    reg_kwargs = {
+        "identifier": "MON_CFG_SOC_TYPE",
+        "units": "none",
+        "cyclic": "CONFIG",
+        "phy": REG_PHY.NONE,
+        "subnode": 0,
+        "storage": 1,
+        "reg_range": (-20, 20),
+        "labels": "Monitoring trigger type",
+        "enums": {'0': 'TRIGGER_EVENT_AUTO', '1': 'TRIGGER_EVENT_FORCED'},
+        "cat_id": "MONITORING",
+        "scat_id": "SUB_CATEGORY_TEST",
+        "internal_use": "No description (invent here)",
+    }
+    aux_enums = []
+    for key, value in reg_kwargs["enums"].items():
+        test_dictionary = {'label': value, 'value': int(key)}
+        aux_enums.append(test_dictionary)
+
+    register = Register(reg_dtype, reg_access, **reg_kwargs)
+
+    assert register.identifier == reg_kwargs["identifier"]
+    assert register.units == reg_kwargs["units"]
+    assert register.cyclic == reg_kwargs["cyclic"]
+    assert register.dtype == reg_dtype
+    assert register.access == reg_access
+    assert register.phy == reg_kwargs["phy"]
+    assert register.subnode == reg_kwargs["subnode"]
+    assert register.storage == reg_kwargs["storage"]
+    assert register.range == reg_kwargs["reg_range"]
+    assert register.labels == reg_kwargs["labels"]
+    assert register.cat_id == reg_kwargs["cat_id"]
+    assert register.scat_id == reg_kwargs["scat_id"]
+    assert register.internal_use == reg_kwargs["internal_use"]
+    assert register.enums == aux_enums
+    assert register.enums_count == 2
+    assert register.storage_valid == True
+
+
+def test_register_type_errors():
+    dtype = "False type"
+    access = REG_ACCESS.RW
+    with pytest.raises(exc.ILValueError):
+        Register(dtype, access)
+
+    dtype = REG_DTYPE.FLOAT
+    access = "False access"
+    with pytest.raises(exc.ILAccessError):
+        Register(dtype, access)
+
+    dtype = REG_DTYPE.FLOAT
+    access = REG_ACCESS.RW
+    with pytest.raises(exc.ILValueError):
+        Register(dtype, access, phy="False Phy")
+
+        
+def test_register_get_storage():
+    access = REG_ACCESS.RW
+
+    # invalid storage
+    dtype = REG_DTYPE.STR
+    register = Register(dtype, access, storage=1)
+    assert register.storage_valid == 0
+    assert register.storage is None
+
+    # no storage
+    dtype = REG_DTYPE.FLOAT
+    register = Register(dtype, access)
+    assert register.storage_valid == 0
+    assert register.storage is None
+
+    # float storage
+    dtype = REG_DTYPE.FLOAT
+    storage = 12.34
+    register = Register(dtype, access, storage=storage)
+    assert register.storage_valid == 1
+    assert register.storage == storage
+
+    # parse float storage
+    dtype = REG_DTYPE.FLOAT
+    storage = 123
+    register = Register(dtype, access, storage=storage)
+    assert type(register.storage) is float
+
+    # parse int storage
+    dtype = REG_DTYPE.U8
+    storage = 123.1
+    register = Register(dtype, access, storage=storage)
+    assert type(register.storage) is int
+    assert register.storage == 123
+
+
+@pytest.mark.no_connection
+def test_register_set_storage():
+    access = REG_ACCESS.RW
+    dtype = REG_DTYPE.FLOAT
+    storage = 20.0
+    register = Register(dtype, access, storage=storage)
+    assert register.storage == storage
+
+    storage = 1.1
+    register.storage = storage
+    assert register.storage == storage
+
+
+@pytest.mark.no_connection
+def test_register_range():
+    access = REG_ACCESS.RW
+
+    # custom range
+    dtype = REG_DTYPE.U8
+    range = (0, 100)
+    register = Register(dtype, access, reg_range=range)
+    assert type(register.range[0]) is int
+    assert type(register.range[1]) is int
+    assert register.range == range
+
+    # custom range float
+    dtype = REG_DTYPE.FLOAT
+    range = (1.11, 100.25)
+    register = Register(dtype, access, reg_range=range)
+    assert type(register.range[0]) is float
+    assert type(register.range[1]) is float
+    assert register.range == range
+
+    # default range
+    dtype = REG_DTYPE.U8
+    register = Register(dtype, access)
+    assert register.range == (dtypes_ranges[dtype]["min"], dtypes_ranges[dtype]["max"])
+

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -48,6 +48,7 @@ def test_getters_register():
     assert register.storage_valid == True
 
 
+@pytest.mark.no_connection
 def test_register_type_errors():
     dtype = "False type"
     access = REG_ACCESS.RW
@@ -64,7 +65,8 @@ def test_register_type_errors():
     with pytest.raises(exc.ILValueError):
         Register(dtype, access, phy="False Phy")
 
-        
+
+@pytest.mark.no_connection
 def test_register_get_storage():
     access = REG_ACCESS.RW
 


### PR DESCRIPTION
## Improve no-communication tests

### Description

This PR improves the tests that do not use communication (with the `no_connection` mark)

Fixes # INGK-559

### Type of change

- [x] Improve the tests of CanopenDictionary
- [x] Improve the tests of EthernetDictionary
- [x] Create a test_register.py file to test the method of the Register class (avoid repeating test)
- [x] Simplify tests of EthernetRegister
- [x] Simplify tests of CanopenRegister
- [x] Improve tests of MCB

### Tests
- [x] Run tests and obtain better coverage

