### PR TITLE
INGK-642 Read a register instead of doing a ping (NetStatusListener in Ethernet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased] 
+### Changed
+- Read a register instead of doing a ping in the Ethernet's NetStatusListener
+
 ## [7.0.1] - 2023-04-04
 ### Fixed
 - Recover old Monitoring/Disturbance compatibility

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -54,7 +54,10 @@ class NetStatusListener(Thread):
                 servo_state = self.__network._get_servo_state(servo_ip)
                 while unsuccessful_pings < self.__max_unsuccessful_pings:
                     response = servo.is_alive() # TODO: Use ping after CAP-924 is fixed 
-                    unsuccessful_pings = int(response)
+                    if response == False:
+                        unsuccessful_pings += 1
+                    else:
+                        break
                 ping_response = unsuccessful_pings != self.__max_unsuccessful_pings
                 if servo_state == NET_STATE.CONNECTED and not ping_response:
                     self.__network._notify_status(servo_ip, NET_DEV_EVT.REMOVED)

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -39,9 +39,10 @@ class NetStatusListener(Thread):
 
     """
 
-    def __init__(self, network):
+    def __init__(self, network, refresh_time=0.25):
         super(NetStatusListener, self).__init__()
         self.__network = network
+        self.__refresh_time = refresh_time
         self.__stop = False
         self.__max_unsuccessful_pings = MAX_NUM_UNSUCCESSFUL_PINGS
 
@@ -52,11 +53,8 @@ class NetStatusListener(Thread):
                 servo_ip = servo.ip_address
                 servo_state = self.__network._get_servo_state(servo_ip)
                 while unsuccessful_pings < self.__max_unsuccessful_pings:
-                    response = ping(servo_ip, timeout=1)
-                    if not isinstance(response, float):
-                        unsuccessful_pings += 1
-                    else:
-                        break
+                    response = servo.is_alive() # TODO: Use ping after CAP-924 is fixed 
+                    unsuccessful_pings = int(response)
                 ping_response = unsuccessful_pings != self.__max_unsuccessful_pings
                 if servo_state == NET_STATE.CONNECTED and not ping_response:
                     self.__network._notify_status(servo_ip, NET_DEV_EVT.REMOVED)
@@ -64,7 +62,7 @@ class NetStatusListener(Thread):
                 if servo_state == NET_STATE.DISCONNECTED and ping_response:
                     self.__network._notify_status(servo_ip, NET_DEV_EVT.ADDED)
                     self.__network._set_servo_state(servo_ip, NET_STATE.CONNECTED)
-            time.sleep(0.25)
+            time.sleep(self.__refresh_time)
 
     def stop(self):
         self.__stop = True

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -53,7 +53,7 @@ class NetStatusListener(Thread):
                 servo_ip = servo.ip_address
                 servo_state = self.__network._get_servo_state(servo_ip)
                 while unsuccessful_pings < self.__max_unsuccessful_pings:
-                    response = servo.is_alive() # TODO: Use ping after CAP-924 is fixed 
+                    response = servo.is_alive()  # TODO: Use ping after CAP-924 is fixed
                     if response == False:
                         unsuccessful_pings += 1
                     else:


### PR DESCRIPTION
## Read register instead of ping (NetStatusListener in Ethernet)

### Description

This PR changes the way to verify network connection in ethernet. Now a reading is used instead of a ping to avoid conflicts between pings and readings in Capitan.

Fixes INGK-642 

### Type of change

- [x] Read a register instead of doing a ping.
- [x] Parametrize refresh time.

### Tests
- [x] Test cable disconnection in ML3.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.