### PR TITLE
Ingk 621 servo status listener crash in ethernet when receives a timeout

### DIFF
--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -60,7 +60,7 @@ class ServoStatusListener(threading.Thread):
                     if previous_states[subnode] != current_state:
                         previous_states[subnode] = current_state
                         self.__servo._notify_state(current_state, subnode)
-                except ILIOError as e:
+                except (ILIOError, ILTimeoutError) as e:
                     logger.error("Error getting drive status. Exception : %s", e)
             time.sleep(1.5)
 


### PR DESCRIPTION
Fixes # INGK-621

### Type of change

- [x] Add ILTimeoutError in the try-except in ServoStatusListener

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.