### PR TITLE
Ingk 589 configuration file cannot be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Don't add PartNumber to the configuration file if it does not exist in the dictionary
+
 ## [6.5.0] - 2023-01-04
 ### Added
 - Tests are separated by communication protocol.

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -223,7 +223,8 @@ class Servo:
         registers = ET.SubElement(device, "Registers")
 
         device.set("Interface", self.dictionary.interface)
-        device.set("PartNumber", self.dictionary.part_number)
+        if self.dictionary.part_number is not None:
+            device.set("PartNumber", self.dictionary.part_number)
         device.set("ProductCode", str(prod_code))
         device.set("RevisionNumber", str(rev_number))
         device.set("firmwareVersion", self.dictionary.firmware_version)

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -89,7 +89,10 @@ def test_save_configuration(connect_to_slave):
     if "RevisionNumber" in device.attrib and rev_number is not None:
         assert int(device.attrib.get("RevisionNumber")) == rev_number
 
-    assert device.attrib.get("PartNumber") == servo.dictionary.part_number
+    if servo.dictionary.part_number is None:
+        assert "PartNumber" not in device.attrib
+    else:
+        assert device.attrib["PartNumber"] == servo.dictionary.part_number
     assert device.attrib.get("Interface") == servo.dictionary.interface
     assert device.attrib.get("firmwareVersion") == servo.dictionary.firmware_version
     # TODO: check name and family? These are not stored at the dictionary


### PR DESCRIPTION
### Fix save_configuration PartNumber bug

### Description

If the drive dictionary has no PartNumber, ignore it to create the configuration file.

Fixes # INGK-589

### Type of change

- [x] Don't add PartNumber to the configuration file if it does not exist in the dictionary

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

#### Manual test
- Connect a servo with a dictionary with no PartNumber
- Save drive configuration
- Check the configuration file was saved correctly

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.