### PR TITLE
INGK-766 Make pysoem import optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.1.1]
+
+### Fixed
+- Import Ingenialink does not raise an error if WinPcap is not installed, but ethercat features are disabled.
+
 ## [7.1.0] - 2023-11-28
 
 ### Add

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,17 @@ pipeline {
                         """
                     }
                 }
+                stage('Run docker tests') {
+                    steps {
+                        bat """
+                            venv\\Scripts\\python.exe -m coverage run -m pytest tests -m docker --junitxml=pytest_docker_report.xml
+                            move .coverage ${env.WORKSPACE}\\.coverage_docker
+                            move pytest_docker_report.xml ${env.WORKSPACE}\\pytest_docker_report.xml
+                            exit /b 0
+                        """
+                        junit 'pytest_docker_report.xml'
+                    }
+                }
                 stage('Archive') {
                     steps {
                         bat """
@@ -109,6 +120,8 @@ pipeline {
                             XCOPY dist ${env.WORKSPACE}\\dist /i
                             XCOPY docs.zip ${env.WORKSPACE}
                         """
+                        stash includes: '.coverage_docker', name: 'coverage_docker'
+                        archiveArtifacts artifacts: 'pytest_docker_report.xml'
                         archiveArtifacts artifacts: "dist\\*, docs.zip"
                     }
                 }
@@ -236,9 +249,10 @@ pipeline {
                 }
                 stage('Save test results') {
                     steps {
+                        unstash 'coverage_docker'
                         unstash 'coverage_reports'
                         bat '''
-                            venv\\Scripts\\python.exe -m coverage combine .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
+                            venv\\Scripts\\python.exe -m coverage combine .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
                             venv\\Scripts\\python.exe -m coverage xml --include=ingenialink/*
                         '''
                         publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,17 @@ pipeline {
                         """
                     }
                 }
+                stage('Run no-connection tests') {
+                    steps {
+                        bat '''
+                            cd C:\\Users\\ContainerAdministrator\\ingenialink-python
+                            venv\\Scripts\\python.exe -m coverage run -m pytest tests --junitxml=pytest_no_connection_report.xml
+                            move .coverage .coverage_no_connection
+                            exit /b 0
+                        '''
+                        junit 'pytest_no_connection_report.xml'
+                    }
+                }
                 stage('Archive') {
                     steps {
                         bat """
@@ -109,6 +120,8 @@ pipeline {
                             XCOPY dist ${env.WORKSPACE}\\dist /i
                             XCOPY docs.zip ${env.WORKSPACE}
                         """
+                        stash includes: '.coverage_no_connection', name: 'coverage_no_connection'
+                        archiveArtifacts artifacts: 'pytest_no_connection_report.xml'
                         archiveArtifacts artifacts: "dist\\*, docs.zip"
                     }
                 }
@@ -160,19 +173,9 @@ pipeline {
                         junit 'pytest_ethercat_report.xml'
                     }
                 }
-                stage('Run no-connection tests') {
-                    steps {
-                        bat '''
-                            venv\\Scripts\\python.exe -m coverage run -m pytest tests --junitxml=pytest_no_connection_report.xml
-                            move .coverage .coverage_no_connection
-                            exit /b 0
-                        '''
-                        junit 'pytest_no_connection_report.xml'
-                    }
-                }
                 stage('Archive') {
                     steps {
-                        stash includes: '.coverage_no_connection, .coverage_ethercat', name: 'coverage_reports'
+                        stash includes: '.coverage_ethercat', name: 'coverage_ethercat'
                         archiveArtifacts artifacts: '*.xml'
                     }
                 }
