### PR TITLE
INGK-668 Reread when ethernet read a wrong address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [7.0.4]
+### Fixed
+- Reread when ethernet read a wrong address
+
 ## [7.0.3] - 2023-09-05
 
 ### Add

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "CanopenDictionary",
 ]
 
-__version__ = "7.0.3"
+__version__ = "7.0.4"

--- a/ingenialink/ethernet/servo.py
+++ b/ingenialink/ethernet/servo.py
@@ -143,20 +143,18 @@ class EthernetServo(Servo):
             except socket.error as e:
                 raise ILIOError("Error sending data.") from e
             try:
-                return self.__receive_mcb_frame(reg, self.socket)
+                return self.__receive_mcb_frame(reg)
             except ILWrongRegisterError as e:
                 logger.error(e)
-                return self.__receive_mcb_frame(reg, self.socket)
+                return self.__receive_mcb_frame(reg)
         finally:
             self._lock.release()
 
-    @staticmethod
-    def __receive_mcb_frame(reg: int, conn_socket: socket.socket) -> bytes:
+    def __receive_mcb_frame(self, reg: int) -> bytes:
         """Receive frame from socket and return MCB data
 
         Args:
             reg: expected address
-            conn_socket: connection socket
 
         Returns:
             MCB message data in bytes
@@ -167,7 +165,7 @@ class EthernetServo(Servo):
 
         """
         try:
-            response = conn_socket.recv(ETH_BUF_SIZE)
+            response = self.socket.recv(ETH_BUF_SIZE)
         except socket.timeout as e:
             raise ILTimeoutError("Timeout while receiving data.") from e
         except socket.error as e:


### PR DESCRIPTION
Reread when Ethernet read a wrong address

Fixes # (INGK-668)

### Type of change

- [x] First time ILWrongRegisterError is raised reread the socket

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.