### PR TITLE
Ingk 765 parse wrong work count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Store and restore functionalities for subnode 0.
 - Add functionalities to update ECAT state machine
 
+### Fixed
+- Raise exception when ECAT SDO write/read is wrong
+
 ### Deprecated
 - Support to Python 3.6 to 3.8.
 

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from ingenialink.constants import CAN_MAX_WRITE_SIZE, CANOPEN_ADDRESS_OFFSET, MAP_ADDRESS_OFFSET
 from ingenialink.ethercat.dictionary import EthercatDictionary
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.exceptions import ILIOError
+from ingenialink.exceptions import ILIOError, ILTimeoutError
 from ingenialink.pdo import PDOServo, RPDOMap, TPDOMap
 from ingenialink.register import REG_ACCESS, REG_DTYPE
 
@@ -39,7 +39,9 @@ class EthercatServo(PDOServo):
 
     DICTIONARY_CLASS = EthercatDictionary
     MAX_WRITE_SIZE = CAN_MAX_WRITE_SIZE
-    WRONG_WORKING_COUNTER = -1
+
+    TIMEOUT_WORKING_COUNTER = -5
+    NOFRAME_WORKING_COUNTER = 0
 
     MONITORING_DATA = EthercatRegister(
         identifier="MONITORING_DATA",
@@ -166,9 +168,14 @@ class EthercatServo(PDOServo):
         self._lock.acquire()
         try:
             value: bytes = self.__slave.sdo_read(reg.idx, reg.subidx, buffer_size, complete_access)
-            self._check_working_counter()
         except (pysoem.SdoError, pysoem.MailboxError, pysoem.PacketError, ILIOError) as e:
             raise ILIOError(f"Error reading {reg.identifier}. Reason: {e}") from e
+        except pysoem.WkcError as e:
+            if e.wkc == self.NOFRAME_WORKING_COUNTER:
+                raise ILIOError("Error reading data: No frame.") from e
+            if e.wkc == self.TIMEOUT_WORKING_COUNTER:
+                raise ILTimeoutError("Timeout reading data.") from e
+            raise ILIOError("Error reading data") from e
         except pysoem.Emergency as e:
             error_description = self._get_emergency_description(e.error_code)
             if error_description is None:
@@ -182,9 +189,14 @@ class EthercatServo(PDOServo):
         self._lock.acquire()
         try:
             self.__slave.sdo_write(reg.idx, reg.subidx, data, complete_access)
-            self._check_working_counter()
         except (pysoem.SdoError, pysoem.MailboxError, pysoem.PacketError, ILIOError) as e:
             raise ILIOError(f"Error writing {reg.identifier}. Reason: {e}") from e
+        except pysoem.WkcError as e:
+            if e.wkc == self.NOFRAME_WORKING_COUNTER:
+                raise ILIOError("Error writing data: No frame.") from e
+            if e.wkc == self.TIMEOUT_WORKING_COUNTER:
+                raise ILTimeoutError("Timeout writing data.") from e
+            raise ILIOError("Error writing data") from e
         except pysoem.Emergency as e:
             error_description = self._get_emergency_description(e.error_code)
             if error_description is None:
@@ -232,16 +244,6 @@ class EthercatServo(PDOServo):
             subnode, ipb_address, dtype, size
         )
         return mapped_address
-
-    def _check_working_counter(self) -> None:
-        """Check if the slave responds with a correct working counter.
-
-        Raises:
-            ILIOError: If the received working counter is incorrect.
-
-        """
-        if self.__slave.mbx_receive() == self.WRONG_WORKING_COUNTER:
-            raise ILIOError("Wrong working counter")
 
     def _get_emergency_description(self, error_code: int) -> Optional[str]:
         """Get the error description from the error code.

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1006,6 +1006,7 @@ class Servo:
         Raises:
             ILAccessError: Wrong access to the register.
             ILIOError: Error writing the register.
+            ILTimeoutError: Write timeout.
 
         """
         _reg = self._get_reg(reg, subnode)
@@ -1031,6 +1032,7 @@ class Servo:
         Raises:
             ILAccessError: Wrong access to the register.
             ILIOError: Error reading the register.
+            ILTimeoutError: Read timeout.
 
         """
         _reg = self._get_reg(reg, subnode)

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
         "python-can==4.3.1",
         "ingenialogger>=0.2.1",
         "ping3==4.0.3",
-        "pysoem==1.1.5",
+        "pysoem==1.1.6",
         "numpy==1.26.3",
         "scipy==1.12.0",
     ],


### PR DESCRIPTION
### Description

Clean ECAT _write_raw and _read_raw functions and update PySOEM library

Fixes # INGK-765

### Type of change

Please add a description and delete options that are not relevant.

- [x] Clean ECAT _write_raw and _read_raw functions
- [x] Update PySOEM library to 1.1.6

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.