### PR TITLE
Bugfix/ingk 438 fix ca nopen upload firmware

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -468,8 +468,8 @@ class CanopenNetwork(Network):
         """
         if callback_status_msg:
             callback_status_msg("Flashing firmware")
-        servo.write(PROG_STAT_1, PROG_CTRL_STATE_STOP, subnode=0)
         with contextlib.suppress(ILError):
+            servo.write(PROG_STAT_1, PROG_CTRL_STATE_STOP, subnode=0)
             servo.write(PROG_STAT_1, PROG_CTRL_STATE_START, subnode=0)
         logger.info("Flashing firmware...")
 
@@ -516,7 +516,7 @@ class CanopenNetwork(Network):
         if callback_status_msg:
             callback_status_msg("Optimizing file")
         lfu_file_d, lfu_path = tempfile.mkstemp(suffix=".lfu")
-        with open(sfu_file, "wb") as lfu_file:
+        with open(lfu_path, "wb") as lfu_file:
             with open(sfu_file, "r") as coco_in:
                 bin_node = ""
                 current_progress = 0

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -490,8 +490,7 @@ class CanopenNetwork(Network):
             callback_status_msg("Starting program")
         logger.info("Waiting for the drive to be available.")
         initial_time = time()
-        time_diff = time() - initial_time
-        while time_diff < RECONNECTION_TIMEOUT:
+        while (time() - initial_time) < RECONNECTION_TIMEOUT:
             with contextlib.suppress(ILError):
                 servo.read(servo.STATUS_WORD_REGISTERS)
                 return

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -159,6 +159,15 @@ class Servo:
             self.__listener_servo_status.join()
         self.__listener_servo_status = None
 
+    def is_listener_started(self) -> bool:
+        """Check if servo listener is started
+
+        Returns:
+            True if listener is started, else False
+
+        """
+        return self.__listener_servo_status is not None
+
     def load_configuration(self, config_file, subnode=None):
         """Write current dictionary storage to the servo drive.
 


### PR DESCRIPTION
### Description

Improve CANopen load firmware

Fixes # INGK-438

### Type of change

- [ ] Split CANopen function

### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [ ] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.