@@ -236,7 +239,8 @@ pipeline {
                 }
                 stage('Save test results') {
                     steps {
-                        unstash 'coverage_reports'
+                        unstash 'coverage_no_connection'
+                        unstash 'coverage_ethercat'
                         bat '''
                             venv\\Scripts\\python.exe -m coverage combine .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
                             venv\\Scripts\\python.exe -m coverage xml --include=ingenialink/*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,6 +104,7 @@ pipeline {
                 stage('Run docker tests') {
                     steps {
                         bat """
+                            cd C:\\Users\\ContainerAdministrator\\ingenialink-python
                             venv\\Scripts\\python.exe -m coverage run -m pytest tests -m docker --junitxml=pytest_docker_report.xml
                             move .coverage ${env.WORKSPACE}\\.coverage_docker
                             move pytest_docker_report.xml ${env.WORKSPACE}\\pytest_docker_report.xml

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -12,7 +12,9 @@ import ingenialogger
 
 try:
     import pysoem  # type: ignore
-except ImportError:
+except ImportError as e:
+    if isinstance(e, ModuleNotFoundError):
+        raise e
     pysoem = None
 
 from ingenialink.network import Network, NET_PROT, NET_STATE, NET_DEV_EVT
@@ -29,6 +31,9 @@ class NetStatusListener(Thread):
 
     Args:
         network: Network instance of the EtherCAT communication.
+
+    Raises:
+        ImportError: WinPcap is not installed
 
     """
 

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -12,10 +12,9 @@ import ingenialogger
 
 try:
     import pysoem  # type: ignore
-except ImportError as e:
-    if isinstance(e, ModuleNotFoundError):
-        raise e
+except ImportError as ex:
     pysoem = None
+    pysoem_import_error = ex
 
 from ingenialink.network import Network, NET_PROT, NET_STATE, NET_DEV_EVT
 from ingenialink.exceptions import ILFirmwareLoadError, ILError
@@ -86,7 +85,7 @@ class EthercatNetwork(Network):
         self, interface_name: str, connection_timeout: float = DEFAULT_ECAT_CONNECTION_TIMEOUT
     ):
         if not pysoem:
-            raise ImportError("DLLs required not found: Please install WinPcap and restart")
+            raise pysoem_import_error
         super(EthercatNetwork, self).__init__()
         self.interface_name: str = interface_name
         self.servos: List[EthercatServo] = []

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -31,9 +31,6 @@ class NetStatusListener(Thread):
     Args:
         network: Network instance of the EtherCAT communication.
 
-    Raises:
-        ImportError: WinPcap is not installed
-
     """
 
     def __init__(self, network: "EthercatNetwork", refresh_time: float = 0.25):
@@ -68,6 +65,9 @@ class EthercatNetwork(Network):
     Args:
         interface_name: Interface name to be targeted.
         connection_timeout: Time in seconds of the connection timeout.
+
+    Raises:
+        ImportError: WinPcap is not installed
 
     """
 

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -9,7 +9,11 @@ from typing import Optional, Any, Callable, List, Dict
 from threading import Thread
 
 import ingenialogger
-import pysoem  # type: ignore
+
+try:
+    import pysoem  # type: ignore
+except ImportError:
+    pysoem = None
 
 from ingenialink.network import Network, NET_PROT, NET_STATE, NET_DEV_EVT
 from ingenialink.exceptions import ILFirmwareLoadError, ILError
@@ -76,6 +80,8 @@ class EthercatNetwork(Network):
     def __init__(
         self, interface_name: str, connection_timeout: float = DEFAULT_ECAT_CONNECTION_TIMEOUT
     ):
+        if not pysoem:
+            raise ImportError("DLLs required not found: Please install WinPcap and restart")
         super(EthercatNetwork, self).__init__()
         self.interface_name: str = interface_name
         self.servos: List[EthercatServo] = []

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -4,7 +4,9 @@ import ingenialogger
 
 try:
     import pysoem  # type: ignore
-except ImportError:
+except ImportError as e:
+    if isinstance(e, ModuleNotFoundError):
+        raise e
     pysoem = None
 if TYPE_CHECKING:
     from pysoem import CdefSlave
@@ -28,6 +30,9 @@ class EthercatServo(Servo):
         dictionary_path: Path to the dictionary.
         servo_status_listener: Toggle the listener of the servo for
             its status, errors, faults, etc.
+
+    Raises:
+        ImportError: WinPcap is not installed
 
     """
 

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -4,10 +4,10 @@ import ingenialogger
 
 try:
     import pysoem  # type: ignore
-except ImportError as e:
-    if isinstance(e, ModuleNotFoundError):
-        raise e
+except ImportError as ex:
     pysoem = None
+    pysoem_import_error = ex
+
 if TYPE_CHECKING:
     from pysoem import CdefSlave
 
@@ -69,7 +69,7 @@ class EthercatServo(Servo):
         servo_status_listener: bool = False,
     ):
         if not pysoem:
-            raise ImportError("DLLs required not found: Please install WinPcap and restart")
+            raise pysoem_import_error
         self.__slave = slave
         self.slave_id = slave_id
         super(EthercatServo, self).__init__(slave_id, dictionary_path, servo_status_listener)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,4 @@ markers =
     ethercat: EtherCAT tests
     eoe: EtherCAT service tests
     canopen: CANopen tests
+    docker: Test executed in docker

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -5,13 +5,25 @@ from ingenialink.exceptions import ILFirmwareLoadError, ILError
 
 
 @pytest.mark.no_connection
+def test_raise_exception_if_not_winpcap():
+    try:
+        import pysoem
+
+        pytest.skip("WinPcap is installed")
+    except ImportError:
+        pass
+    with pytest.raises(ImportError):
+        EthercatNetwork("dummy_ifname")
+
+
+@pytest.mark.ethercat
 def test_load_firmware_file_not_found_error(read_config):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     with pytest.raises(FileNotFoundError):
         net.load_firmware(fw_file="ethercat.sfu")
 
 
-@pytest.mark.no_connection
+@pytest.mark.ethercat
 def test_load_firmware_no_slave_detected_error(mocker, read_config):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     mocker.patch("os.path.isfile", return_value=True)
@@ -22,7 +34,7 @@ def test_load_firmware_no_slave_detected_error(mocker, read_config):
         net.load_firmware(fw_file="dummy_file.lfu", slave_id=23)
 
 
-@pytest.mark.no_connection
+@pytest.mark.ethercat
 def test_wrong_interface_name_error(read_config):
     with pytest.raises(ConnectionError):
         net = EthercatNetwork("not existing ifname")
@@ -31,7 +43,7 @@ def test_wrong_interface_name_error(read_config):
         net.connect_to_slave(slave_id, dictionary)
 
 
-@pytest.mark.no_connection
+@pytest.mark.ethercat
 def test_load_firmware_not_implemented_error(mocker, read_config):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     mocker.patch("os.path.isfile", return_value=True)

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -4,11 +4,10 @@ from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.exceptions import ILFirmwareLoadError, ILError
 
 
-@pytest.mark.no_connection
+@pytest.mark.docker
 def test_raise_exception_if_not_winpcap():
     try:
         import pysoem
-
         pytest.skip("WinPcap is installed")
     except ImportError:
         pass

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -8,6 +8,7 @@ from ingenialink.exceptions import ILFirmwareLoadError, ILError
 def test_raise_exception_if_not_winpcap():
     try:
         import pysoem
+
         pytest.skip("WinPcap is installed")
     except ImportError:
         pass


### PR DESCRIPTION
### Description

If WinPcap is not installed, do not raise an exception on import, but on ethercat network init

Fixes # INGK-766

### Type of change

- [x] Add try-except on pysoem import in ethercat network and servo
- [x] Raise an exception on ethercat network and servo if pysoem couldn't be imported

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.