### PR TITLE
Bugfix/ingk 677 read drive strings until null character x 00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.0.4]
 ### Fixed
 - Reread when ethernet read a wrong address
+- Read strings until NULL character
 
 ## [7.0.3] - 2023-09-05
 

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -257,7 +257,7 @@ def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, s
         [value] = struct.unpack("f", data)
     elif dtype == REG_DTYPE.STR:
         try:
-            value = data.decode("utf-8").rstrip("\0")
+            value = data.split(b"\x00")[0].decode("utf-8")
         except UnicodeDecodeError as e:
             raise ILValueError(f"Can't decode {e.object} to utf-8 string") from e
     else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from ingenialink.utils._utils import convert_bytes_to_dtype
         (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
         (b"\xFF", 255, REG_DTYPE.U16),
         (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
+        (b"\x74\x68\x61\x74\x27\x73\x20\x67\x6f\x6f\x64\x00\xca\xca", "that's good", REG_DTYPE.STR),
     ],
 )
 def test_convert_bytes_to_dtype(v_input, v_output, dtype):


### PR DESCRIPTION
Read drive strings until null character \x00

Fixes # (INGK-677)

### Type of change

Please add a description and delete options that are not relevant.

- [x] Change convert_bytes_to_dtype functions, split bytes by NULL character

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.