### PR TITLE
INGK-709 Deprecate Python 3.6 and 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@
 ### Changed
 - Raise ILValueError when the disturbance data does not fit in a register.
 
+### Deprecated 
+- Support to Python 3.6 and 3.7.
+
 ## [7.0.4] - 2023-10-11
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ ingenialink-python is a Python library for simple motion control tasks and commu
 Requirements
 ------------
 
-* Python 3
+* Python 3.8 or higher
 * WinPcap_ 4.1.3
 
 .. _WinPcap: https://www.winpcap.org/install/

--- a/setup.py
+++ b/setup.py
@@ -57,4 +57,5 @@ setuptools.setup(
             "mypy==0.971"
         ],
     },
+    python_requires='>=3.8',
 )

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,5 @@ setuptools.setup(
             "m2r2==0.3.2",
             "mypy==0.971"
         ],
-    },
-    python_requires='>=3.8',
+    }
 )


### PR DESCRIPTION
### Deprecate Python 3.6 and 3.7

### Description

This PR deprecates Python 3.6 and 3.7.

Fixes #709

### Type of change

- [x] Update Changelog
- [x] Update README
- [x] Update setup.py

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).