### PR TITLE
Bugfix/ingk 680 disturbance create data chunks raise overflow error if values do not fit in registers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - Docstrings from Register constructor and its subclasses are updated.
 - CanopenRegister and EthernetRegister have the same signature.
 
+### Changed
+- Raise ILValueError when the disturbance data does not fit in a register.
+
 ## [7.0.4] - 2023-10-11
 
 ### Fixed

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -12,6 +12,7 @@ from ingenialink.exceptions import (
     ILStateError,
     ILAccessError,
     ILTimeoutError,
+    ILValueError,
 )
 from ingenialink.register import Register
 from ingenialink.utils._utils import (
@@ -997,9 +998,12 @@ class Servo:
             data_arr (list or list of list): Data array.
 
         """
-        data, chunks = self._disturbance_create_data_chunks(
-            channels, dtypes, data_arr, self.MAX_WRITE_SIZE
-        )
+        try:
+            data, chunks = self._disturbance_create_data_chunks(
+                channels, dtypes, data_arr, self.MAX_WRITE_SIZE
+            )
+        except OverflowError as e:
+            raise ILValueError(f"Disturbance data cannot be written. Reason: {e}")
         for chunk in chunks:
             self._write_raw(self.DIST_DATA, data=chunk)
         self.disturbance_data = data

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1003,7 +1003,7 @@ class Servo:
                 channels, dtypes, data_arr, self.MAX_WRITE_SIZE
             )
         except OverflowError as e:
-            raise ILValueError(f"Disturbance data cannot be written. Reason: {e}")
+            raise ILValueError("Disturbance data cannot be written.") from e
         for chunk in chunks:
             self._write_raw(self.DIST_DATA, data=chunk)
         self.disturbance_data = data

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1058,9 +1058,6 @@ class Servo:
             )
         except OverflowError as e:
             raise ILValueError("Disturbance data cannot be written.") from e
-        data, chunks = self._disturbance_create_data_chunks(
-            channels, dtypes, data_arr, self.MAX_WRITE_SIZE
-        )
         for chunk in chunks:
             self._write_raw(self.DIST_DATA, data=chunk)
         self.disturbance_data = data


### PR DESCRIPTION
### Description
Raise ILValueError when the disturbance data does not fit in a register.

Fixes #INGK-680

### Type of change

Please add a description and delete options that are not relevant.

- Raise ILValueError when the disturbance data does not fit in a register.

### Tests
- Create a disturbance signal that cannot fit in the register dtype (for example the signal contains negative values and the register dtype is unsigned).
- Try to write the disturbance data.
- Check that the ILValueError exception is raised.
