### PR TITLE
INGK-646 Set subprocess run encoding to utf-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Changed
 - Read a register instead of doing a ping in the Ethernet's NetStatusListener
 - Use inspect instead of pkg_resources to find the path to the FoE application.
+- Call FoE application with utf-8 encoding.
 
 
 ## [7.0.1] - 2023-04-04

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -67,7 +67,10 @@ class EthercatNetwork:
         logger.debug(f"Call FoE application for {sys_name}-{arch}")
         try:
             subprocess.run(
-                [exec_path, self.interface_name, f"{slave_id}", fw_file], check=True, shell=True
+                [exec_path, self.interface_name, f"{slave_id}", fw_file],
+                check=True,
+                shell=True,
+                encoding="utf-8",
             )
         except subprocess.CalledProcessError as e:
             foe_return_error = self.FOE_ERRORS.get(e.returncode, self.UNKNOWN_FOE_ERROR)


### PR DESCRIPTION
### Description

Use utf-8 in subprocess.run

Fixes # INGK-646

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.