### PR TITLE
INGK-823 Add scan_slaves_info method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Store and restore functionalities for subnode 0.
 - Add functionalities to update ECAT state machine
 - Add send_receive_processdata function
+- Add scan_slaves_info method
 
 ### Fixed
 - Raise exception when ECAT SDO write/read is wrong

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -251,6 +251,7 @@ class CanopenNetwork(Network):
             Ordered dict with the slave information.
 
         """
+        connected_slaves = {servo.target: servo.node for servo in self.servos}
         slave_info: OrderedDict[int, SlaveInfo] = OrderedDict()
         try:
             slaves = self.scan_slaves()
@@ -270,7 +271,10 @@ class CanopenNetwork(Network):
             return slave_info
 
         for slave_id in slaves:
-            node = self._connection.add_node(slave_id)
+            if slave_id not in connected_slaves:
+                node = self._connection.add_node(slave_id)
+            else:
+                node = connected_slaves[slave_id]
             product_code = convert_bytes_to_dtype(
                 node.sdo.upload(self.DRIVE_INFO_INDEX, self.PRODUCT_CODE_SUB_IX), REG_DTYPE.U32
             )

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -257,7 +257,9 @@ class CanopenNetwork(Network):
         except ILError:
             return slave_info
 
+        is_connection_created = False
         if self._connection is None:
+            is_connection_created = True
             try:
                 self._setup_connection()
             except ILError:
@@ -277,7 +279,8 @@ class CanopenNetwork(Network):
             )
             slave_info[slave_id] = SlaveInfo(int(product_code), int(revision_number))
 
-        self._teardown_connection()
+        if is_connection_created:
+            self._teardown_connection()
         return slave_info
 
     def connect_to_slave(  # type: ignore [override]

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -251,22 +251,22 @@ class CanopenNetwork(Network):
             Ordered dict with the slave information.
 
         """
+        slave_info = OrderedDict()
         try:
             slaves = self.scan_slaves()
         except ILError:
-            return OrderedDict()
+            return slave_info
 
         if self._connection is None:
             try:
                 self._setup_connection()
             except ILError:
                 self._teardown_connection()
-                return OrderedDict()
+                return slave_info
 
         if self._connection is None:
-            return OrderedDict()
+            return slave_info
 
