### PR TITLE
INGK-858 Add NVM_NONE address type to missing registers

### DIFF
--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS
+from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
 
 import ingenialogger
 import xml.etree.ElementTree as ET
@@ -26,6 +26,7 @@ class CanopenDictionaryV2(DictionaryV2):
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
             subnode=0,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         CanopenRegister(
             identifier="DISTURBANCE_DATA",
@@ -35,6 +36,7 @@ class CanopenDictionaryV2(DictionaryV2):
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RW,
             subnode=0,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -26,7 +26,6 @@ class CanopenDictionaryV2(DictionaryV2):
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
             subnode=0,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         CanopenRegister(
             identifier="DISTURBANCE_DATA",
@@ -34,9 +33,8 @@ class CanopenDictionaryV2(DictionaryV2):
             subidx=0x00,
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
-            access=REG_ACCESS.RW,
+            access=REG_ACCESS.WO,
             subnode=0,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
+from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS
 
 import ingenialogger
 import xml.etree.ElementTree as ET

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -32,7 +32,6 @@ class EthercatDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="DISTURBANCE_DATA",
@@ -43,7 +42,6 @@ class EthercatDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.WO,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethercat.register import EthercatRegister, REG_DTYPE, REG_ACCESS
+from ingenialink.ethercat.register import EthercatRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
 from ingenialink.constants import (
     CANOPEN_ADDRESS_OFFSET,
     CANOPEN_SUBNODE_0_ADDRESS_OFFSET,
@@ -32,6 +32,7 @@ class EthercatDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="DISTURBANCE_DATA",
@@ -42,6 +43,7 @@ class EthercatDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.WO,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 
@@ -54,6 +56,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_ASSIGN_REGISTER_SUB_IDX_1",
@@ -63,6 +66,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_MAP_REGISTER_SUB_IDX_0",
@@ -72,6 +76,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_MAP_REGISTER_SUB_IDX_1",
@@ -81,6 +86,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=REG_DTYPE.STR,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_ASSIGN_REGISTER_SUB_IDX_0",
@@ -90,6 +96,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_ASSIGN_REGISTER_SUB_IDX_1",
@@ -99,6 +106,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_MAP_REGISTER_SUB_IDX_0",
@@ -108,6 +116,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=REG_DTYPE.S32,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_MAP_REGISTER_SUB_IDX_1",
@@ -117,6 +126,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=REG_DTYPE.STR,
             access=REG_ACCESS.RW,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
+from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -26,7 +26,6 @@ class EthernetDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthernetRegister(
             identifier="DISTURBANCE_DATA",
@@ -36,7 +35,6 @@ class EthernetDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.WO,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS
+from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -26,6 +26,7 @@ class EthernetDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.RO,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthernetRegister(
             identifier="DISTURBANCE_DATA",
@@ -35,6 +36,7 @@ class EthernetDictionaryV2(DictionaryV2):
             cyclic="CONFIG",
             dtype=REG_DTYPE.U16,
             access=REG_ACCESS.WO,
+            address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -355,8 +355,8 @@ class Servo:
         for subnode in subnodes:
             registers_dict = self.dictionary.registers(subnode=subnode)
             for reg_id, register in registers_dict.items():
-                if (register.address_type == REG_ADDRESS_TYPE.NVM_NONE) or (
-                    register.access != REG_ACCESS.RW
+                if (register.access != REG_ACCESS.RW) or (
+                    register.address_type == REG_ADDRESS_TYPE.NVM_NONE
                 ):
                     continue
                 register_xml = ET.SubElement(registers, "Register")


### PR DESCRIPTION
### Description
Add NVM_NONE address type to missing registers to prevent them from being saved to the configuration file.

Fixes # INGK-858

### Type of change

Please add a description and delete options that are not relevant.

- [x] Add NVM_NONE address type to missing registers.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.