### PR TITLE
INGK-798 Store parameters and restore parameters always raises an exception when subnode is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Emulate control loops in the virtual drive.
 - Support to Python 3.9 to 3.12.
 - EtherCAT PDO module.
+- Store and restore functionalities for subnode 0.
 
 ### Deprecated
 - Support to Python 3.6 to 3.8.

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -14,6 +14,7 @@ from ingenialink.constants import (
     MONITORING_BUFFER_SIZE,
     PASSWORD_RESTORE_ALL,
     PASSWORD_STORE_ALL,
+    PASSWORD_STORE_RESTORE_SUB_0,
 )
 from ingenialink.dictionary import Dictionary
 from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
@@ -336,7 +337,7 @@ class Servo:
             logger.info("Restore all successfully done.")
         elif subnode == 0:
             # Restore subnode 0
-            raise ILError("The current firmware version does not have this feature implemented.")
+            self.write(reg=self.RESTORE_COCO_ALL, data=PASSWORD_STORE_RESTORE_SUB_0, subnode=0)
         elif subnode > 0:
             # Restore axis
             self.write(
@@ -344,7 +345,10 @@ class Servo:
             )
             logger.info(f"Restore subnode {subnode} successfully done.")
         else:
-            raise ILError("Invalid subnode {subnode}.")
+            raise ILError(
+                f"The drive's configuration cannot be restored. The subnode value: {subnode} is"
+                " invalid."
+            )
         time.sleep(1.5)
 
     def store_parameters(self, subnode: Optional[int] = None) -> None:
@@ -379,9 +383,7 @@ class Servo:
                         logger.info(f"Store axis {dict_subnode} successfully done.")
             elif subnode == 0:
                 # Store subnode 0
-                raise ILError(
-                    "The current firmware version does not have this feature implemented."
-                )
+                self.write(reg=self.STORE_COCO_ALL, data=PASSWORD_STORE_RESTORE_SUB_0, subnode=0)
             elif subnode > 0:
                 # Store axis
                 self.write(
@@ -389,7 +391,10 @@ class Servo:
                 )
                 logger.info(f"Store axis {subnode} successfully done.")
             else:
-                raise ILError("Invalid subnode.")
+                raise ILError(
+                    f"The drive's configuration cannot be stored. The subnode value: {subnode} is"
+                    " invalid."
+                )
         finally:
             time.sleep(1.5)
 


### PR DESCRIPTION
### Description

Add the possibility to store and restore exclusively subnode 0 values.

Fixes #INGK-798

### Type of change

- Store subnode 0 values.
- Restore subnode 0 values.

### Tests
**Test 1**
- Set custom values for registers COMMS_CYCLE_TIMEOUT and DRV_PROT_USER_OVER_VOLT.
- Only store the subnode 0 values.
- Perform a power cycle.
- Check that only the COMMS_CYCLE_TIMEOUT value is maintained.

**Test 2**
- Set custom values for registers COMMS_CYCLE_TIMEOUT and DRV_PROT_USER_OVER_VOLT.
- Store all register values.
- Perform a power cycle.
- Only restore the subnode 0 values.
- Perform a power cycle.
- Check that only the DRV_PROT_USER_OVER_VOLT value is maintained.


### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.