### PR TITLE
INGK-855 Add an sleep to unlock threads in SDO read/write

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -182,6 +182,7 @@ class EthercatServo(PDOServo):
             start_time = time.time()
         self._lock.acquire()
         try:
+            time.sleep(0.0001)  # Unlock threads before SDO read
             value: bytes = self.__slave.sdo_read(reg.idx, reg.subidx, buffer_size, complete_access)
         except (
             pysoem.SdoError,
@@ -213,6 +214,7 @@ class EthercatServo(PDOServo):
             start_time = time.time()
         self._lock.acquire()
         try:
+            time.sleep(0.0001)  # Unlock threads before SDO write
             self.__slave.sdo_write(reg.idx, reg.subidx, data, complete_access)
         except (
             pysoem.SdoError,


### PR DESCRIPTION
### Description

Add very little sleep to unlock threads in EtherCAT read/write.

Fixes # INGK-855

### Type of change

- [x] Add very little sleep to unlock threads in EtherCAT read/write.

### Tests

- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.