### PR TITLE
bugfix/INGK-711: VCIErrors management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Avoid crashes in the Poller due to read timeouts.
 - Poller timer thread not closing after the poller is finished.
 - Improve the enable and disable methods of the Servo class.
+- Unexpected VCIErrors.
 
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1,24 +1,29 @@
 import contextlib
-import re
 import os
+import re
 import tempfile
-from enum import Enum
-from time import sleep
-from threading import Thread
-from typing import Optional, Callable, Union, List, Any, Dict, Tuple
 from collections import defaultdict
-
-from .register import CanopenRegister
-from ingenialink.utils.mcb import MCB
-from ..exceptions import ILFirmwareLoadError, ILObjectNotExist, ILError
-from can import CanError
-from ..network import NET_PROT, NET_STATE, NET_DEV_EVT, Network
-from .servo import CanopenServo, REG_ACCESS, REG_DTYPE, CANOPEN_SDO_RESPONSE_TIMEOUT
+from enum import Enum
+from threading import Thread
+from time import sleep
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import canopen
-from canopen import Network as NetworkLib
 import ingenialogger
+from can import CanError
 from can.interfaces.ixxat.exceptions import VCIError
+from canopen import Network as NetworkLib
+
+from ingenialink.canopen.register import CanopenRegister
+from ingenialink.canopen.servo import (
+    CANOPEN_SDO_RESPONSE_TIMEOUT,
+    REG_ACCESS,
+    REG_DTYPE,
+    CanopenServo,
+)
+from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILObjectNotExist
+from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network
+from ingenialink.utils.mcb import MCB
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -582,7 +582,7 @@ class CanopenNetwork(Network):
         try:
             servo.node.nmt.start_node_guarding(CANOPEN_BOTT_NODE_GUARDING_PERIOD)
         except VCIError as e:
-            raise ILFirmwareLoadError(f"Firmware loading error using ixxat device: {e}")
+            raise ILFirmwareLoadError(f"Firmware loading error using ixxat device") from e
         try:
             servo.node.nmt.wait_for_heartbeat(timeout=RECONNECTION_TIMEOUT)
         except canopen.nmt.NmtError as e:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -582,7 +582,8 @@ class CanopenNetwork(Network):
         try:
             servo.node.nmt.start_node_guarding(CANOPEN_BOTT_NODE_GUARDING_PERIOD)
         except VCIError as e:
-            raise ILFirmwareLoadError(f"Firmware loading error using ixxat device") from e
+            # This error is a specific error for ixxat transceivers
+            raise ILFirmwareLoadError("An error occurred when starting the node guarding.") from e
         try:
             servo.node.nmt.wait_for_heartbeat(timeout=RECONNECTION_TIMEOUT)
         except canopen.nmt.NmtError as e:

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,3 +17,6 @@ ignore_missing_imports = True
 
 [mypy-ingenialogger]
 ignore_missing_imports = True
+
+[mypy-can.*]
+ignore_missing_imports = True


### PR DESCRIPTION
## VCIErrors management

### Description

When updating a firmware using a ixxat tranceiver may causes VCIErrors from can library. Here these type of errors will be managed.

Fixes # INGK-711

### Type of change

Please add a description and delete options that are not relevant.

- [X] VCIErrors management.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.