### PR TITLE
INGK-664 In convert_bytes_to_dtype raise an ILValueError if string can't be covert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Add
 - Virtual drive.
 
+### Changed
+- convert_bytes_to_dtype raises an ILValueError string bytes are wrong
+
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.
 - Log exceptions in read_coco_moco_register function correctly.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,12 +5,15 @@ from ingenialink.enums.register import REG_DTYPE
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
 
-@pytest.mark.parametrize("v_input, v_output, dtype", [
-    (b"\x00", 0, REG_DTYPE.S32),
-    (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
-    (b"\xFF", 255, REG_DTYPE.U16),
-    (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
-])
+@pytest.mark.parametrize(
+    "v_input, v_output, dtype",
+    [
+        (b"\x00", 0, REG_DTYPE.S32),
+        (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
+        (b"\xFF", 255, REG_DTYPE.U16),
+        (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
+    ],
+)
 def test_convert_bytes_to_dtype(v_input, v_output, dtype):
     assert convert_bytes_to_dtype(v_input, dtype) == v_output
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,21 @@
+import pytest
+
+from ingenialink.exceptions import ILValueError
+from ingenialink.enums.register import REG_DTYPE
+from ingenialink.utils._utils import convert_bytes_to_dtype
+
+
+@pytest.mark.parametrize("v_input, v_output, dtype", [
+    (b"\x00", 0, REG_DTYPE.S32),
+    (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
+    (b"\xFF", 255, REG_DTYPE.U16),
+    (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
+])
+def test_convert_bytes_to_dtype(v_input, v_output, dtype):
+    assert convert_bytes_to_dtype(v_input, dtype) == v_output
+
+
+def test_convert_bytes_to_dtype_wrong_string():
+    wrong_data = b"\xff\xff\xff\xff\xff\x00"
+    with pytest.raises(ILValueError):
+        convert_bytes_to_dtype(wrong_data, REG_DTYPE.STR)


### PR DESCRIPTION
### Description

Fixes # (INGK-664)

### Type of change

- [x] Raise ILValueError when bytes can't be decoded in utf-8
- [x] Update convert_bytes_to_dtype docstring

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.