### PR TITLE
INGK-651 Avoid NACK error to crash the status listener

### DIFF
--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "CanopenDictionary",
 ]
 
-__version__ = "7.0.2-RC3"
+__version__ = "7.0.2-RC4"

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -60,7 +60,7 @@ class ServoStatusListener(threading.Thread):
                     if subnode not in previous_states or previous_states[subnode] != current_state:
                         previous_states[subnode] = current_state
                         self.__servo._notify_state(current_state, subnode)
-                except (ILIOError, ILTimeoutError) as e:
+                except ILError as e:
                     logger.error("Error getting drive status. Exception : %s", e)
             time.sleep(1.5)
 


### PR DESCRIPTION
### Avoid NACK error to crash the status listener

### Description

This PR changes the errors caught in the status listener thread to include NACK and other possible future errors.

Fixes # INGK-651

### Type of change

- [x] Catch ILError in the status listener thread

### Tests
- [x] Test it with ML3.
- [x] Run tests.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.