### PR TITLE
INGK-769 Add ethercat servo dictionary and register to doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.1.1]
+
+### Added
+- Missing EtherCAT protocol documentation.
+
 ## [7.1.0] - 2023-11-28
 
 ### Add

--- a/docs/api/protocols/ethercat.rst
+++ b/docs/api/protocols/ethercat.rst
@@ -6,3 +6,6 @@ EtherCAT API documentation
     :glob:
 
     ethercat/network
+    ethercat/servo
+    ethercat/dictionary
+    ethercat/register

--- a/docs/api/protocols/ethercat/dictionary.rst
+++ b/docs/api/protocols/ethercat/dictionary.rst
@@ -1,0 +1,8 @@
+==========
+Dictionary
+==========
+
+.. automodule:: ingenialink.ethercat.dictionary
+    :members:
+    :inherited-members:
+    :member-order: groupwise

--- a/docs/api/protocols/ethercat/register.rst
+++ b/docs/api/protocols/ethercat/register.rst
@@ -1,0 +1,8 @@
+=========
+Registers
+=========
+
+.. automodule:: ingenialink.ethercat.register
+    :members:
+    :inherited-members:
+    :member-order: groupwise

--- a/docs/api/protocols/ethercat/servo.rst
+++ b/docs/api/protocols/ethercat/servo.rst
@@ -1,0 +1,9 @@
+=======
+Servo
+=======
+
+.. automodule:: ingenialink.ethercat.servo
+    :members:
+    :noindex:
+    :inherited-members:
+    :member-order: groupwise


### PR DESCRIPTION
### Description

Add missing EtherCAT protocol documentation.

Fixes #INGK-769

### Type of change

- Add EtherCAT servo documentation
- Add EtherCAT dictionary documentation
- Add EtherCAT register documentation


### Tests
- Build docs and check that the missing documentation appears.

### Documentation

Please update the documentation.

- [X] Build documentation locally to verify changes.
- [X] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [X] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.