### PR TITLE
INGK-579 Avoid repeated code between the Servo children

### DIFF
--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -81,13 +81,12 @@ class CanopenServo(Servo):
         except Exception as e:
             logger.error("Failed writing %s. Exception: %s",
                          str(reg.identifier), e)
-            error_raised = "Error writing {}".format(reg.identifier)
+            error_raised = f"Error writing {reg.identifier}"
             raise ILIOError(error_raised)
         finally:
             self._lock.release()
 
     def _read_raw(self, reg):
-        value = None
         try:
             self._lock.acquire()
             value = self.__node.sdo.upload(reg.idx, reg.subidx)

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -27,6 +27,9 @@ class CanopenServo(Servo):
             its status, errors, faults, etc.
 
     """
+    DICTIONARY_CLASS = CanopenDictionary
+    MAX_WRITE_SIZE = CAN_MAX_WRITE_SIZE
+
     STATUS_WORD_REGISTERS = "CIA402_DRV_STATE_STATUS"
     RESTORE_COCO_ALL = "CIA301_COMMS_RESTORE_ALL"
     STORE_COCO_ALL = "CIA301_COMMS_STORE_ALL"
@@ -44,27 +47,13 @@ class CanopenServo(Servo):
         self.eds = eds
         self.__node = node
         self.__emcy_consumer = EmcyConsumer()
-        if dictionary_path is not None:
-            self._dictionary = CanopenDictionary(dictionary_path)
-        else:
-            self._dictionary = None
-        super(CanopenServo, self).__init__(target, servo_status_listener)
+        super(CanopenServo, self).__init__(target, dictionary_path, servo_status_listener)
 
     def read(self, reg, subnode=1):
-        _reg = self._get_reg(reg, subnode)
-        raw_read = self._read_raw(reg, subnode)
-        value = convert_bytes_to_dtype(raw_read, _reg.dtype)
+        value = super().read(reg, subnode=subnode)
         if isinstance(value, str):
             value = value.replace('\x00', '')
         return value
-
-    def write(self, reg, data, subnode=1):
-        _reg = self._get_reg(reg, subnode)
-        value = convert_dtype_to_bytes(data, _reg.dtype)
-        self._write_raw(reg, value, subnode)
-
-    def replace_dictionary(self, dictionary):
-        self._dictionary = CanopenDictionary(dictionary)
 
     def store_parameters(self, subnode=None, sdo_timeout=3):
         """Store all the current parameters of the target subnode.
@@ -83,63 +72,29 @@ class CanopenServo(Servo):
         super().store_parameters(subnode)
         self._change_sdo_timeout(CANOPEN_SDO_RESPONSE_TIMEOUT)
 
-    def _write_raw(self, reg, data, subnode=1):
-        """Writes a data to a target register.
-
-        Args:
-            reg (CanopenRegister, str): Target register to be written.
-            data (int, str, float): Data to be written.
-            subnode (int): Target axis of the drive.
-
-        Raises:
-            ILAccessError: Wrong access to the register.
-            ILIOError: Error reading the register.
-
-        """
-        _reg = self._get_reg(reg, subnode)
-
-        if _reg.access == REG_ACCESS.RO:
-            raise ILAccessError('Register is Read-only')
+    def _write_raw(self, reg, data):
         try:
             self._lock.acquire()
-            self.__node.sdo.download(_reg.idx,
-                                     _reg.subidx,
+            self.__node.sdo.download(reg.idx,
+                                     reg.subidx,
                                      data)
         except Exception as e:
             logger.error("Failed writing %s. Exception: %s",
-                         str(_reg.identifier), e)
-            error_raised = "Error writing {}".format(_reg.identifier)
+                         str(reg.identifier), e)
+            error_raised = "Error writing {}".format(reg.identifier)
             raise ILIOError(error_raised)
         finally:
             self._lock.release()
 
-    def _read_raw(self, reg, subnode=1):
-        """Read raw bytes from servo.
-
-        Args:
-            reg (str, Register): Register.
-
-        Returns:
-            bytearray: Raw bytes reading from servo.
-
-        Raises:
-            ILAccessError: Wrong access to the register.
-            ILIOError: Error reading the register.
-
-        """
-        _reg = self._get_reg(reg, subnode)
-
-        access = _reg.access
-        if access == REG_ACCESS.WO:
-            raise ILAccessError('Register is Write-only')
+    def _read_raw(self, reg):
         value = None
         try:
             self._lock.acquire()
