### PR TITLE
INGK-604 Add black config to toml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
                     steps {
                         bat """
                             cd C:\\Users\\ContainerAdministrator\\ingenialink-python
-                            py${PYTHON_VERSIONS[-1]}\\Scripts\\python.exe -m black -l 100 --check ingenialink tests
+                            py${PYTHON_VERSIONS[-1]}\\Scripts\\python.exe -m black --check ingenialink tests
                         """
                     }
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.black]
+line-length = 100
+preview = true
+target-version = ['py39']

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[pycodestyle]
-max-line-length = 89


### PR DESCRIPTION
In this file we can store configuration settings for different tools such as black.

So we can run this command

`python -m black --check ingenialink tests`

Instead of specifying the arguments like this:

`python -m black --check --preview -l 100  ingenialink tests`