### PR TITLE
INGK-683 Crash when disconnecting from drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Docstrings from Register constructor and its subclasses are updated.
 - CanopenRegister and EthernetRegister have the same signature.
 - Add PySOEM to setup.py.
+- Unexpected closing when disconnecting from an EtherCAT (SDOs) drive if servo status listener is active.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -142,6 +142,7 @@ class EthercatNetwork(Network):
             servo: Instance of the servo connected.
 
         """
+        servo.stop_status_listener()
         self.servos.remove(servo)
         if not self.servos:
             self.stop_status_listener()


### PR DESCRIPTION
### Description

If the servo status listener is active when disconnecting an EtherCAT (SDOs) servo from the network, a crash occurs.

Fixes #INGK-683

### Type of change

-Stop the servo status listener before disconnecting the servo from the network.

### Tests
- Connect to an EtherCAT device, activate the network and servo status listeners.
- Disconnect from the drive.
- Check that there is no crash.
