### PR TITLE
INGK-665 Wait EoE starts before connect drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - convert_bytes_to_dtype raises an ILValueError string bytes are wrong
+- Wait EoE starts before connect drive
 
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.


### PR DESCRIPTION
### Description

Wait until EoE starts before connecting the drive. Some times IL tries to connect to the drives too fast, and EoE services can't initialize EoE

Fixes # (INGK-665)

### Type of change

- [x] Wait EoE starts before connecting the drive

### Tests
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.