### PR TITLE
INGK-837 Don't reset PDO mapping when mapping PDOs

### DIFF
--- a/examples/ethercat/process_data_objects.py
+++ b/examples/ethercat/process_data_objects.py
@@ -110,6 +110,7 @@ class ProcessDataExample:
 
     def run(self) -> None:
         """Main loop of the program."""
+        self.net.config_pdo_maps()
         self.net.start_pdos()
         print("Process data started")
         proc_thread = threading.Thread(target=self._processdata_thread)

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -223,8 +223,19 @@ class EthercatNetwork(Network):
             self.__is_master_running = False
             self.__last_init_nodes = []
 
+    def config_pdo_maps(self) -> None:
+        """Configure the PDO maps.
+
+        It maps the PDO maps of each slave and sets its state to SafeOP.
+
+        """
+        if self._overlapping_io_map:
+            self._ecat_master.config_overlap_map()
+        else:
+            self._ecat_master.config_map()
+
     def start_pdos(self, timeout: float = 1.0) -> None:
-        """Configure the PDOs and set slave state to OP for all slaves with mapped PDOs
+        """Set all slaves with mapped PDOs to Operational State.
 
         Args:
             timeout: timeout in seconds to reach Op state, 1.0 seconds by default.
@@ -245,10 +256,6 @@ class EthercatNetwork(Network):
             raise ILError(
                 "The RPDO values should be set before starting the PDO exchange process."
             ) from e
-        if self._overlapping_io_map:
-            self._ecat_master.config_overlap_map()
-        else:
-            self._ecat_master.config_map()
         self._ecat_master.state = pysoem.SAFEOP_STATE
         if not self._change_nodes_state(op_servo_list, pysoem.SAFEOP_STATE):
             raise ILStateError("Drives can not reach SafeOp state")

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -199,6 +199,7 @@ class EthercatNetwork(Network):
         )
         if not self._change_nodes_state(servo, pysoem.PREOP_STATE):
             raise ILStateError("Slave can not reach PreOp state")
+        servo.reset_pdo_mapping()
         self.servos.append(servo)
         self._set_servo_state(slave_id, NET_STATE.CONNECTED)
         if net_status_listener:

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -328,10 +328,8 @@ class EthercatServo(PDOServo):
         return error_description
 
     def set_pdo_map_to_slave(self, rpdo_maps: List[RPDOMap], tpdo_maps: List[TPDOMap]) -> None:
-        self.reset_rpdo_mapping()
-        self.reset_tpdo_mapping()
-        self._rpdo_maps = rpdo_maps
-        self._tpdo_maps = tpdo_maps
+        self._rpdo_maps.extend(rpdo_maps)
+        self._tpdo_maps.extend(tpdo_maps)
         self.slave.config_func = self.map_pdos
 
     def process_pdo_inputs(self) -> None:

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -370,6 +370,7 @@ class PDOServo(Servo):
         servo_status_listener: bool = False,
     ):
         super().__init__(target, dictionary_path, servo_status_listener)
+        self.reset_pdo_mapping()
         self._rpdo_maps: List[RPDOMap] = []
         self._tpdo_maps: List[TPDOMap] = []
 

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -480,6 +480,55 @@ class PDOServo(Servo):
         self.map_tpdos()
         self.map_rpdos()
 
