### PR TITLE
INGK-713 Fix errors with Python 3.9-3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Add
 - Motor enable and disable features in the virtual drive.
 - Emulate control loops in the virtual drive.
+- Support to Python 3.9 to 3.12.
 
+### Deprecated
+- Support to Python 3.6 to 3.8.
 
 ## [7.1.1] - 2024-01-03
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ def LIB_FOE_APP_PATH = "ingenialink\\bin\\FOE"
 def FOE_APP_NAME = "FoEUpdateFirmware.exe"
 def FOE_APP_VERSION = ""
 
-def PYTHON_VERSIONS = "py38,py39"
+def PYTHON_VERSIONS = "py39,py310,py311,py312"
 def TOX_VERSION = "4.12.1"
 
 pipeline {

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ ingenialink-python is a Python library for simple motion control tasks and commu
 Requirements
 ------------
 
-* Python 3.8 or higher
+* Python 3.9 or higher
 * WinPcap_ 4.1.3
 
 .. _WinPcap: https://www.winpcap.org/install/

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,13 @@ setuptools.setup(
         "Topic :: Software Development :: Libraries",
     ],
     install_requires=[
-        "canopen==1.2.1",
-        "python-can==3.3.4",
+        "canopen==2.2.0",
+        "python-can==4.3.1",
         "ingenialogger>=0.2.1",
         "ping3==4.0.3",
-        "pysoem==1.0.7",
-        "numpy==1.19.5",
-        "scipy==1.5.4",
+        "pysoem==1.1.5",
+        "numpy==1.26.3",
+        "scipy==1.12.0",
     ],
     extras_require={
         "dev": ["tox==4.12.1"],

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ setuptools.setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "Topic :: Communications",
         "Topic :: Software Development :: Libraries",
     ],
@@ -47,4 +51,5 @@ setuptools.setup(
     extras_require={
         "dev": ["tox==4.12.1"],
     },
+    python_requires=">=3.9",
 )

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ deps =
     sphinxcontrib-jsmath==1.0.1
     nbsphinx==0.8.6
     m2r2==0.3.2
-    jinja2==3.1.3
+    jinja2==3.0.3
 commands =
     python -m sphinx -b html {posargs:docs _docs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox>=4
-env_list = build, firmware, docs, format, type, py{36,37,38,39,310,312}
+env_list = build, firmware, docs, format, type, py{39,310,311,312}
 
 [testenv]
 description = run unit tests
@@ -9,7 +9,7 @@ deps =
     pytest==7.0.1
     pytest-cov==2.12.1
     pytest-mock==3.6.1
-    pytest-console-scripts==1.3.1
+    pytest-console-scripts==1.4.1
 commands =
     python -m coverage run -m pytest {posargs:tests}
 

--- a/tox.ini
+++ b/tox.ini
@@ -51,14 +51,14 @@ deps =
     sphinxcontrib-jsmath==1.0.1
     nbsphinx==0.8.6
     m2r2==0.3.2
-    jinja2==3.0.3
+    jinja2==3.1.3
 commands =
     python -m sphinx -b html {posargs:docs _docs}
 
 [testenv:build]
 description = build wheels
 deps =
-    wheel==0.37.1
+    wheel==0.42.0
 commands =
     python setup.py {posargs:build sdist bdist_wheel}
 


### PR DESCRIPTION
## Fix errors with Python 3.9-3.12

This PR fixes the requirements for Python 3.9 to 3.12. 

### Description

Fixes # INGK-713

### Type of change

- [x] Fix requirements to work with Python 3.9 to 3.12.
- [x] Older versions of Python are not supported.
- [x] Test Pythons 3.9 to 3.12 in Jenkins.


### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.