### PR TITLE
INGK-660 Catch EoE service deinit error when disconnecting the drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Catch EoE service deinit error when disconnecting the drive.
+
+
 ## [7.0.2] - 2023-05-22
 ### Changed
 - Read a register instead of doing a ping in the Ethernet's NetStatusListener

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Add
+- Virtual drive.
+
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.
 

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -128,7 +128,10 @@ class EoENetwork(EthernetNetwork):
         if len(self.servos) == 0:
             self._stop_eoe_service()
             self._erase_config_eoe_service()
-            self._deinitialize_eoe_service()
+            try:
+                self._deinitialize_eoe_service()
+            except ILError as e:
+                logger.error(e)
 
     def __del__(self):
         self._eoe_socket.shutdown(socket.SHUT_RDWR)

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -260,11 +260,11 @@ class EoENetwork(EthernetNetwork):
             ILError: If the EoE service cannot be stopped on the network interface.
 
         """
-        self._eoe_service_init = False
         data = self.ifname
         msg = self._build_eoe_command_msg(EoECommand.DEINIT.value, data=data.encode("utf-8"))
         try:
             self._send_command(msg)
+            self._eoe_service_init = False
         except (ILIOError, ILTimeoutError) as e:
             raise ILError("Failed to deinitialize the EoE service.") from e
 


### PR DESCRIPTION
### INGK-660 Catch EoE service deinit error when disconnecting the drive

### Description

Please include a summary of the change and which issue is fixed. 

Fixes # INGK-660

### Changes

- [x] Catch deinit error when disconnecting the drive.

### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.