### PR TITLE
INGK-787 Use dict to represent enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Changed
 - The PCAN transceiver bus is automatically reset when the bus-off state is reached.
+- The enums are represented using dicts in the Register class.
 
 ## [7.1.1] - 2024-01-03
 

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -1,7 +1,7 @@
-from typing import Optional, Any, Union, Tuple, Dict, List
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
 from ingenialink.register import Register
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 
 class CanopenRegister(Register):
@@ -49,7 +49,7 @@ class CanopenRegister(Register):
             Tuple[None, None], Tuple[int, int], Tuple[float, float], Tuple[str, str]
         ] = (None, None),
         labels: Optional[Dict[str, str]] = None,
-        enums: Optional[List[Dict[str, Union[str, int]]]] = None,
+        enums: Optional[Dict[int, str]] = None,
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1,14 +1,13 @@
-from typing import List, Dict, Optional, Union, Tuple
-from abc import ABC, abstractmethod
-
 import xml.etree.ElementTree as ET
+from abc import ABC, abstractmethod
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import ingenialogger
 
-from ingenialink.constants import SINGLE_AXIS_MINIMUM_SUBNODES
-from ingenialink.register import Register, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
 from ingenialink import exceptions as exc
+from ingenialink.constants import SINGLE_AXIS_MINIMUM_SUBNODES
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -363,13 +362,7 @@ class Dictionary(ABC):
 
             # Enumerations
             enums_elem = register.findall(self.DICT_ENUMERATIONS_ENUMERATION)
-            enums = []
-            for enum in enums_elem:
-                dictionary: Dict[str, Union[str, int]] = {
-                    "label": str(enum.text),
-                    "value": int(enum.attrib["value"]),
-                }
-                enums.append(dictionary)
+            enums = {int(enum.attrib["value"]): str(enum.text) for enum in enums_elem}
 
             current_read_register = Register(
                 dtype,

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -1,7 +1,7 @@
-from typing import Optional, Union, Tuple, Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple, Union
 
+from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
 from ingenialink.register import Register
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
 
 
 class EthernetRegister(Register):
@@ -49,7 +49,7 @@ class EthernetRegister(Register):
             Tuple[None, None], Tuple[int, int], Tuple[float, float], Tuple[str, str]
         ] = (None, None),
         labels: Optional[Dict[str, str]] = None,
-        enums: Optional[List[Dict[str, Union[str, int]]]] = None,
+        enums: Optional[Dict[int, str]] = None,
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -1,8 +1,8 @@
 from abc import ABC
-from typing import Optional, Any, Tuple, Union, Dict, List
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ingenialink import exceptions as exc
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
+from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
 
 # CANOPEN DTYPES
 IL_REG_DTYPE_DOMAIN = 15
@@ -61,7 +61,7 @@ class Register(ABC):
             Tuple[None, None], Tuple[int, int], Tuple[float, float], Tuple[str, str]
         ] = (None, None),
         labels: Optional[Dict[str, str]] = None,
-        enums: Optional[List[Dict[str, Union[str, int]]]] = None,
+        enums: Optional[Dict[int, str]] = None,
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
@@ -70,7 +70,7 @@ class Register(ABC):
         if labels is None:
             labels = {}
         if enums is None:
-            enums = []
+            enums = {}
 
         self.__type_errors(dtype, access, phy)
 
@@ -84,7 +84,6 @@ class Register(ABC):
         self._storage = storage
         self._range = (None, None) if not reg_range else reg_range
         self._labels = labels
-        self._enums_count = len(enums)
         self._cat_id = cat_id
         self._scat_id = scat_id
         self._internal_use = internal_use
@@ -212,14 +211,14 @@ class Register(ABC):
         return self._labels
 
     @property
-    def enums(self) -> List[Dict[str, Union[str, int]]]:
+    def enums(self) -> Dict[int, str]:
         """Containing all the enums for the register."""
         return self._enums
 
     @property
     def enums_count(self) -> int:
         """The number of the enums in the register."""
-        return self._enums_count
+        return len(self._enums)
 
     @property
     def cat_id(self) -> Optional[str]:

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -2,11 +2,11 @@ import pytest
 
 from ingenialink.canopen.dictionary import CanopenDictionary
 from ingenialink.canopen.register import (
-    CanopenRegister,
-    REG_DTYPE,
     REG_ACCESS,
-    REG_PHY,
     REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    CanopenRegister,
 )
 
 
