### PR TITLE
INGK-641 Fix the path of the FoE application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+### Changed
+- Use inspect instead of pkg_resources to find the path to the FoE application.
+
+
 ## [7.0.1] - 2023-04-04
 ### Fixed
 - Recover old Monitoring/Disturbance compatibility

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -66,7 +66,9 @@ class EthercatNetwork:
         exec_path = os.path.join(os.path.dirname(inspect.getfile(bin_module)), app_path)
         logger.debug(f"Call FoE application for {sys_name}-{arch}")
         try:
-            subprocess.run([exec_path, self.interface_name, f"{slave_id}", fw_file], check=True)
+            subprocess.run(
+                [exec_path, self.interface_name, f"{slave_id}", fw_file], check=True, shell=True
+            )
         except subprocess.CalledProcessError as e:
             foe_return_error = self.FOE_ERRORS.get(e.returncode, self.UNKNOWN_FOE_ERROR)
             raise ILFirmwareLoadError(

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -2,11 +2,7 @@ import os
 import sys
 import platform
 import subprocess
-
-try:
-    import importlib.resources as pkg_resources
-except ImportError:
-    import importlib_resources as pkg_resources
+import inspect
 
 import ingenialogger
 
@@ -67,7 +63,7 @@ class EthercatNetwork:
                 "Load FW by ECAT is not implemented for this OS and architecture:"
                 f" {sys_name} {arch}"
             )
-        exec_path = os.path.join(str(pkg_resources.files(bin_module)), app_path)
+        exec_path = os.path.join(os.path.dirname(inspect.getfile(bin_module)), app_path)
         logger.debug(f"Call FoE application for {sys_name}-{arch}")
         try:
             subprocess.run([exec_path, self.interface_name, f"{slave_id}", fw_file], check=True)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,3 @@ python-can==3.3.4
 ingenialogger>=0.2.1
 ping3==4.0.3
 pysoem==1.0.7
-importlib-resources==5.4.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@
 import re
 import setuptools
 
-_version = re.search(r"__version__\s+=\s+\"(.*)\"", open("ingenialink/__init__.py").read()).group(1)
+_version = re.search(r'__version__\s+=\s+\"(.*)\"',
+                     open('ingenialink/__init__.py').read()).group(1)
 
 
 def get_docs_url():
@@ -11,33 +12,33 @@ def get_docs_url():
 
 
 setuptools.setup(
-    name="ingenialink",
+    name='ingenialink',
     version=_version,
     packages=setuptools.find_packages(exclude=["test", "examples"]),
     include_package_data=True,
     package_data={"ingenialink": ["bin/FoE/*/*"]},
-    description="IngeniaLink Communications Library",
-    long_description=open("README.rst").read(),
-    author="Ingenia Motion Control",
-    author_email="support@ingeniamc.com",
-    url="https://www.ingeniamc.com",
+    description='IngeniaLink Communications Library',
+    long_description=open('README.rst').read(),
+    author='Ingenia Motion Control',
+    author_email='support@ingeniamc.com',
+    url='https://www.ingeniamc.com',
     project_urls={
-        "Documentation": get_docs_url(),
-        "Source": "https://github.com/ingeniamc/ingenialink-python",
+      'Documentation': get_docs_url(),
+      'Source': 'https://github.com/ingeniamc/ingenialink-python'
     },
     classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Topic :: Communications",
-        "Topic :: Software Development :: Libraries",
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 3',
+        'Topic :: Communications',
+        'Topic :: Software Development :: Libraries'
     ],
     install_requires=[
-        "canopen==1.2.1",
-        "python-can==3.3.4",
-        "ingenialogger>=0.2.1",
-        "ping3==4.0.3",
+        'canopen==1.2.1',
+        'python-can==3.3.4',
+        'ingenialogger>=0.2.1',
+        'ping3==4.0.3'
     ],
     extras_require={
         "dev": [
@@ -51,7 +52,7 @@ setuptools.setup(
             "jinja2==3.0.3",
             "pycodestyle==2.6.0",
             "wheel==0.37.1",
-            "m2r2==0.3.2",
+            "m2r2==0.3.2"
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 import re
 import setuptools
 
-_version = re.search(r'__version__\s+=\s+\"(.*)\"',
-                     open('ingenialink/__init__.py').read()).group(1)
+_version = re.search(r"__version__\s+=\s+\"(.*)\"", open("ingenialink/__init__.py").read()).group(1)
 
 
 def get_docs_url():
@@ -12,34 +11,33 @@ def get_docs_url():
 
 
 setuptools.setup(
-    name='ingenialink',
+    name="ingenialink",
     version=_version,
     packages=setuptools.find_packages(exclude=["test", "examples"]),
     include_package_data=True,
     package_data={"ingenialink": ["bin/FoE/*/*"]},
-    description='IngeniaLink Communications Library',
-    long_description=open('README.rst').read(),
-    author='Ingenia Motion Control',
-    author_email='support@ingeniamc.com',
-    url='https://www.ingeniamc.com',
+    description="IngeniaLink Communications Library",
+    long_description=open("README.rst").read(),
+    author="Ingenia Motion Control",
+    author_email="support@ingeniamc.com",
+    url="https://www.ingeniamc.com",
     project_urls={
-      'Documentation': get_docs_url(),
-      'Source': 'https://github.com/ingeniamc/ingenialink-python'
+        "Documentation": get_docs_url(),
+        "Source": "https://github.com/ingeniamc/ingenialink-python",
     },
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3',
-        'Topic :: Communications',
-        'Topic :: Software Development :: Libraries'
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Topic :: Communications",
+        "Topic :: Software Development :: Libraries",
     ],
     install_requires=[
-        'canopen==1.2.1',
-        'python-can==3.3.4',
-        'ingenialogger>=0.2.1',
-        'ping3==4.0.3',
-        'importlib-resources==5.4.0'
+        "canopen==1.2.1",
+        "python-can==3.3.4",
+        "ingenialogger>=0.2.1",
+        "ping3==4.0.3",
     ],
     extras_require={
         "dev": [
@@ -53,7 +51,7 @@ setuptools.setup(
             "jinja2==3.0.3",
             "pycodestyle==2.6.0",
             "wheel==0.37.1",
-            "m2r2==0.3.2"
+            "m2r2==0.3.2",
         ],
     },
 )


### PR DESCRIPTION
Fix the path of the FoE application

### Description

This PR changes the way to find the path to the FoE application. It uses inspect module instead of pkg_resources. This is needed to use FoE from ML3.

Fixes # INGK-641

### Type of change

- [x] Use inspect instead of pkg_resources.

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.