### PR TITLE
INGK-315 Modify status network property in case of multislave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Add
+- Support for multi-drive in CANopen's NetStatusListener.
+
 ### Fixed
 - Fix CANopen load_firmware function.
 - Set product name correctly if no dictionary is provided.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -129,13 +129,14 @@ class NetStatusListener(Thread):
         self.__stop = False
 
     def run(self):
-        timestamps = {
-            node_id: node.nmt.timestamp
-            for node_id, node in self.__network._connection.nodes.items()
-        }
+        timestamps = {}
         while not self.__stop:
-            for node_id, node in self.__network._connection.nodes.items():
+            for node_id, node in list(self.__network._connection.nodes.items()):
+                sleep(1.5)
                 current_timestamp = node.nmt.timestamp
+                if node_id not in timestamps:
+                    timestamps[node_id] = current_timestamp
+                    continue
                 is_alive = current_timestamp != timestamps[node_id]
                 servo_state = self.__network._get_servo_state(node_id)
                 if is_alive:
@@ -148,7 +149,6 @@ class NetStatusListener(Thread):
                 else:
                     self.__network._notify_status(node_id, NET_DEV_EVT.REMOVED)
                     self.__network._set_servo_state(node_id, NET_STATE.DISCONNECTED)
-                sleep(1.5)
 
     def stop(self):
         self.__stop = True

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -906,15 +906,6 @@ class CanopenNetwork(Network):
         """NET_PROT: Obtain network protocol."""
         return NET_PROT.CAN
 
-    @property
-    def status(self):
-        """NET_STATE: Network state."""
-        return self.__net_state
-
-    @status.setter
-    def status(self, new_state):
-        self.__net_state = new_state
-
     def _get_servo_state(self, node_id):
         return self.__servos_state[node_id]
 

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -24,7 +24,6 @@ def test_getters_canopen(virtual_network):
     assert virtual_network.channel == test_channel
     assert virtual_network.baudrate == test_baudrate
     assert virtual_network.network is None
-    assert virtual_network.status == NET_STATE.DISCONNECTED
 
 
 @pytest.mark.canopen


### PR DESCRIPTION
### Description

Adapt CANopen's Network status listener to support multi-drives.

Fixes #INGK-315

### Type of change

Please add a description and delete options that are not relevant.

-  The subscribe_to_status function takes the node ID as argument.
- The start and stop status listener functions no longer require the servo as argument.

### Tests
- Connect to two CANopen drives, subscribe to their status, and check that the callback functions are notified of the network status changes.
