### PR TITLE
INGK-442 Set product name correctly if no dictionary file is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Fix CANopen load_firmware function.
+- Set product name correctly if no dictionary is provided.
+
 ## [7.0.3] - 2023-09-05
 
 ### Add

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.
 - Log exceptions in read_coco_moco_register function correctly.
+- Set product name correctly if no dictionary is provided.
 
 
 ## [7.0.2] - 2023-05-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 ### Fixed
 - Catch EoE service deinit error when disconnecting the drive.
 - Log exceptions in read_coco_moco_register function correctly.
-- Set product name correctly if no dictionary is provided.
 
 
 ## [7.0.2] - 2023-05-22

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -116,13 +116,15 @@ class Servo:
 
     def __init__(self, target, dictionary_path=None, servo_status_listener=False):
         self.target = target
+        prod_name = ""
         if dictionary_path is not None:
             self._dictionary = self.DICTIONARY_CLASS(dictionary_path)
+            if self.dictionary.part_number is not None:
+                prod_name = self.dictionary.part_number
         else:
             self._dictionary = None
         self._info = None
         self.name = DEFAULT_DRIVE_NAME
-        prod_name = "" if self.dictionary.part_number is None else self.dictionary.part_number
         self.full_name = f"{prod_name} {self.name} ({self.target})"
         """str: Obtains the servo full name."""
         self.units_torque = None


### PR DESCRIPTION
### Description
 Set product name correctly if no dictionary file is provided

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.