### PR TITLE
INGK-739 Make virtual drive monitoring usable from IW and IM

### DIFF
--- a/ingenialink/virtual/virtual_drive.py
+++ b/ingenialink/virtual/virtual_drive.py
@@ -213,7 +213,7 @@ class VirtualMonitoring(VirtualMonDistBase):
         self.map_registers()
         self.disable()
         self.enable()
-        
+
     def __create_signals(self) -> None:
         """Creates emulated monitoring signals."""
         for channel in range(self.number_mapped_registers):

--- a/ingenialink/virtual/virtual_drive.py
+++ b/ingenialink/virtual/virtual_drive.py
@@ -371,7 +371,7 @@ class VirtualDrive(Thread):
             elif cmd == self.READ_CMD:
                 value = self.get_value_by_id(subnode, str(register.identifier))
                 sent_cmd = self.ACK_CMD
-                if reg_add == self.id_to_address(0, "MON_DATA"):
+                if reg_add == self.id_to_address(0, "MON_DATA") and isinstance(value, bytes):
                     response = self._response_monitoring_data(value)
                 else:
                     data = convert_dtype_to_bytes(value, register.dtype)


### PR DESCRIPTION
##  Make virtual drive monitoring and disturbance usable from IW and IM

### Description

This PR fixes some issues with monitoring of virtual drive to make it usable from ingeniamotion and ingeniawizard.

Fixes # 739

### Type of change

- [x] Add monitoring rearm
- [x] Add monitoring status
- [x] Fix remove_data method.


### Tests
- [x] Run tests.
- [x] Test from ingeniawizard and ML3.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.