### PR TITLE
INGK-684 Add int type to accepted types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Docstrings from Register constructor and its subclasses are updated.
 - CanopenRegister and EthernetRegister have the same signature.
 - Add PySOEM to setup.py.
+- Exception error when trying to write an int to a register of dtype float.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -237,7 +237,7 @@ def convert_dtype_to_bytes(data: Union[int, float, str, bytes], dtype: REG_DTYPE
             raise ValueError(f"Expected data of type bytes, but got {type(data)}")
         return data
     if dtype == REG_DTYPE.FLOAT:
-        if not isinstance(data, float):
+        if not isinstance(data, (float, int)):
             raise ValueError(f"Expected data of type float, but got {type(data)}")
         return struct.pack("f", float(data))
     if dtype == REG_DTYPE.STR:


### PR DESCRIPTION
### Description

Exception is raised when trying to write an int to register of float type.

Fixes #INGK-684

### Type of change
- Add int type to accepted types to write to a register of type float.

### Tests
- Connect to a drive.
- Write an int to a register of type float.
- Check that no exception is raised.