### PR TITLE
INGK-835 Raise exception if unexpected working counter is received

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -253,8 +253,12 @@ class EthercatServo(PDOServo):
         elif isinstance(exception, pysoem.WkcError):
             if exception.wkc == self.NOFRAME_WORKING_COUNTER:
                 raise ILIOError(f"Error {operation_msg.value} data: No frame.") from exception
-            if exception.wkc == self.TIMEOUT_WORKING_COUNTER:
+            elif exception.wkc == self.TIMEOUT_WORKING_COUNTER:
                 raise ILTimeoutError(f"Timeout {operation_msg.value} data.") from exception
+            else:
+                raise ILIOError(
+                    f"Error {operation_msg.value} data. Wrong working counter: {exception.wkc}"
+                ) from exception
 
     def _monitoring_read_data(self) -> bytes:  # type: ignore [override]
         """Read monitoring data frame."""


### PR DESCRIPTION
### Description

If the working counter value is not expected (different than [NO_FRAME](https://github.com/ingeniamc/ingenialink-python/blob/develop/ingenialink/ethercat/servo.py#L54) and [TIMEOUT](https://github.com/ingeniamc/ingenialink-python/blob/develop/ingenialink/ethercat/servo.py#L53)), no exception is raised.

Fixes # INGK-835

### Type of change

- Raise exception if an unexpected working counter value is received

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.