-            value = self.__node.sdo.upload(_reg.idx, _reg.subidx)
+            value = self.__node.sdo.upload(reg.idx, reg.subidx)
         except Exception as e:
             logger.error("Failed reading %s. Exception: %s",
-                         str(_reg.identifier), e)
-            error_raised = f"Error reading {_reg.identifier}"
+                         str(reg.identifier), e)
+            error_raised = f"Error reading {reg.identifier}"
             raise ILIOError(error_raised)
         finally:
             self._lock.release()
@@ -168,16 +123,6 @@ class CanopenServo(Servo):
         """
         del self.__emcy_consumer.callbacks[slot]
 
-    def disturbance_write_data(self, channels, dtypes, data_arr):
-        data, chunks = self._disturbance_create_data_chunks(channels,
-                                                            dtypes,
-                                                            data_arr,
-                                                            CAN_MAX_WRITE_SIZE)
-        for chunk in chunks:
-            self._write_raw(self.DIST_DATA, data=chunk, subnode=0)
-        self.disturbance_data = data
-        self.disturbance_data_size = len(data)
-
     def _change_sdo_timeout(self, value):
         """Changes the SDO timeout of the node."""
         self.__node.sdo.RESPONSE_TIMEOUT = value
@@ -186,9 +131,6 @@ class CanopenServo(Servo):
     def __monitoring_disturbance_map_can_address(address, subnode):
         """Map CAN register address to IPB register address."""
         return address - (0x2000 + (0x800 * (subnode - 1)))
-
-    def _monitoring_read_data(self):
-        return self._read_raw(self.MONITORING_DATA, subnode=0)
 
     def _monitoring_disturbance_data_to_map_register(self, subnode, address,
                                                       dtype, size):
@@ -201,10 +143,10 @@ class CanopenServo(Servo):
             size (int): Size of data in bytes.
 
         """
-        data_h = self.__monitoring_disturbance_map_can_address(
-                     address, subnode) | subnode << 12
-        data_l = dtype << 8 | size
-        return (data_h << 16) | data_l
+        ipb_address = self.__monitoring_disturbance_map_can_address(address, subnode)
+        return super()._monitoring_disturbance_data_to_map_register(
+            subnode, ipb_address, dtype, size
+        )
 
     @property
     def node(self):

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -59,6 +59,7 @@ class Servo:
 
     Args:
         target (str, int): Target ID of the servo.
+        dictionary_path (str): Path to the dictionary file.
         servo_status_listener (bool): Toggle the listener of the servo for
             its status, errors, faults, etc.
 
@@ -1043,7 +1044,7 @@ class Servo:
 
     @abstractmethod
     def _write_raw(self, reg, data):
-        """Writes a raw bytes data to a target register.
+        """Write raw bytes to a target register.
 
         Args:
             reg (Register): Target register to be written.
@@ -1058,7 +1059,7 @@ class Servo:
 
     @abstractmethod
     def _read_raw(self, reg):
-        """Read raw bytes from servo.
+        """Read raw bytes from a target register.
 
         Args:
             reg (Register): Register.


### PR DESCRIPTION
##  Avoid repeated code between the Servo children

### Description

This PR moves some functions of the Servo children to the Servo parent. This simplifies the code and avoids possible bugs when re-defining abstract methods in the children. Only two methods are kept as abstract methods:  `read_raw` and `write_raw`. Those are protocol-dependent methods to write and read byte arrays.

Fixes # INGK-579

### Type of change

- [x] Add a `DICTIONARY_CLASS` constant at the `Servo` class, which stores the `Dictionary` class related to the `Servo` (e.g., `CanopenDictionary` for `CanopenServo`).
- [x]  Add a `MAX_WRITE_SIZE ` constant at the `Servo` class, which stores the disturbance max size for each protocol.
- [x] Creates `read_raw` and `write_raw` abstract methods at the `Servo` parent. 
- [x] Define `write` and `read` functions at the parent. These functions use `read_raw` and `write_raw` defined for each protocol.
- [x] Define `replace_dictionary` at the `Servo` parent.
- [x] Define `disturbance_write_data` at the `Servo` parent.
- [x] Define `_monitoring_read_data` at the `Servo` parent.

### Tests
- [x] Run tests and obtain similar coverage.