### PR TITLE
INGK-809 Allow any value when writing an enum registe in the virtual drive

### DIFF
--- a/tests/test_virtual_drive.py
+++ b/tests/test_virtual_drive.py
@@ -68,7 +68,7 @@ def test_virtual_drive_write_wrong_enum(virtual_drive):
     virtual_servo.write(register, 1, subnode)
     assert virtual_servo.read(register, subnode) == 1
     virtual_servo.write(register, 5, subnode)
-    assert virtual_servo.read(register, subnode) == 1
+    assert virtual_servo.read(register, subnode) == 5
 
 
 @pytest.mark.ethernet

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1610,14 +1610,6 @@ class VirtualDrive(Thread):
             value: Value to be set.
         """
         register = self.__dictionary.registers(subnode)[id]
-        if register.enums_count > 0:
-            value_in_enum_keys = False
-            for enum in register.enums:
-                if enum["value"] == value:
-                    value_in_enum_keys = True
-                    break
-            if not value_in_enum_keys:
-                return
         self.__dictionary.registers(subnode)[id].storage = value
 
     def get_register(

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1609,7 +1609,6 @@ class VirtualDrive(Thread):
             id: Register ID.
             value: Value to be set.
         """
-        register = self.__dictionary.registers(subnode)[id]
         self.__dictionary.registers(subnode)[id].storage = value
 
     def get_register(


### PR DESCRIPTION
## Allow any value when writing an enum registe in the virtual drive

### Description

This PR allows to write any value in enum register in the virtual drive.

Fixes # INGK-809 

### Type of change

- [x] Allow to write any value in enum register in the virtual drive.

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.