### PR TITLE
INGK-650 Truncate the NACK error message

### DIFF
--- a/ingenialink/utils/mcb.py
+++ b/ingenialink/utils/mcb.py
@@ -135,7 +135,7 @@ class MCB:
         recv_add, _, cmd, data = cls.read_mcb_frame(frame)
 
         if cmd != MCB_CMD_ACK:
-            err_code_little = int.from_bytes(data, byteorder="little")
+            err_code_little = int.from_bytes(data[: cls.ERR_CODE_SIZE], byteorder="little")
             err_code_big = err_code_little.to_bytes(cls.ERR_CODE_SIZE, byteorder="big")
             raise ILNACKError(f"Communications error (NACK -> 0x{err_code_big.hex().upper()})")
         if expected_address != recv_add:

--- a/tests/test_mcb.py
+++ b/tests/test_mcb.py
@@ -65,7 +65,10 @@ def test_read_mcb_frame_wrong_crc(expected_address, frame):
 
 
 @pytest.mark.no_connection
-@pytest.mark.parametrize("expected_address, frame", [(0x11, "a1001c0100000106000000009ad7")])
+@pytest.mark.parametrize(
+    "expected_address, frame",
+    [(0x11, "a1001c0100000106000000009ad7"), (0x11, "a1001c01772f2f3a00004650608b")],
+)
 def test_read_mcb_frame_nack(expected_address, frame):
     frame_byte_arr = bytearray.fromhex(frame)
     with pytest.raises(ILNACKError):


### PR DESCRIPTION
### Truncate the NACK error message

### Description

This PR truncates the NACK error message to avoid including noise in the reading,

Fixes # INGK-650

### Type of change

- [x] Truncate NACK error

### Tests
- [x] Add test case at `test_read_mcb_frame_nack`.
- [x] Run tests.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.