@@ -26,7 +26,7 @@ def test_getters_canopen_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": [{"TRIGGER_EVENT_AUTO": 0}, {"TRIGGER_EVENT_FORCED", 1}],
+        "enums": {0: "TRIGGER_EVENT_AUTO", 1: "TRIGGER_EVENT_FORCED"},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
 
 
 @pytest.mark.no_connection
@@ -20,7 +20,7 @@ def test_getters_ethercat_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": [{"TRIGGER_EVENT_AUTO": 0}, {"TRIGGER_EVENT_FORCED", 1}],
+        "enums": {0: "TRIGGER_EVENT_AUTO", 1: "TRIGGER_EVENT_FORCED"},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, REG_ADDRESS_TYPE, dtypes_ranges
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY, dtypes_ranges
 
 
 @pytest.mark.no_connection
@@ -19,7 +19,7 @@ def test_getters_ethernet_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": [{"TRIGGER_EVENT_AUTO": 0}, {"TRIGGER_EVENT_FORCED", 1}],
+        "enums": {0: "TRIGGER_EVENT_AUTO", 1: "TRIGGER_EVENT_FORCED"},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,10 +1,9 @@
 import pytest
 
-from ingenialink.register import Register
-from ingenialink.register import REG_DTYPE, REG_ACCESS, REG_PHY, dtypes_ranges
-from ingenialink.exceptions import ILValueError, ILAccessError
-from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.canopen.register import CanopenRegister
+from ingenialink.ethernet.register import EthernetRegister
+from ingenialink.exceptions import ILAccessError, ILValueError
+from ingenialink.register import REG_ACCESS, REG_DTYPE, REG_PHY, Register, dtypes_ranges
 
 
 @pytest.mark.no_connection
@@ -20,7 +19,7 @@ def test_getters_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": [{"TRIGGER_EVENT_AUTO": 0}, {"TRIGGER_EVENT_FORCED", 1}],
+        "enums": {0: "TRIGGER_EVENT_AUTO", 1: "TRIGGER_EVENT_FORCED"},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": 1,

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -69,7 +69,7 @@ def test_connect_virtual_custom_dictionaries(connect_virtual_drive, read_config)
         for reg_key, register in servo.dictionary.registers(1).items():
             if register.access in [REG_ACCESS.RO, REG_ACCESS.RW]:
                 value = servo.read(reg_key)
-                assert pytest.approx(server.get_value_by_id(1, reg_key), abs=0.01) == value
+                assert pytest.approx(server.get_value_by_id(1, reg_key), abs=0.02) == value
 
             if register.access in [REG_ACCESS.WO, REG_ACCESS.RW]:
                 if register.enums_count > 0:

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -35,7 +35,7 @@ def connect_virtual_drive():
     return connect
 
 
-@pytest.mark.virtual
+@pytest.mark.no_connection
 def test_connect_to_virtual_drive(connect_virtual_drive):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
     connect = connect_virtual_drive
@@ -46,7 +46,7 @@ def test_connect_to_virtual_drive(connect_virtual_drive):
     assert fw_version is not None and fw_version != ""
 
 
-@pytest.mark.virtual
+@pytest.mark.no_connection
 def test_virtual_drive_disconnection(connect_virtual_drive):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
     servo, net = connect_virtual_drive(dictionary)
@@ -56,7 +56,7 @@ def test_virtual_drive_disconnection(connect_virtual_drive):
     assert servo.socket._closed
 
 
-@pytest.mark.virtual
+@pytest.mark.no_connection
 def test_connect_virtual_custom_dictionaries(connect_virtual_drive, read_config):
     config = read_config
     for protocol in ["ethernet", "canopen"]:

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1368,7 +1368,7 @@ class VirtualDrive(Thread):
                 if reg._storage is not None:
                     continue
                 elif reg.enums_count > 0:
-                    value = reg.enums[0]["value"]
+                    value = list(reg.enums.keys())[0]
                 elif reg.dtype == REG_DTYPE.STR:
                     value = ""
                 else:


### PR DESCRIPTION
## Use dict to represent enums

This PR changes how the enums are represented in the Register class.

### Description

Please include a summary of the change and which issue is fixed. 

Fixes # INGK-787

### Type of change

- [x] Use dicts to represent enums.

### Tests
- [x] Update tests.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.