### PR TITLE
INGK-675: unify canopen register and ethernet register constructor signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - Fix CANopen load_firmware function.
 - Set product name correctly if no dictionary is provided.
+- CanopenRegister and EthernetRegister have the same signature.
 
 ## [7.0.4] - 2023-10-11
 

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -20,45 +20,41 @@ import ingenialogger
 logger = ingenialogger.get_logger(__name__)
 
 PROG_STAT_1 = CanopenRegister(
-    identifier="CIA302_BL_PROGRAM_CONTROL_1",
-    units="",
-    subnode=0,
     idx=0x1F51,
     subidx=0x01,
     cyclic="CONFIG",
     dtype=REG_DTYPE.U8,
     access=REG_ACCESS.RW,
+    identifier="CIA302_BL_PROGRAM_CONTROL_1",
+    subnode=0,
 )
 PROG_DL_1 = CanopenRegister(
-    identifier="CIA302_BL_PROGRAM_DATA",
-    units="",
-    subnode=0,
     idx=0x1F50,
     subidx=0x01,
     cyclic="CONFIG",
     dtype=REG_DTYPE.DOMAIN,
     access=REG_ACCESS.RW,
+    identifier="CIA302_BL_PROGRAM_DATA",
+    subnode=0,
 )
 FORCE_BOOT = CanopenRegister(
-    identifier="DRV_BOOT_COCO_FORCE",
-    units="",
-    subnode=0,
     idx=0x5EDE,
     subidx=0x00,
     cyclic="CONFIG",
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.WO,
+    identifier="DRV_BOOT_COCO_FORCE",
+    subnode=0,
 )
 
 CIA301_DRV_ID_DEVICE_TYPE = CanopenRegister(
-    identifier="",
-    units="",
-    subnode=0,
     idx=0x1000,
     subidx=0x00,
     cyclic="CONFIG",
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.RO,
+    identifier="",
+    subnode=0,
 )
 
 CANOPEN_BOTT_NODE_GUARDING_PERIOD = 5

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -6,13 +6,13 @@ class CanopenRegister(Register):
     """CANopen Register.
 
     Args:
-        identifier (str): Identifier.
-        units (str): Units.
-        cyclic (str): Cyclic typed register.
         idx (int): Index of the register.
         subidx (int): Subindex of the register.
         dtype (REG_DTYPE): Data type.
         access (REG_ACCESS): Access type.
+        identifier (str): Identifier.
+        units (str): Units.
+        cyclic (str): Cyclic typed register.
         phy (REG_PHY, optional): Physical units.
         subnode (int): Subnode.
         storage (any, optional): Storage.
@@ -34,13 +34,13 @@ class CanopenRegister(Register):
 
     def __init__(
         self,
-        identifier,
-        units,
-        cyclic,
         idx,
         subidx,
         dtype,
         access,
+        identifier=None,
+        units=None,
+        cyclic="CONFIG",
         phy=REG_PHY.NONE,
         subnode=1,
         storage=None,

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -35,24 +35,20 @@ class CanopenServo(Servo):
     RESTORE_COCO_ALL = "CIA301_COMMS_RESTORE_ALL"
     STORE_COCO_ALL = "CIA301_COMMS_STORE_ALL"
     MONITORING_DATA = CanopenRegister(
-        identifier="",
-        units="",
-        subnode=0,
         idx=0x58B2,
         subidx=0x00,
         cyclic="CONFIG",
         dtype=REG_DTYPE.U16,
         access=REG_ACCESS.RO,
+        subnode=0,
     )
     DIST_DATA = CanopenRegister(
-        identifier="",
-        units="",
-        subnode=0,
         idx=0x58B4,
         subidx=0x00,
         cyclic="CONFIG",
         dtype=REG_DTYPE.U16,
         access=REG_ACCESS.RW,
+        subnode=0,
     )
 
     def __init__(self, target, node, dictionary_path=None, servo_status_listener=False):

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -13,14 +13,14 @@ from ingenialink.canopen.register import (
 @pytest.mark.no_connection
 @pytest.mark.smoke
 def test_getters_canopen_register():
-    reg_identifier = "MON_CFG_SOC_TYPE"
-    reg_units = "none"
-    reg_cyclic = "CONFIG"
     reg_idx = 0x58F0
     reg_subidx = 0x00
     reg_dtype = REG_DTYPE.U32
     reg_access = REG_ACCESS.RW
     reg_kwargs = {
+        "identifier": "MON_CFG_SOC_TYPE",
+        "units": "none",
+        "cyclic": "CONFIG",
         "phy": REG_PHY.NONE,
         "subnode": 0,
         "storage": 1,
@@ -38,9 +38,6 @@ def test_getters_canopen_register():
         aux_enums.append(test_dictionary)
 
     register = CanopenRegister(
-        reg_identifier,
-        reg_units,
-        reg_cyclic,
         reg_idx,
         reg_subidx,
         reg_dtype,
@@ -48,13 +45,13 @@ def test_getters_canopen_register():
         **reg_kwargs,
     )
 
-    assert register.identifier == reg_identifier
-    assert register.units == reg_units
-    assert register.cyclic == reg_cyclic
     assert register.idx == reg_idx
     assert register.subidx == reg_subidx
     assert register.dtype == reg_dtype
     assert register.access == reg_access
+    assert register.identifier == reg_kwargs["identifier"]
+    assert register.units == reg_kwargs["units"]
+    assert register.cyclic == reg_kwargs["cyclic"]
     assert register.phy == reg_kwargs["phy"]
     assert register.subnode == reg_kwargs["subnode"]
     assert register.storage == reg_kwargs["storage"]


### PR DESCRIPTION
### CanopenRegister and EthernetRegister signatures

### Description

CanopenRegister constructor is changed, and it has the same order as the EthernetRegister constructor.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [x] CanopenRegister has the same signature as EthernetRegister
- [x] The rest of the library is adapted.


### Tests
- [x] Tests that already implemented are updated.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.