### PR TITLE
INKG-738 fix ILIOError crashing poller threads

### DIFF
--- a/ingenialink/poller.py
+++ b/ingenialink/poller.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Tuple, Union, Callable, Optional, Any
 
 from ingenialink.exceptions import (
     ILAlreadyInitializedError,
+    ILIOError,
     ILStateError,
     ILValueError,
     ILTimeoutError,
@@ -211,7 +212,7 @@ class Poller:
                 register = self.__mappings[channel]
                 try:
                     self.__acq_data[channel][self.__samples_count] = self.servo.read(register)  # type: ignore
-                except ILTimeoutError:
+                except (ILTimeoutError, ILIOError):
                     reading_error = True
                     logger.warning(
                         f"Could not read {register.identifier} register. This sample is lost for"


### PR DESCRIPTION
### ILIOError crashes poller threads

### Description

When polling from a drive, it is not uncommon that a read operation fails (e.g. “Wrong working counter”). This warrants logging a warning, but the exception should be caught in order to prevent the poller thread from terminating (since it’s not a critical error).
Fixes # ([issue](https://novantamotion.atlassian.net/browse/INGK-738))

### Tests

Connect to a drive with a poller thread and provoke a "Wrong working counter" - error. The thread should not terminate.
A way to easily do this is by using https://github.com/ingeniamc/ingeniajumpstart and connecting to both drives as the program is designed to.