### PR TITLE
INGK-594 Fix canopen FW loader

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -635,9 +635,7 @@ class CanopenNetwork(Network):
                         initial_time = time()
                         time_diff = time() - initial_time
                         bool_timeout = False
-                        stop_status_listener_after_reconnect = True
-                        if self.is_listener_started(servo):
-                            stop_status_listener_after_reconnect = False
+                        stop_status_listener_after_reconnect = not self.is_listener_started(servo)
                         self.start_status_listener(servo)
                         logger.debug("Starting status listener...")
                         while (

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -635,7 +635,7 @@ class CanopenNetwork(Network):
                         initial_time = time()
                         time_diff = time() - initial_time
                         bool_timeout = False
-                        stop_status_listener_after_reconect = True
+                        stop_status_listener_after_reconnect = True
                         for listener in self.__listeners_net_status:
                             if listener.node.id == servo.node.id:
                                 stop_status_listener_after_reconnect = False

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -640,6 +640,7 @@ class CanopenNetwork(Network):
                             if listener.node.id == servo.node.id:
                                 stop_status_listener_after_reconnect = False
                         self.start_status_listener(servo)
+                        logger.debug("Starting status listener...")
                         while (
                             self.status != NET_STATE.CONNECTED and time_diff < RECONNECTION_TIMEOUT
                         ):
@@ -650,6 +651,7 @@ class CanopenNetwork(Network):
 
                         if stop_status_listener_after_reconnect:
                             self.stop_status_listener(servo)
+                            logger.debug("Stopping status listener...")
 
                         logger.debug(f"Time waited for reconnection: {time_diff} {bool_timeout}")
                         logger.debug(f"Net state after reconnection: {self.status}")

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -636,9 +636,8 @@ class CanopenNetwork(Network):
                         time_diff = time() - initial_time
                         bool_timeout = False
                         stop_status_listener_after_reconnect = True
-                        for listener in self.__listeners_net_status:
-                            if listener.node.id == servo.node.id:
-                                stop_status_listener_after_reconnect = False
+                        if self.is_listener_started(servo):
+                            stop_status_listener_after_reconnect = False
                         self.start_status_listener(servo)
                         logger.debug("Starting status listener...")
                         while (
@@ -913,12 +912,17 @@ class CanopenNetwork(Network):
         for callback in self.__observers_net_state:
             callback(status)
 
-    def start_status_listener(self, servo):
-        """Start monitoring network events (CONNECTION/DISCONNECTION)."""
+    def is_listener_started(self, servo):
         for listener in self.__listeners_net_status:
             if listener.node.id == servo.node.id:
-                logger.info(f"Listener on node {servo.node.id} is already started.")
-                return
+                return True
+        return False
+
+    def start_status_listener(self, servo):
+        """Start monitoring network events (CONNECTION/DISCONNECTION)."""
+        if self.is_listener_started(servo):
+            logger.info(f"Listener on node {servo.node.id} is already started.")
+            return
         listener = NetStatusListener(self, servo.node)
         listener.start()
         self.__listeners_net_status.append(listener)

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -635,6 +635,11 @@ class CanopenNetwork(Network):
                         initial_time = time()
                         time_diff = time() - initial_time
                         bool_timeout = False
+                        stop_status_listener_after_reconect = True
+                        for listener in self.__listeners_net_status:
+                            if listener.node.id == servo.node.id:
+                                stop_status_listener_after_reconnect = False
+                        self.start_status_listener(servo)
                         while (
                             self.status != NET_STATE.CONNECTED and time_diff < RECONNECTION_TIMEOUT
                         ):
@@ -642,6 +647,9 @@ class CanopenNetwork(Network):
                             sleep(0.5)
                         if not time_diff < RECONNECTION_TIMEOUT:
                             bool_timeout = True
+
+                        if stop_status_listener_after_reconnect:
+                            self.stop_status_listener(servo)
 
                         logger.debug(f"Time waited for reconnection: {time_diff} {bool_timeout}")
                         logger.debug(f"Net state after reconnection: {self.status}")


### PR DESCRIPTION
## Fix canopen FW loader

### Description

Canopen FW loader always raises the "Could not recover drive" error.

Fixes # INGK-594

### Type of change

- [x] Start the status listener before checking the drive is recovered.

### Tests
- [x] Test flashing FW locally and in Jenkins.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.