### PR TITLE
INGK-691 Avoid crashes in Poller due to timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Exception error when trying to write an int to a register of dtype float.
 - Fix acquisition data variable initialization in Poller class.
 - Unexpected closing when disconnecting from an EtherCAT (SDOs) drive if servo status listener is active.
+- Avoid crashes in the Poller due to read timeouts.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.


### PR DESCRIPTION
### Avoid crashes in Poller due to timeouts

### Description

This PR adds a try-except to avoid crashes in the Poller due to timeouts.

Fixes # INGK-691 

### Type of change

- [x] Add try-except in the Poller

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.