### PR TITLE
INGK-687 Improve Servo's enable and disable methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Exception error when trying to write an int to a register of dtype float.
 - Fix acquisition data variable initialization in Poller class.
 - Unexpected closing when disconnecting from an EtherCAT (SDOs) drive if servo status listener is active.
+- Improve the enable and disable methods of the Servo class.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.


### PR DESCRIPTION
## Improve Servo's enable and disable methods

### Description

This PR improves the enable and disable methods of the Servo class.

Fixes # INGK-687

### Type of change

- [x] Improve how the library enables and disables the motor to avoid fake timeouts.

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.