### PR TITLE
Bugfix/ingk 692 scope in polling mode opens and closes threads after its stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Fix acquisition data variable initialization in Poller class.
 - Unexpected closing when disconnecting from an EtherCAT (SDOs) drive if servo status listener is active.
 - Avoid crashes in the Poller due to read timeouts.
+- Poller timer thread not closing after the poller is finished.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.

--- a/ingenialink/poller.py
+++ b/ingenialink/poller.py
@@ -16,35 +16,15 @@ import ingenialogger
 logger = ingenialogger.get_logger(__name__)
 
 
-class PollerTimer:
-    """Custom timer for the Poller.
+class PollerTimer(Timer):
+    def __init__(self, interval: float, function: Callable[..., Any]) -> None:
+        super().__init__(interval, function)
+        self.cb = function
+        self.time = interval
 
-    Args:
-        time: Timeout to use for the timer.
-        cb: Callback.
-
-    """
-
-    def __init__(self, time: float, cb: Callable[..., Any]) -> None:
-        self.cb = cb
-        self.time = time
-        self.thread = Timer(self.time, self.handle_function)
-
-    def handle_function(self) -> None:
-        """Handle method that creates the timer for the poller"""
-        self.cb()
-        self.thread = Timer(self.time, self.handle_function)
-        self.thread.start()
-
-    def start(self) -> None:
-        """Starts the poller timer"""
-        self.thread.start()
-
-    def cancel(self) -> None:
-        """Stops the poller timer"""
-        self.thread.cancel()
-        if self.thread.is_alive():
-            self.thread.join()
+    def run(self) -> None:
+        while not self.finished.wait(self.time):
+            self.cb(*self.args, **self.kwargs)
 
 
 class Poller:


### PR DESCRIPTION
### Description

Simplify the Poller Timer class.

Fixes #INGK-692

### Type of change

- Create a single Timer instance and call the callback function at each time interval.  Based on this [stackoverflow answer](https://stackoverflow.com/questions/12435211/threading-timer-repeat-function-every-n-seconds#:~:text=Improving%20a%20little%20on%20Hans%20Then%27s%20answer%2C%20we%20can%20just%20subclass%20the%20Timer%20function.%20The%20following%20becomes%20our%20entire%20%22repeat%20timer%22%20code%2C%20and%20it%20can%20be%20used%20as%20a%20drop%2Din%20replacement%20for%20threading.Timer%20with%20all%20the%20same%20arguments%3A).


### Tests
- Follow the steps described in the issue.
- Check that the poller timer thread closes.