### PR TITLE
Ingk 620 ecat service does not allow ip out of 192 168 3

### DIFF
--- a/docs/api/protocols/eoe/network.rst
+++ b/docs/api/protocols/eoe/network.rst
@@ -1,0 +1,8 @@
+=======
+Network
+=======
+
+.. automodule:: ingenialink.eoe.network
+    :members:
+    :inherited-members:
+    :member-order: groupwise

--- a/docs/api/protocols/eoe_service.rst
+++ b/docs/api/protocols/eoe_service.rst
@@ -1,0 +1,8 @@
+=============================
+EoE Service API documentation
+=============================
+
+.. toctree::
+    :glob:
+
+    eoe/network

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -26,6 +26,8 @@ class EoENetwork(EthernetNetwork):
 
     """
 
+    ECAT_SERVICE_NETWORK = ipaddress.ip_network("192.168.3.0/24")
+
     def __init__(self, ifname, connection_timeout=DEFAULT_ETH_CONNECTION_TIMEOUT):
         super().__init__()
         self.ifname = ifname
@@ -61,6 +63,8 @@ class EoENetwork(EthernetNetwork):
             EthernetServo: Instance of the servo connected.
 
         """
+        if ipaddress.ip_address(ip_address) not in self.ECAT_SERVICE_NETWORK:
+            raise ValueError("ip_address must be a subnetwork of 192.168.3.0/24")
         self._initialize_eoe_service()
         self._configure_slave(slave_id, ip_address)
         self._start_eoe_service()

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -59,6 +59,11 @@ class EoENetwork(EthernetNetwork):
             net_status_listener (bool): Toggle the listener of the network
                 status, connection and disconnection.
 
+        Raises:
+            ValueError: ip_address must be a subnetwork of 192.168.3.0/24
+            ILError: If the EoE service is not running.
+            ILError: If the EoE service cannot be started on the network interface.
+
         Returns:
             EthernetServo: Instance of the servo connected.
 

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -238,6 +238,7 @@ class INT_SIZES(Enum):
 
 def convert_bytes_to_dtype(data, dtype):
     """Convert data in bytes to corresponding dtype."""
+    signed = None
     if dtype in __dtype_value:
         bytes_length, signed = __dtype_value[dtype]
         data = data[:bytes_length]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,5 @@ markers =
     no_connection: Tests without connection
     ethernet: Ethernet tests
     ethercat: EtherCAT tests
+    eoe: EtherCAT service tests
     canopen: CANopen tests

--- a/tests/eoe/test_eoe_network.py
+++ b/tests/eoe/test_eoe_network.py
@@ -50,6 +50,18 @@ def test_eoe_connection(connect_to_slave, read_config):
 
 
 @pytest.mark.eoe
+def test_eoe_connection_wrong_ip_address(read_config):
+    protocol_contents = read_config["eoe"]
+    net = EoENetwork(protocol_contents["ifname"])
+    with pytest.raises(ValueError):
+        net.connect_to_slave(
+            slave_id=protocol_contents["slave"],
+            ip_address="192.168.2.22",
+            dictionary=protocol_contents["dictionary"],
+        )
+
+
+@pytest.mark.eoe
 def test_eoe_disconnection(connect):
     servo, net = connect
     net.disconnect_from_slave(servo)


### PR DESCRIPTION
### Description

Add a check in the EoENetwork connection to ensure the IP address is inside the right subnet

Fixes # INGK-620

### Type of change

- [x] Check the IP address in EoENetwork connection

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.