### PR TITLE
INGK-591 Truncate received data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Truncate received data in ethernet by the expected data length.
+
 ## [6.5.0] - 2023-01-04
 ### Added
 - Tests are separated by communication protocol.

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -24,6 +24,7 @@ __dtype_value = {
     REG_DTYPE.S32: (4, True),
     REG_DTYPE.U64: (8, False),
     REG_DTYPE.S64: (8, True),
+    REG_DTYPE.FLOAT: (4, None),
 }
 
 

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -347,6 +347,7 @@ def set_logger_level(level):
 def convert_bytes_to_dtype(data, dtype):
     """Convert data in bytes to corresponding dtype."""
     __signed_dtypes_bytes = {REG_DTYPE.S8: 1, REG_DTYPE.S16: 2, REG_DTYPE.S32: 4}
+    __unsigned_dtypes_bytes = {REG_DTYPE.U8: 1, REG_DTYPE.U16: 2, REG_DTYPE.U32: 4}
     if dtype in __signed_dtypes_bytes:
         value = int.from_bytes(data[: __signed_dtypes_bytes[dtype]], "little", signed=True)
     elif dtype == REG_DTYPE.FLOAT:
@@ -356,7 +357,7 @@ def convert_bytes_to_dtype(data, dtype):
     elif dtype == REG_DTYPE.STR:
         value = data.decode("utf-8").rstrip("\0")
     else:
-        value = int.from_bytes(data, "little")
+        value = int.from_bytes(data[: __unsigned_dtypes_bytes[dtype]], "little")
     return value
 
 


### PR DESCRIPTION
### Truncate received data

### Description

Sometimes, using ethernet, the received data is longer than expected, for instance, 4 bytes are received for a u16 register. We assume this is an FW issue. We could truncate the received data by the expected length to fix this issue at the library level.

Fixes # INGK-591

### Type of change

- [x] Truncate received data to the expected length.

### Tests
- [x] Tested with ingeniamotion.
- [x] Run tests and passed.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.