### PR TITLE
INGK-661 Log exceptions in read_coco_moco_register correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.
+- Log exceptions in read_coco_moco_register function correctly.
 
 
 ## [7.0.2] - 2023-05-22

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -817,13 +817,11 @@ class Servo:
         try:
             return self.read(register_coco, subnode=0)
         except ILError:
-            logger.warning(
-                f"Error reading register {register_coco.identifier} from COCO. Trying MOCO"
-            )
+            logger.warning(f"Error reading register {register_coco} from COCO. Trying MOCO")
         try:
             return self.read(register_moco, subnode=1)
         except ILError:
-            raise ILError(f"Error reading register {register_moco.identifier} from MOCO.")
+            raise ILError(f"Error reading register {register_moco} from MOCO.")
 
     def __monitoring_map_register(self):
         """Get the first available Monitoring Mapped Register slot.


### PR DESCRIPTION
### INGK-661 Log exceptions in read_coco_moco_register correctly

### Description

Fixes #INGK-661

### Type of change

- [x] Assume string registers.

### Documentation

Please update the documentation.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.