### PR TITLE
INGK-810 Automatically reset the PCAN bus if the bus-off state is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Deprecated
 - Support to Python 3.6 to 3.8.
 
+### Changed
+- The PCAN transceiver bus is automatically reset when the bus-off state is reached.
+
 ## [7.1.1] - 2024-01-03
 
 ### Added

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -307,11 +307,15 @@ class CanopenNetwork(Network):
         with all the network attributes already specified."""
         if self._connection is None:
             self._connection = canopen.Network()
-
+            connection_args = {
+                "bustype": self.__device,
+                "channel": self.__channel,
+                "bitrate": self.__baudrate,
+            }
+            if self.__device == CAN_DEVICE.PCAN.value:
+                connection_args["auto_reset"] = True
             try:
-                self._connection.connect(
-                    bustype=self.__device, channel=self.__channel, bitrate=self.__baudrate
-                )
+                self._connection.connect(**connection_args)
             except CanError as e:
                 logger.error("Transceiver not found in network. Exception: %s", e)
                 raise ILError(


### PR DESCRIPTION
### Description

Automatically reset the PCAN bus if the bus-off state is reached.

Fixes # (issue)

### Type of change

- Add the `auto_reset` parameter when using a PCAN transceiver.


### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.