### PR TITLE
INGK-742 Emulate control loops in the virtual drive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Add
 - Motor enable and disable features in the virtual drive.
+- Emulate control loops in the virtual drive.
 
 
 ## [7.1.0] - 2023-11-28

--- a/ingenialink/virtual/virtual_drive.py
+++ b/ingenialink/virtual/virtual_drive.py
@@ -253,7 +253,7 @@ class BaseClosedLoopPlant(BasePlant):
         super().emulate_plant(from_disturbance=from_disturbance)
         self.__obtain_command_signal()
 
-    def __obtain_command_signal(self):
+    def __obtain_command_signal(self) -> None:
         """Obtain command signal from the output by applying the inverse of the open-loop plant."""
         if not (
             self.TUNING_OPERATION_MODE is not None

--- a/ingenialink/virtual/virtual_drive.py
+++ b/ingenialink/virtual/virtual_drive.py
@@ -630,7 +630,6 @@ class VirtualMonitoring(VirtualMonDistBase):
         self.update_data()
 
     def update_data(self) -> None:
-
         self.__create_signals()
 
         # Store data
@@ -1065,12 +1064,14 @@ class VirtualDrive(Thread):
             message: Received or sent message.
             msg_type: Sent or Received.
         """
-        self.__logger.append({
-            "timestamp": time.time(),
-            "ip_port": ip_port,
-            "type": msg_type.value,
-            "message": message,
-        })
+        self.__logger.append(
+            {
+                "timestamp": time.time(),
+                "ip_port": ip_port,
+                "type": msg_type.value,
+                "message": message,
+            }
+        )
 
     @property
     def log(self) -> List[Dict[str, Union[float, bytes, str, Tuple[str, int]]]]:

--- a/ingenialink/virtual/virtual_drive.py
+++ b/ingenialink/virtual/virtual_drive.py
@@ -588,6 +588,16 @@ class VirtualMonDistBase:
             self.bytes_per_block += size
 
     def get_channel_index(self, reg_id: str) -> Optional[int]:
+        """Return the channel index of a mapped register.
+
+        If the register is not mapped returns None.
+
+        Args:
+            reg_id: Register ID.
+
+        Returns:
+            Channel index. None if the register is not mapped.
+        """
         channel_index = None
         for channel in range(self.number_mapped_registers):
             subnode, address, _, _ = self.get_mapped_register(channel)

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,3 +23,9 @@ ignore_missing_imports = True
 
 [mypy-pysoem.*]
 ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-scipy.*]
+ignore_missing_imports = True

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,4 +3,5 @@ python-can==3.3.4
 ingenialogger>=0.2.1
 ping3==4.0.3
 pysoem==1.0.7
+numpy==1.19.5
 scipy==1.5.4

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,3 +3,4 @@ python-can==3.3.4
 ingenialogger>=0.2.1
 ping3==4.0.3
 pysoem==1.0.7
+scipy==1.5.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,11 @@
 import json
+
 import pytest
 
-from ingenialink.canopen.network import CanopenNetwork, CAN_DEVICE, CAN_BAUDRATE
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.virtual.virtual_drive import VirtualDrive
-from ingenialink.eoe.network import EoENetwork
 
 ALLOW_PROTOCOLS = ["no_connection", "ethernet", "ethercat", "canopen", "eoe"]
 
@@ -97,10 +98,13 @@ def connect_to_slave(pytestconfig, read_config):
 
 
 @pytest.fixture()
-def virtual_drive():
+def virtual_drive(read_config):
     test_ip = "127.0.0.1"
     test_port = 81
     server = VirtualDrive(test_ip, test_port, dictionary_path="./tests/resources/virtual_drive.xdf")
     server.start()
-    yield server
+    net = EthernetNetwork()
+    protocol_contents = read_config["ethernet"]
+    virtual_servo = net.connect_to_slave(server.ip, protocol_contents["dictionary"], server.port)
+    yield server, virtual_servo
     server.stop()

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -1,10 +1,10 @@
-import time
 import socket
+import time
 
 import pytest
 
-from ingenialink.ethernet.network import EthernetNetwork, NET_PROT, NET_STATE, NET_DEV_EVT
-from ingenialink.exceptions import ILFirmwareLoadError, ILError
+from ingenialink.ethernet.network import NET_DEV_EVT, NET_PROT, NET_STATE, EthernetNetwork
+from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 
 @pytest.fixture()
@@ -99,7 +99,7 @@ def test_load_firmware_error_during_loading():
 
 @pytest.mark.no_connection
 def test_net_status_listener_connection(virtual_drive, read_config):
-    server = virtual_drive
+    server, _ = virtual_drive
     net = EthernetNetwork()
     protocol_contents = read_config["ethernet"]
     status_list = []
@@ -126,7 +126,7 @@ def test_net_status_listener_disconnection():
 
 @pytest.mark.no_connection
 def test_unsubscribe_from_status(virtual_drive, read_config):
-    server = virtual_drive
+    server, _ = virtual_drive
     net = EthernetNetwork()
     protocol_contents = read_config["ethernet"]
 


### PR DESCRIPTION
## Emulate control loops

### Description

This PR adds emulators of the open-loop and closed-loop plants.

Fixes # INGK-742

### Type of change

- [x] Add classes that emulate the plants.

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tunes, jogs and wizards from ML3. 
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.