### PR TITLE
INGK-615 Add exceptions eoe service

### DIFF
--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -162,8 +162,8 @@ class EoENetwork(EthernetNetwork):
         the packet forwarder.
 
         Raises:
-            ILError: If the EoE service fails to initialize.
-            ILError: If there is no slave connected to the network interface.
+            ILError: If the EoE service is not running.
+            ILError: If the EoE service cannot be started on the network interface.
 
         """
         self._connect_to_eoe_service()
@@ -177,7 +177,7 @@ class EoENetwork(EthernetNetwork):
             ) from e
         if r < 0:
             raise ILError(
-                f"No slaves connected to interface {self.ifname}"
+                f"Failed to initialize the EoE service using interface {self.ifname}."
             )
 
     def _configure_slave(self, slave_id, ip_address):


### PR DESCRIPTION
### Description

Add an exception if the EoE service fails to initialize on a network interface.

Fixes # INGK-615

### Tests
- Try to initialize the service on a non-existing network interface exception and verify that the exception is raised.

