### PR TITLE
INGK-635 Close socket when network is deleted

### DIFF
--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -129,8 +129,10 @@ class EoENetwork(EthernetNetwork):
             self._stop_eoe_service()
             self._erase_config_eoe_service()
             self._deinitialize_eoe_service()
-            self._eoe_socket.shutdown(socket.SHUT_RDWR)
-            self._eoe_socket.close()
+
+    def __del__(self):
+        self._eoe_socket.shutdown(socket.SHUT_RDWR)
+        self._eoe_socket.close()
 
     def scan_slaves(self):
         """Scan slaves connected to the network adapter.

--- a/tests/eoe/test_eoe_network.py
+++ b/tests/eoe/test_eoe_network.py
@@ -58,7 +58,6 @@ def test_eoe_disconnection(connect):
     assert not net._eoe_service_init
     assert not net._eoe_service_started
     assert len(net.servos) == 0
-    assert net._eoe_socket._closed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description

Close the socket when the garbage collector removes the network. Before this change, if the last drive was disconnected the network became useless and a new network must be created.

Fixes # INGK-635

### Type of change

- [x] Close socket in __del__

### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.