### PR TITLE
INGK-512: delete enums count parameter in register constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fix CANopen load_firmware function.
 - Set product name correctly if no dictionary is provided.
+- Docstrings from Register constructor and its subclasses are updated.
 
 ## [7.0.4] - 2023-10-11
 

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -19,7 +19,6 @@ class CanopenRegister(Register):
         reg_range (tuple, optional): Range (min, max).
         labels (dict, optional): Register labels.
         enums (dict): Enumeration registers.
-        enums_count (int): Number of enumeration registers.
         cat_id (str, optional): Category ID.
         scat_id (str, optional): Sub-category ID.
         internal_use (int, optional): Internal use.

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -18,7 +18,6 @@ class EthernetRegister(Register):
         reg_range (tuple, optional): Range (min, max).
         labels (dict, optional): Register labels.
         enums (dict): Enumeration registers.
-        enums_count (int): Number of enumeration registers.
         cat_id (str, optional): Category ID.
         scat_id (str, optional): Sub-category ID.
         internal_use (int, optional): Internal use.

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -34,7 +34,6 @@ class Register(ABC):
         reg_range (tuple, optional): Range (min, max).
         labels (dict, optional): Register labels.
         enums (dict): Enumeration registers.
-        enums_count (int): Number of enumeration registers.
         cat_id (str, optional): Category ID.
         scat_id (str, optional): Sub-category ID.
         internal_use (int, optional): Internal use.


### PR DESCRIPTION
### Delete enums_count

Delete enums_count parameter in Register class and its subclasses.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [x] Delete enums_count parameter in Register class and its subclasses.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.