### PR TITLE
Ingk 666 mutex should not be created inside in a thread

### DIFF
--- a/ingenialink/ethernet/servo.py
+++ b/ingenialink/ethernet/servo.py
@@ -1,5 +1,6 @@
 import ipaddress
 import socket
+import threading
 
 from ingenialink.exceptions import ILError, ILTimeoutError, ILIOError
 from ingenialink.constants import PASSWORD_STORE_RESTORE_TCP_IP
@@ -19,6 +20,7 @@ import ingenialogger
 
 logger = ingenialogger.get_logger(__name__)
 
+lock_ethernet_servo = threading.Lock()
 
 class EthernetServo(Servo):
     """Servo object for all the Ethernet slave functionalities.
@@ -136,7 +138,7 @@ class EthernetServo(Servo):
             bytes: The response frame.
         """
         frame = MCB.build_mcb_frame(cmd, subnode, reg, data)
-        self._lock.acquire()
+        lock_ethernet_servo.acquire()
         try:
             try:
                 self.socket.sendall(frame)
@@ -151,5 +153,5 @@ class EthernetServo(Servo):
         except (ILIOError, ILTimeoutError) as e:
             raise e
         finally:
-            self._lock.release()
+            lock_ethernet_servo.release()
         return MCB.read_mcb_data(reg, response)

--- a/ingenialink/poller.py
+++ b/ingenialink/poller.py
@@ -38,6 +38,7 @@ class PollerTimer:
         if self.thread.is_alive():
             self.thread.join()
 
+lock_poller = Lock()
 
 class Poller:
     """Register poller for CANOpen/Ethernet communications.
@@ -60,7 +61,6 @@ class Poller:
         self.__running = False
         self.__mappings = []
         self.__mappings_enabled = []
-        self.__lock = Lock()
         self._reset_acq()
 
     def start(self):
@@ -198,7 +198,7 @@ class Poller:
         # Obtain current time
         t = delta.total_seconds()
 
-        self.__lock.acquire()
+        lock_poller.acquire()
         # Acquire all configured channels
         if self.__samples_count >= self.__sz:
             self.__samples_lost = True
@@ -221,7 +221,7 @@ class Poller:
             # Increment samples count
             self.__samples_count += 1
 
-        self.__lock.release()
+        lock_poller.release()
 
     @property
     def data(self):
@@ -243,10 +243,10 @@ class Poller:
             else:
                 d.append(list(None))
 
-        self.__lock.acquire()
+        lock_poller.acquire()
         self.__samples_count = 0
         self.__samples_lost = False
-        self.__lock.release()
+        lock_poller.release()
 
         return t, d, self.__samples_lost
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -133,7 +133,6 @@ class Servo:
         """SERVO_UNITS_VEL: Velocity units."""
         self.units_acc = None
         """SERVO_UNITS_ACC: Acceleration units."""
-        self._lock = threading.Lock()
         self.__observers_servo_state = []
         self.__listener_servo_status = None
         self.__monitoring = {}


### PR DESCRIPTION
### Mutex outside threads

### Description

The issue  was there were no mutual exclusion for some shared resources. The reason is mutexes were created inside per each thread, and it seems mutexes in python need to be created outside them, because before locks were used just by their own thread.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [x ] Locks are created outside threads


### Code formatting

- [ ] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.