### PR TITLE
INGK-825 Raise generic exception if firmware loading process fails

### DIFF
--- a/tests/resources/Scripts/load_FWs.py
+++ b/tests/resources/Scripts/load_FWs.py
@@ -113,7 +113,10 @@ def load_can(drive_conf):
 
 def load_ecat(drive_conf):
     net = EthercatNetwork(drive_conf["ifname"])
-    net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
+    try:
+        net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
+    except ILError as e:
+        raise Exception(f"Could not load the firmware: {e}") from e
     logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
 
 

--- a/tests/resources/Scripts/load_FWs.py
+++ b/tests/resources/Scripts/load_FWs.py
@@ -113,10 +113,7 @@ def load_can(drive_conf):
 
 def load_ecat(drive_conf):
     net = EthercatNetwork(drive_conf["ifname"])
-    try:
-        net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
-    except ILError as e:
-        raise Exception(f"Could not load the firmware: {e}") from e
+    net.load_firmware(drive_conf["fw_file"], drive_conf["slave"])
     logger.info("FW updated. ifname: %s, slave: %d", drive_conf["ifname"], drive_conf["slave"])
 
 
@@ -172,10 +169,7 @@ def load_eth(drive_conf):
         logger.warning(
             f"Drive does not respond ({e}). It may already be in boot mode.", drive=drive_conf["ip"]
         )
-    try:
-        net.load_firmware(drive_conf["fw_file"], drive_conf["ip"], "Ingenia", "Ingenia")
-    except ILError as e:
-        raise Exception(f"Could not load the firmware: {e}")
+    net.load_firmware(drive_conf["fw_file"], drive_conf["ip"], "Ingenia", "Ingenia")
     detected = ping_check(drive_conf["ip"])
     if not detected:
         logger.info("FW not updated. IP: %s", drive_conf["ip"])
@@ -187,16 +181,12 @@ def main(comm, config):
     servo_list = config[comm]
     for index, servo_conf in enumerate(servo_list):
         logger.info("Upload FW comm %s, index: %d", comm, index)
-        try:
-            if comm == "canopen":
-                load_can(servo_conf)
-            if comm == "ethercat":
-                load_ecat(servo_conf)
-            if comm == "ethernet":
-                load_eth(servo_conf)
-        except ILError as e:
-            logger.exception(e)
-            logger.error("Error in FW update. comm %s, index: %d", comm, index)
+        if comm == "canopen":
+            load_can(servo_conf)
+        elif comm == "ethercat":
+            load_ecat(servo_conf)
+        else:
+            load_eth(servo_conf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

The Jenkins pipeline does not stop when the load FW stage fails.

Fixes # INGK-825

### Type of change

Please add a description and delete options that are not relevant.

- [x] Raise an exception if an error occurs while updating firmware.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [] Update docstrings of every function, method or class that change.
- [] Build documentation locally to verify changes.
- [] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.