-        slave_info = OrderedDict()
         for slave_id in slaves:
             node = self._connection.add_node(slave_id)
             product_code = convert_bytes_to_dtype(

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -251,7 +251,7 @@ class CanopenNetwork(Network):
             Ordered dict with the slave information.
 
         """
-        slave_info = OrderedDict()
+        slave_info: OrderedDict[int, SlaveInfo] = OrderedDict()
         try:
             slaves = self.scan_slaves()
         except ILError:

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -1,15 +1,17 @@
 import ipaddress
 import socket
 import time
+from collections import OrderedDict
 from enum import Enum
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 import ingenialogger
 
 from ingenialink import constants
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.ethernet.servo import EthernetServo
-from ingenialink.exceptions import ILTimeoutError, ILIOError, ILError
+from ingenialink.exceptions import ILError, ILIOError, ILTimeoutError
+from ingenialink.network import SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -190,6 +192,9 @@ class EoENetwork(EthernetNetwork):
                 "Failed to perform a network scan. Please verify the EoE service is running."
             ) from e
         return list(range(1, r + 1))
+
+    def scan_slaves_info(self) -> OrderedDict[int, SlaveInfo]:
+        raise NotImplementedError
 
     @staticmethod
     def _build_eoe_command_msg(cmd: int, data: Optional[bytes] = None) -> bytes:

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -135,11 +135,11 @@ class EthercatNetwork(Network):
             ILError: If any slave is already connected.
 
         """
+        slave_info = OrderedDict()
         try:
             slaves = self.scan_slaves()
         except ILError:
-            return OrderedDict()
-        slave_info = OrderedDict()
+            return slave_info
         for slave_id in slaves:
             slave = self._ecat_master.slaves[slave_id - 1]
             slave_info[slave_id] = SlaveInfo(slave.id, slave.rev)

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -140,7 +140,7 @@ class EthercatNetwork(Network):
             ILError: If any slave is already connected.
 
         """
-        slave_info = OrderedDict()
+        slave_info: OrderedDict[int, SlaveInfo] = OrderedDict()
         try:
             slaves = self.scan_slaves()
         except ILError:

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -1,21 +1,22 @@
 import ftplib
-import time
 import os
 import socket
-from threading import Thread
-from collections import defaultdict
+import time
+from collections import OrderedDict, defaultdict
 from ftplib import FTP
+from threading import Thread
 from time import sleep
-from typing import Callable, Any, Dict, List, Optional
-
-from .servo import EthernetServo
-from ingenialink.utils.udp import UDP
-from ..network import NET_PROT
-from ingenialink.network import Network, NET_STATE, NET_DEV_EVT
-from ingenialink.exceptions import ILFirmwareLoadError, ILError
-from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
+from typing import Any, Callable, Dict, List, Optional
 
 import ingenialogger
+
+from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
+from ingenialink.exceptions import ILError, ILFirmwareLoadError
+from ingenialink.network import NET_DEV_EVT, NET_STATE, Network, SlaveInfo
+from ingenialink.utils.udp import UDP
+
+from ..network import NET_PROT
+from .servo import EthernetServo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -196,6 +197,9 @@ class EthernetNetwork(Network):
             raise ILFirmwareLoadError("Error during bootloader process.")
 
     def scan_slaves(self) -> List[int]:
+        raise NotImplementedError
+
+    def scan_slaves_info(self) -> OrderedDict[int, SlaveInfo]:
         raise NotImplementedError
 
     def connect_to_slave(  # type: ignore [override]

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -1,6 +1,8 @@
-from enum import Enum
 from abc import ABC, abstractmethod
-from typing import List, Any, Callable, Union
+from collections import OrderedDict
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, List, Union
 
 import ingenialogger
 
@@ -48,6 +50,12 @@ class NET_TRANS_PROT(Enum):
     UDP = 2
 
 
+@dataclass
+class SlaveInfo:
+    product_code: int
+    revision_number: int
+
+
 class Network(ABC):
     """Declaration of a general Network object."""
 
@@ -57,6 +65,10 @@ class Network(ABC):
 
     @abstractmethod
     def scan_slaves(self) -> List[int]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def scan_slaves_info(self) -> OrderedDict[int, SlaveInfo]:
         raise NotImplementedError
 
     @abstractmethod

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -1,8 +1,8 @@
 import pytest
-
 from canopen import Network
 
-from ingenialink.canopen.network import CanopenNetwork, CAN_DEVICE, CAN_BAUDRATE, NET_STATE
+from ingenialink.canopen.dictionary import CanopenDictionary
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, NET_STATE, CanopenNetwork
 from ingenialink.exceptions import ILError
 
 test_bus = "virtual"
@@ -72,6 +72,24 @@ def test_scan_slaves(read_config):
 def test_scan_slaves_none_nodes(virtual_network):
     nodes = virtual_network.scan_slaves()
     assert len(nodes) == 0
+
+
+@pytest.mark.canopen
+def test_scan_slaves_info(read_config):
+    net = CanopenNetwork(
+        device=CAN_DEVICE(read_config["canopen"]["device"]),
+        channel=read_config["canopen"]["channel"],
+        baudrate=CAN_BAUDRATE(read_config["canopen"]["baudrate"]),
+    )
+    slaves_info = net.scan_slaves_info()
+    dictionary = CanopenDictionary(read_config["canopen"]["dictionary"])
+
+    assert len(slaves_info) > 0
+    assert read_config["canopen"]["node_id"] in slaves_info
+    assert slaves_info[read_config["canopen"]["node_id"]].product_code == dictionary.product_code
+    assert (
+        slaves_info[read_config["canopen"]["node_id"]].revision_number == dictionary.revision_number
+    )
 
 
 @pytest.mark.canopen

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -4,8 +4,9 @@ except ImportError:
     pass
 import pytest
 
+from ingenialink.ethercat.dictionary import EthercatDictionary
 from ingenialink.ethercat.network import EthercatNetwork
-from ingenialink.exceptions import ILFirmwareLoadError, ILError
+from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 
 @pytest.mark.docker
@@ -84,3 +85,17 @@ def test_scan_slaves_raises_exception_if_drive_is_already_connected(connect_to_s
     with pytest.raises(ILError):
         net.scan_slaves()
     assert servo.slave.state_check(pysoem.PREOP_STATE) == pysoem.PREOP_STATE
+
+
+@pytest.mark.ethercat
+def test_scan_slaves_info(read_config):
+    net = EthercatNetwork(read_config["ethercat"]["ifname"])
+    slaves_info = net.scan_slaves_info()
+    dictionary = EthercatDictionary(read_config["ethercat"]["dictionary"])
+
+    assert len(slaves_info) > 0
+    assert read_config["ethercat"]["slave"] in slaves_info
+    assert slaves_info[read_config["ethercat"]["slave"]].product_code == dictionary.product_code
+    assert (
+        slaves_info[read_config["ethercat"]["slave"]].revision_number == dictionary.revision_number
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,8 @@ commands = black --check {posargs:ingenialink tests}
 [testenv:type]
 description = run type checks
 skip_install = true
-base_python = py39
 deps =
+    types-dataclasses==0.6.6
     mypy==0.971
 commands =
     mypy {posargs:ingenialink virtual_drive}

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ commands = black --check {posargs:ingenialink tests}
 [testenv:type]
 description = run type checks
 skip_install = true
+base_python = py39
 deps =
     mypy==0.971
 commands =


### PR DESCRIPTION
## Add scan_slaves_info method

### Description

This PR adds the `scan_slaves_info` method that performs a scan and returns the product code and revision number of each drive.

Fixes # INGK-823

### Type of change

Please add a description and delete options that are not relevant.

- [x] Add `scan_slaves_info` method

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.