+    def reset_pdo_mapping(self) -> None:
+        """Reset the RPDO and TPDO mapping in the slave."""
+        self.reset_rpdo_mapping()
+        self.reset_tpdo_mapping()
+
+    def remove_rpdo_map(
+        self, rpdo_map: Optional[RPDOMap] = None, rpdo_map_index: Optional[int] = None
+    ) -> None:
+        """Remove a RPDOMap from the RPDOMap list.
+
+        Args:
+            rpdo_map: The RPDOMap instance to be removed.
+            rpdo_map_index: The index of the RPDOMap list to be removed.
+
+        Raises:
+            ValueError: If the RPDOMap instance is not in the RPDOMap list.
+            IndexError: If the index is out of range.
+
+        """
+        if rpdo_map_index is None and rpdo_map is None:
+            raise ValueError("The RPDOMap instance or the index should be provided.")
+        if rpdo_map is not None:
+            self._rpdo_maps.remove(rpdo_map)
+            return
+        if rpdo_map_index is not None:
+            self._rpdo_maps.pop(rpdo_map_index)
+
+    def remove_tpdo_map(
+        self, tpdo_map: Optional[TPDOMap] = None, tpdo_map_index: Optional[int] = None
+    ) -> None:
+        """Remove a TPDOMap from the TPDOMap list.
+
+        Args:
+            tpdo_map: The TPDOMap instance to be removed.
+            tpdo_map_index: The index of the TPDOMap list to be removed.
+
+        Raises:
+            ValueError: If the TPDOMap instance is not in the TPDOMap list.
+            IndexError: If the index is out of range.
+
+        """
+        if tpdo_map_index is None and tpdo_map is None:
+            raise ValueError("The TPDOMap instance or the index should be provided.")
+        if tpdo_map is not None:
+            self._tpdo_maps.remove(tpdo_map)
+            return
+        if tpdo_map_index is not None:
+            self._tpdo_maps.pop(tpdo_map_index)
+
     def set_pdo_map_to_slave(self, rpdo_maps: List[RPDOMap], tpdo_maps: List[TPDOMap]) -> None:
         """Callback called by the slave to configure the map.
 

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -370,7 +370,6 @@ class PDOServo(Servo):
         servo_status_listener: bool = False,
     ):
         super().__init__(target, dictionary_path, servo_status_listener)
-        self.reset_pdo_mapping()
         self._rpdo_maps: List[RPDOMap] = []
         self._tpdo_maps: List[TPDOMap] = []
 

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -299,6 +299,7 @@ def test_start_stop_pdo(connect_to_all_slave):
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
         net._ecat_master.read_state()
         assert servo.slave.state_check(pysoem.PREOP_STATE) == pysoem.PREOP_STATE
+    net.config_pdo_map()
     net.start_pdos()
     net._ecat_master.read_state()
     start_time = time.time()

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -299,7 +299,7 @@ def test_start_stop_pdo(connect_to_all_slave):
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
         net._ecat_master.read_state()
         assert servo.slave.state_check(pysoem.PREOP_STATE) == pysoem.PREOP_STATE
-    net.config_pdo_map()
+    net.config_pdo_maps()
     net.start_pdos()
     net._ecat_master.read_state()
     start_time = time.time()

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -419,3 +419,55 @@ def test_map_pdo_with_bools(open_dictionary):
     assert item4.raw_data_bits.to01() == "1"
     assert rpdo_map.get_item_bits().to01() == "00010001000100010001000100011000101101"
     assert rpdo_map.get_item_bytes() == b"\x88\x88\x88\x18-"
+
+
+@pytest.mark.ethercat
+def test_remove_rpdo_map(connect_to_slave, create_pdo_map):
+    _, rpdo_map = create_pdo_map
+    servo, net = connect_to_slave
+    servo.set_pdo_map_to_slave([rpdo_map], [])
+    assert len(servo._rpdo_maps) > 0
+    servo.remove_rpdo_map(rpdo_map)
+    assert len(servo._rpdo_maps) == 0
+    servo._rpdo_maps.append(rpdo_map)
+    servo.remove_rpdo_map(rpdo_map_index=0)
+    assert len(servo._rpdo_maps) == 0
+
+
+@pytest.mark.ethercat
+def test_remove_rpdo_map_exceptions(connect_to_slave, create_pdo_map):
+    tpdo_map, rpdo_map = create_pdo_map
+    servo, net = connect_to_slave
+    servo.set_pdo_map_to_slave([rpdo_map], [])
+    with pytest.raises(ValueError):
+        servo.remove_rpdo_map()
+    with pytest.raises(ValueError):
+        servo.remove_rpdo_map(tpdo_map)
+    with pytest.raises(IndexError):
+        servo.remove_rpdo_map(rpdo_map_index=1)
+
+
+@pytest.mark.ethercat
+def test_remove_tpdo_map(connect_to_slave, create_pdo_map):
+    tpdo_map, _ = create_pdo_map
+    servo, net = connect_to_slave
+    servo.set_pdo_map_to_slave([], [tpdo_map])
+    assert len(servo._tpdo_maps) > 0
+    servo.remove_tpdo_map(tpdo_map)
+    assert len(servo._tpdo_maps) == 0
+    servo._tpdo_maps.append(tpdo_map)
+    servo.remove_tpdo_map(tpdo_map_index=0)
+    assert len(servo._tpdo_maps) == 0
+
+
+@pytest.mark.ethercat
+def test_remove_tpdo_map_exceptions(connect_to_slave, create_pdo_map):
+    tpdo_map, rpdo_map = create_pdo_map
+    servo, net = connect_to_slave
+    servo.set_pdo_map_to_slave([rpdo_map], [])
+    with pytest.raises(ValueError):
+        servo.remove_rpdo_map()
+    with pytest.raises(ValueError):
+        servo.remove_tpdo_map(rpdo_map)
+    with pytest.raises(IndexError):
+        servo.remove_tpdo_map(tpdo_map_index=1)

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -296,7 +296,6 @@ def test_start_stop_pdo(connect_to_all_slave):
             rpdo_map.add_registers(register)
         for item in rpdo_map.items:
             item.value = new_operation_mode[index]
-        servo.reset_pdo_mapping()
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
         net._ecat_master.read_state()
         assert servo.slave.state_check(pysoem.PREOP_STATE) == pysoem.PREOP_STATE
@@ -321,6 +320,12 @@ def test_start_stop_pdo(connect_to_all_slave):
         assert pytest.approx(servo._tpdo_maps[0].items[0].value, abs=2) == servo.read(
             TPDO_REGISTERS[0]
         )
+    # Check that PDOs can be re-started with the same configuration
+    net.start_pdos()
+    start_time = time.time()
+    while time.time() < start_time + timeout:
+        net.send_receive_processdata()
+    net.stop_pdos()
 
 
 @pytest.mark.ethercat


### PR DESCRIPTION
### Description

Don't reset PDO mapping when mapping PDOs

Fixes # INGK-837

### Type of change

- Remove calls to reset_rpdo_mapping and  reset_tpdo_mapping on the set_pdo_map_to_slave method.
- Extend the PDOMap lists with the PDOMaps when calling the set_pdo_map_to_slave method.
- Add the reset_pdo_mapping method.
- Add the remove_rpdo_map method.
- Add the remove_tpdo_map method.

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.