### PR TITLE
INGK-561 Improve canopen tests

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -49,7 +49,8 @@ APPLICATION_LOADED_STATE = 402
 CAN_CHANNELS = {
     'kvaser': (0, 1),
     'pcan': ('PCAN_USBBUS1', 'PCAN_USBBUS2'),
-    'ixxat': (0, 1)
+    'ixxat': (0, 1),
+    'virtual': (0, 1)
 }
 
 
@@ -59,6 +60,7 @@ class CAN_DEVICE(Enum):
     KVASER = 'kvaser'
     PCAN = 'pcan'
     IXXAT = 'ixxat'
+    VIRTUAL = 'virtual'
 
 
 class CAN_BAUDRATE(Enum):

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -805,7 +805,7 @@ class EthercatServo:
         if not os.path.isfile(config_file):
             raise FileNotFoundError('Could not find {}.'.format(config_file))
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
-            raise ILError('Invalid subnode')
+            raise ValueError('Invalid subnode')
         if subnode is None:
             subnode = -1
         r = lib.il_servo_dict_storage_write(self._cffi_servo, cstr(config_file),

--- a/ingenialink/ipb/register.py
+++ b/ingenialink/ipb/register.py
@@ -126,7 +126,7 @@ def ipb_register_from_cffi(cffi_register):
 
     return IPBRegister(identifier, units, cyclic, dtype, access,
                        address, phy, subnode, storage, reg_range,
-                       labels, enums, enums_count, cat_id, scat_id,
+                       labels, enums, cat_id, scat_id,
                        internal_use, cffi_register)
 
 

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -101,3 +101,19 @@ def test_setup_and_teardown_connection(virtual_network):
     assert virtual_network._connection is not None
     virtual_network._teardown_connection()
     assert virtual_network._connection is None
+
+
+@pytest.mark.skip
+def test_load_firmware(connect_to_slave, read_config):
+    # TODO: Fix load_firmware method to work independently of status listeners
+    servo, net = connect_to_slave
+    assert servo is not None and net is not None
+    assert len(net.servos) == 1
+    fw_version = servo.read('DRV_ID_SOFTWARE_VERSION')
+    protocol_contents = read_config['canopen']
+
+    net.load_firmware(protocol_contents['node_id'], protocol_contents['test_fw_file'])
+    new_fw_version = servo.read('DRV_ID_SOFTWARE_VERSION')
+    
+    assert new_fw_version != fw_version
+    net.disconnect_from_slave(servo)

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -1,6 +1,30 @@
 import pytest
 
-from ingenialink.canopen.network import CanopenNetwork, CAN_DEVICE, CAN_BAUDRATE
+from canopen import Network
+
+from ingenialink.canopen.network import CanopenNetwork, CAN_DEVICE, CAN_BAUDRATE, NET_STATE
+from ingenialink.exceptions import  ILError
+
+test_bus = 'virtual'
+test_baudrate = 1000000
+test_channel = 0
+
+@pytest.fixture
+def virtual_network():
+    net = CanopenNetwork(device=CAN_DEVICE(test_bus),
+                         channel=test_channel,
+                         baudrate=CAN_BAUDRATE(test_baudrate))
+    return net
+
+
+@pytest.mark.no_connection
+def test_getters_canopen(virtual_network):
+    assert virtual_network.device == test_bus
+    assert virtual_network.channel == test_channel
+    assert virtual_network.baudrate == test_baudrate
+    assert virtual_network.network is None
+    assert virtual_network.status == NET_STATE.DISCONNECTED
+
 
 @pytest.mark.canopen
 def test_connect_to_slave(connect_to_slave):
@@ -12,6 +36,33 @@ def test_connect_to_slave(connect_to_slave):
 
 
 @pytest.mark.canopen
+def test_connect_to_slave_target_not_in_nodes(read_config):
+    protocol_contents = read_config['canopen']
+    net = CanopenNetwork(device=CAN_DEVICE(protocol_contents['device']),
+                         channel=protocol_contents['channel'],
+                         baudrate=CAN_BAUDRATE(protocol_contents['baudrate']))
+
+    with pytest.raises(ILError):
+        net.connect_to_slave(
+            target=1234,
+            dictionary=protocol_contents['dictionary'],
+            eds=protocol_contents['eds']
+        )
+
+
+@pytest.mark.no_connection
+def test_connect_to_slave_none_nodes(virtual_network, read_config):
+    net = virtual_network
+    protocol_contents = read_config['canopen']
+    with pytest.raises(ILError):
+        net.connect_to_slave(
+            target=1,
+            dictionary=protocol_contents['dictionary'],
+            eds=protocol_contents['eds']
+        )
+
+
+@pytest.mark.canopen
 def test_scan_slaves(read_config):
     net = CanopenNetwork(device=CAN_DEVICE(read_config['canopen']['device']),
                          channel=read_config['canopen']['channel'],
@@ -19,3 +70,34 @@ def test_scan_slaves(read_config):
     slaves = net.scan_slaves()
     assert len(slaves) > 0
 
+
+@pytest.mark.no_connection
+def test_scan_slaves_none_nodes(virtual_network):
+    nodes = virtual_network.scan_slaves()
+    assert len(nodes) == 0
+
+
+@pytest.mark.canopen
+def test_disconnect_from_slave(read_config):
+    protocol_contents = read_config['canopen']
+    net = CanopenNetwork(device=CAN_DEVICE(protocol_contents['device']),
+                         channel=protocol_contents['channel'],
+                         baudrate=CAN_BAUDRATE(protocol_contents['baudrate']))
+
+    servo = net.connect_to_slave(
+        target=protocol_contents['node_id'],
+        dictionary=protocol_contents['dictionary'],
+        eds=protocol_contents['eds'])
+
+    assert len(net.servos) == 1
+    net.disconnect_from_slave(servo)
+    assert len(net.servos) == 0
+
+
+@pytest.mark.no_connection
+def test_setup_and_teardown_connection(virtual_network):
+    assert virtual_network._connection is None
+    virtual_network._setup_connection()
+    assert virtual_network._connection is not None
+    virtual_network._teardown_connection()
+    assert virtual_network._connection is None

--- a/tests/canopen/test_canopen_servo.py
+++ b/tests/canopen/test_canopen_servo.py
@@ -1,101 +1,11 @@
-import os
 import pytest
-import shutil
-from pathlib import Path
 
-import xml.etree.ElementTree as ET
-
-from ingenialink.exceptions import ILError
+from canopen.network import RemoteNode
 
 
 @pytest.mark.canopen
-def test_save_configuration(connect_to_slave):
+def test_canopen_getters(connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
 
-    filename = 'temp_config'
-
-    servo.save_configuration(filename)
-
-    assert os.path.isfile(filename)
-
-    if os.path.isfile(filename):
-        os.remove(filename)
-
-
-@pytest.mark.canopen
-def test_load_configuration(read_config, connect_to_slave):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    filename = read_config['canopen']['load_config_file']
-
-    servo.load_configuration(filename)
-
-
-@pytest.mark.canopen
-def test_load_configuration_file_not_found(connect_to_slave):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    filename = 'can_config.xdf'
-    with pytest.raises(FileNotFoundError):
-        servo.load_configuration(filename)
-
-
-@pytest.mark.parametrize('subnode', [
-    -1, "1"
-])
-@pytest.mark.canopen
-def test_load_configuration_invalid_subnode(read_config, connect_to_slave, subnode):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    filename = read_config['canopen']['load_config_file']
-    with pytest.raises(ValueError):
-        servo.load_configuration(filename, subnode=subnode)
-
-
-@pytest.mark.canopen
-def test_load_configuration_to_subnode_zero(read_config, connect_to_slave):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    filename = read_config['canopen']['load_config_file']
-    path = Path(filename)
-    file = filename.split('/')[-1]
-    modified_path = Path(filename.replace(file, "can_config_0_test.xdf"))
-    shutil.copy(path, modified_path)
-    with open(modified_path, 'r', encoding='utf-8') as xml_file:
-        tree = ET.parse(xml_file)
-        root = tree.getroot()
-        axis = tree.findall('*/Device/Axes/Axis')
-        if axis:
-            # Multiaxis
-            registers = root.findall(
-                './Body/Device/Axes/Axis/Registers/Register'
-            )
-        else:
-            # Single axis
-            registers = root.findall('./Body/Device/Registers/Register')
-        for element in registers:
-            element.attrib['subnode'] = "1"
-        tree.write(modified_path)
-    with pytest.raises(ValueError):
-        servo.load_configuration(modified_path, subnode=0)
-
-
-@pytest.mark.canopen
-def test_store_parameters(connect_to_slave):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    servo.store_parameters()
-
-
-@pytest.mark.canopen
-def test_restore_parameters(connect_to_slave):
-    servo, net = connect_to_slave
-    assert servo is not None and net is not None
-
-    servo.restore_parameters()
+    assert isinstance(servo.node, RemoteNode)

--- a/tests/config.json
+++ b/tests/config.json
@@ -23,6 +23,8 @@
     "baudrate": 1000000,
     "channel": 0,
     "save_config_file": "canopen-config.xcf",
-    "load_config_file": "resources/configurations/canopen-config.xcf"
+    "load_config_file": "resources/configurations/canopen-config.xcf",
+    "fw_file": "resources/firmware/eve-net-c_1.8.1.sfu",
+    "test_fw_file": "resources/firmware/eve-net-c_1.7.0.sfu"	
   }
 }

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -1,5 +1,9 @@
 import os
 import pytest
+import shutil
+from pathlib import Path
+import xml.etree.ElementTree as ET
+from ingenialink.exceptions import  ILError
 
 
 @pytest.mark.canopen
@@ -32,6 +36,65 @@ def test_load_configuration(connect_to_slave, read_config, pytestconfig):
     assert os.path.isfile(filename)
 
     servo.load_configuration(filename)
+
+@pytest.mark.canopen
+@pytest.mark.ethernet
+@pytest.mark.ethercat
+def test_load_configuration_file_not_found(connect_to_slave):
+    servo, net = connect_to_slave
+    assert servo is not None and net is not None
+
+    filename = 'can_config.xdf'
+    with pytest.raises(FileNotFoundError):
+        servo.load_configuration(filename)
+
+
+@pytest.mark.parametrize('subnode', [
+    -1, "1"
+])
+@pytest.mark.canopen
+@pytest.mark.ethernet
+@pytest.mark.ethercat
+def test_load_configuration_invalid_subnode(read_config, pytestconfig, connect_to_slave, subnode):
+    servo, net = connect_to_slave
+    assert servo is not None and net is not None
+    
+    protocol = pytestconfig.getoption("--protocol")
+    filename = read_config[protocol]['load_config_file']
+    with pytest.raises(ValueError):
+        servo.load_configuration(filename, subnode=subnode)
+
+
+@pytest.mark.canopen
+@pytest.mark.ethernet
+@pytest.mark.ethercat
+def test_load_configuration_to_subnode_zero(read_config, pytestconfig, connect_to_slave):
+    servo, net = connect_to_slave
+    assert servo is not None and net is not None
+
+    protocol = pytestconfig.getoption("--protocol")
+    filename = read_config[protocol]['load_config_file']
+    path = Path(filename)
+    file = filename.split('/')[-1]
+    modified_path = Path(filename.replace(file, "config_0_test.xdf"))
+    shutil.copy(path, modified_path)
+    with open(modified_path, 'r', encoding='utf-8') as xml_file:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+        axis = tree.findall('*/Device/Axes/Axis')
+        if axis:
+            # Multiaxis
+            registers = root.findall(
+                './Body/Device/Axes/Axis/Registers/Register'
+            )
+        else:
+            # Single axis
+            registers = root.findall('./Body/Device/Registers/Register')
+        for element in registers:
+            element.attrib['subnode'] = "1"
+        tree.write(modified_path)
+    with pytest.raises(ValueError):
+        servo.load_configuration(str(modified_path), subnode=0)
 
 @pytest.mark.canopen
 @pytest.mark.ethernet

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -2,7 +2,6 @@ import os
 import pytest
 import shutil
 from pathlib import Path
-
 import xml.etree.ElementTree as ET
 
 from ingenialink.utils._utils import get_drive_identification

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -67,7 +67,6 @@ def test_load_configuration_invalid_subnode(read_config, pytestconfig, connect_t
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
-@pytest.mark.ethercat
 def test_load_configuration_to_subnode_zero(read_config, pytestconfig, connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None


### PR DESCRIPTION
## Improve canopen tests

### Description

This PR improves the tests of canopen protocol

Fixes # INGK-561

### Type of change

- [x] Add a virtual device for canopen
- [x] Improve the tests of canopen_servo
- [x] Improve tests of canopen_network
- [x] Move some tests from test_canopen_servo to test_servo since those tests were duplicated or worked for all protocols.
- [x] Add a test of load_firmware

### Tests
- [x] Run tests and obtain better coverage
