### PR TITLE
INGK-857 Recover CoE communication after a power cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 - Bug that prevented the slaves to reach Operational state after the PDO exchange is re-started.
+- Recover the CoE communication after a power-cycle. The network status listener must be turned on in order for it to work.
 
 ## [7.2.0] - 2024-03-13
 

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -477,6 +477,9 @@ class EthercatNetwork(Network):
         Args:
             status: The network status.
 
+        Raises:
+            ILStateError: If not all slaves reach PreOp state.
+
         """
         self._ecat_master.read_state()
         if status == NET_DEV_EVT.ADDED and self._ecat_master.state == pysoem.INIT_STATE:

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -481,3 +481,7 @@ class EthercatNetwork(Network):
         self._ecat_master.read_state()
         if status == NET_DEV_EVT.ADDED and self._ecat_master.state == pysoem.INIT_STATE:
             self.__init_nodes()
+            if not self._check_node_state(self.servos, pysoem.PREOP_STATE):
+                raise ILStateError(
+                    "The communication cannot be recovered. Not all slaves reached PreOp state"
+                )


### PR DESCRIPTION
### Description

Recover the CoE communication after a power cycle. The network status listener must be turned on in order for it to work.

Fixes # INGK-857

### Type of change

- Create the _recover_from_power_cycle method
- Subscribe the  _recover_from_power_cycle method to the network status changes

### Tests
- [x] Run tests.

Steps:

- Connect to a drive (turn on the network status listener).
-  Continuously read a register value
- Turn the power supply off.
- Check that the register is not being read.
- Turn the power supply on.
- Check that the register value is being read.


### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.