### PR TITLE
INGK-861 Support cyclic TXRX in dictionary v 3

### DIFF
--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
+from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, RegCyclicType
 
 import ingenialogger
 import xml.etree.ElementTree as ET
@@ -22,7 +22,7 @@ class CanopenDictionaryV2(DictionaryV2):
             identifier="MONITORING_DATA",
             idx=0x58B2,
             subidx=0x00,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
             subnode=0,
@@ -31,7 +31,7 @@ class CanopenDictionaryV2(DictionaryV2):
             identifier="DISTURBANCE_DATA",
             idx=0x58B4,
             subidx=0x00,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
             subnode=0,

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,7 +1,7 @@
 from typing import Optional, List
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS
+from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
 
 import ingenialogger
 import xml.etree.ElementTree as ET
@@ -22,7 +22,7 @@ class CanopenDictionaryV2(DictionaryV2):
             identifier="MONITORING_DATA",
             idx=0x58B2,
             subidx=0x00,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
             subnode=0,
@@ -31,7 +31,7 @@ class CanopenDictionaryV2(DictionaryV2):
             identifier="DISTURBANCE_DATA",
             idx=0x58B4,
             subidx=0x00,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
             subnode=0,

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -28,7 +28,7 @@ from ingenialink.canopen.servo import (
     REG_DTYPE,
     CanopenServo,
 )
-from ingenialink.enums.register import REG_CYCLIC_TYPE
+from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILObjectNotExist
 from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
 from ingenialink.utils._utils import convert_bytes_to_dtype
@@ -39,7 +39,7 @@ logger = ingenialogger.get_logger(__name__)
 PROG_STAT_1 = CanopenRegister(
     idx=0x1F51,
     subidx=0x01,
-    cyclic=REG_CYCLIC_TYPE.CONFIG,
+    cyclic=RegCyclicType.CONFIG,
     dtype=REG_DTYPE.U8,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_CONTROL_1",
@@ -48,7 +48,7 @@ PROG_STAT_1 = CanopenRegister(
 PROG_DL_1 = CanopenRegister(
     idx=0x1F50,
     subidx=0x01,
-    cyclic=REG_CYCLIC_TYPE.CONFIG,
+    cyclic=RegCyclicType.CONFIG,
     dtype=REG_DTYPE.BYTE_ARRAY_512,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_DATA",
@@ -57,7 +57,7 @@ PROG_DL_1 = CanopenRegister(
 FORCE_BOOT = CanopenRegister(
     idx=0x5EDE,
     subidx=0x00,
-    cyclic=REG_CYCLIC_TYPE.CONFIG,
+    cyclic=RegCyclicType.CONFIG,
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.WO,
     identifier="DRV_BOOT_COCO_FORCE",
@@ -67,7 +67,7 @@ FORCE_BOOT = CanopenRegister(
 CIA301_DRV_ID_DEVICE_TYPE = CanopenRegister(
     idx=0x1000,
     subidx=0x00,
-    cyclic=REG_CYCLIC_TYPE.CONFIG,
+    cyclic=RegCyclicType.CONFIG,
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.RO,
     identifier="",

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -28,6 +28,7 @@ from ingenialink.canopen.servo import (
     REG_DTYPE,
     CanopenServo,
 )
+from ingenialink.enums.register import REG_CYCLIC_TYPE
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILObjectNotExist
 from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
 from ingenialink.utils._utils import convert_bytes_to_dtype
@@ -38,7 +39,7 @@ logger = ingenialogger.get_logger(__name__)
 PROG_STAT_1 = CanopenRegister(
     idx=0x1F51,
     subidx=0x01,
-    cyclic="CONFIG",
+    cyclic=REG_CYCLIC_TYPE.CONFIG,
     dtype=REG_DTYPE.U8,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_CONTROL_1",
@@ -47,7 +48,7 @@ PROG_STAT_1 = CanopenRegister(
 PROG_DL_1 = CanopenRegister(
     idx=0x1F50,
     subidx=0x01,
-    cyclic="CONFIG",
+    cyclic=REG_CYCLIC_TYPE.CONFIG,
     dtype=REG_DTYPE.BYTE_ARRAY_512,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_DATA",
@@ -56,7 +57,7 @@ PROG_DL_1 = CanopenRegister(
 FORCE_BOOT = CanopenRegister(
     idx=0x5EDE,
     subidx=0x00,
-    cyclic="CONFIG",
+    cyclic=REG_CYCLIC_TYPE.CONFIG,
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.WO,
     identifier="DRV_BOOT_COCO_FORCE",
@@ -66,7 +67,7 @@ FORCE_BOOT = CanopenRegister(
 CIA301_DRV_ID_DEVICE_TYPE = CanopenRegister(
     idx=0x1000,
     subidx=0x00,
-    cyclic="CONFIG",
+    cyclic=REG_CYCLIC_TYPE.CONFIG,
     dtype=REG_DTYPE.U32,
     access=REG_ACCESS.RO,
     identifier="",

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.enums.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    REG_CYCLIC_TYPE,
+)
 from ingenialink.register import Register
 
 
@@ -43,7 +49,7 @@ class CanopenRegister(Register):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: str = "CONFIG",
+        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -5,7 +5,7 @@ from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
     REG_DTYPE,
     REG_PHY,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 from ingenialink.register import Register
 
@@ -49,7 +49,7 @@ class CanopenRegister(Register):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
+        cyclic: RegCyclicType = RegCyclicType.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -10,7 +10,7 @@ import ingenialogger
 from ingenialink.exceptions import ILDictionaryParseError
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register, REG_CYCLIC_TYPE
 from ingenialink.ethercat.register import EthercatRegister
 
 logger = ingenialogger.get_logger(__name__)
@@ -782,7 +782,7 @@ class DictionaryV3(Dictionary):
         access = self.access_xdf_options[register.attrib[self.ACCESS_ATTR]]
         dtype = self.dtype_xdf_options[register.attrib[self.DTYPE_ATTR]]
         identifier = register.attrib[self.UID_ATTR]
-        cyclic = register.attrib[self.CYCLIC_ATTR]  # TODO use enums
+        cyclic = REG_CYCLIC_TYPE(register.attrib[self.CYCLIC_ATTR])
         description = register.attrib[self.DESCRIPTION_ATTR]
         default = bytes.fromhex(register.attrib[self.DEFAULT_ATTR])
         cat_id = register.attrib[self.CAT_ID_ATTR]
@@ -857,7 +857,7 @@ class DictionaryV3(Dictionary):
         access = self.access_xdf_options[subitem.attrib[self.ACCESS_ATTR]]
         dtype = self.dtype_xdf_options[subitem.attrib[self.DTYPE_ATTR]]
         identifier = subitem.attrib[self.UID_ATTR]
-        cyclic = subitem.attrib[self.CYCLIC_ATTR]  # TODO use enums
+        cyclic = REG_CYCLIC_TYPE(subitem.attrib[self.CYCLIC_ATTR])
         description = subitem.attrib[self.DESCRIPTION_ATTR]
         default = bytes.fromhex(subitem.attrib[self.DEFAULT_ATTR])
         cat_id = subitem.attrib[self.CAT_ID_ATTR]
@@ -1079,7 +1079,7 @@ class DictionaryV2(Dictionary):
 
         try:
             units = register.attrib["units"]
-            cyclic = register.attrib.get("cyclic", "CONFIG")
+            cyclic = REG_CYCLIC_TYPE(register.attrib.get("cyclic", "CONFIG"))
 
             # Data type
             dtype_aux = register.attrib["dtype"]

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -10,7 +10,7 @@ import ingenialogger
 from ingenialink.exceptions import ILDictionaryParseError
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register, REG_CYCLIC_TYPE
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register, RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
 
 logger = ingenialogger.get_logger(__name__)
@@ -782,7 +782,7 @@ class DictionaryV3(Dictionary):
         access = self.access_xdf_options[register.attrib[self.ACCESS_ATTR]]
         dtype = self.dtype_xdf_options[register.attrib[self.DTYPE_ATTR]]
         identifier = register.attrib[self.UID_ATTR]
-        cyclic = REG_CYCLIC_TYPE(register.attrib[self.CYCLIC_ATTR])
+        cyclic = RegCyclicType(register.attrib[self.CYCLIC_ATTR])
         description = register.attrib[self.DESCRIPTION_ATTR]
         default = bytes.fromhex(register.attrib[self.DEFAULT_ATTR])
         cat_id = register.attrib[self.CAT_ID_ATTR]
@@ -857,7 +857,7 @@ class DictionaryV3(Dictionary):
         access = self.access_xdf_options[subitem.attrib[self.ACCESS_ATTR]]
         dtype = self.dtype_xdf_options[subitem.attrib[self.DTYPE_ATTR]]
         identifier = subitem.attrib[self.UID_ATTR]
-        cyclic = REG_CYCLIC_TYPE(subitem.attrib[self.CYCLIC_ATTR])
+        cyclic = RegCyclicType(subitem.attrib[self.CYCLIC_ATTR])
         description = subitem.attrib[self.DESCRIPTION_ATTR]
         default = bytes.fromhex(subitem.attrib[self.DEFAULT_ATTR])
         cat_id = subitem.attrib[self.CAT_ID_ATTR]
@@ -1079,7 +1079,7 @@ class DictionaryV2(Dictionary):
 
         try:
             units = register.attrib["units"]
-            cyclic = REG_CYCLIC_TYPE(register.attrib.get("cyclic", "CONFIG"))
+            cyclic = RegCyclicType(register.attrib.get("cyclic", "CONFIG"))
 
             # Data type
             dtype_aux = register.attrib["dtype"]

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -70,7 +70,7 @@ class REG_ADDRESS_TYPE(Enum):
     NVM_HW = 4
 
 
-class REG_CYCLIC_TYPE(Enum):
+class RegCyclicType(Enum):
     """Cyclic Type."""
 
     RX = "CYCLIC_RX"

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -68,3 +68,12 @@ class REG_ADDRESS_TYPE(Enum):
     NVM_CFG = 2
     NVM_LOCK = 3
     NVM_HW = 4
+
+
+class REG_CYCLIC_TYPE(Enum):
+    """Cyclic Type."""
+
+    RX = "CYCLIC_RX"
+    TX = "CYCLIC_TX"
+    TXRX = "CYCLIC_TXRX"
+    CONFIG = "CONFIG"

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -9,7 +9,7 @@ from ingenialink.ethercat.register import (
     REG_DTYPE,
     REG_ACCESS,
     REG_ADDRESS_TYPE,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 from ingenialink.constants import (
     CANOPEN_ADDRESS_OFFSET,
@@ -35,7 +35,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x58B2,
             subidx=0x01,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
@@ -45,7 +45,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x58B4,
             subidx=0x01,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -4,7 +4,13 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethercat.register import EthercatRegister, REG_DTYPE, REG_ACCESS, REG_ADDRESS_TYPE
+from ingenialink.ethercat.register import (
+    EthercatRegister,
+    REG_DTYPE,
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_CYCLIC_TYPE,
+)
 from ingenialink.constants import (
     CANOPEN_ADDRESS_OFFSET,
     CANOPEN_SUBNODE_0_ADDRESS_OFFSET,
@@ -29,7 +35,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x58B2,
             subidx=0x01,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
@@ -39,7 +45,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x58B4,
             subidx=0x01,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),

--- a/ingenialink/ethercat/register.py
+++ b/ingenialink/ethercat/register.py
@@ -4,7 +4,7 @@ from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
     REG_DTYPE,
     REG_PHY,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 
 

--- a/ingenialink/ethercat/register.py
+++ b/ingenialink/ethercat/register.py
@@ -1,5 +1,11 @@
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.enums.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    REG_CYCLIC_TYPE,
+)
 
 
 class EthercatRegister(CanopenRegister):

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
+from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, RegCyclicType
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -23,7 +23,7 @@ class EthernetDictionaryV2(DictionaryV2):
             units="",
             subnode=0,
             address=0x00B2,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
@@ -32,7 +32,7 @@ class EthernetDictionaryV2(DictionaryV2):
             units="",
             subnode=0,
             address=0x00B4,
-            cyclic=REG_CYCLIC_TYPE.CONFIG,
+            cyclic=RegCyclicType.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS
+from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -23,7 +23,7 @@ class EthernetDictionaryV2(DictionaryV2):
             units="",
             subnode=0,
             address=0x00B2,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
@@ -32,7 +32,7 @@ class EthernetDictionaryV2(DictionaryV2):
             units="",
             subnode=0,
             address=0x00B4,
-            cyclic="CONFIG",
+            cyclic=REG_CYCLIC_TYPE.CONFIG,
             dtype=REG_DTYPE.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -5,7 +5,7 @@ from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
     REG_DTYPE,
     REG_PHY,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 from ingenialink.register import Register
 
@@ -49,7 +49,7 @@ class EthernetRegister(Register):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
+        cyclic: RegCyclicType = RegCyclicType.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -1,6 +1,12 @@
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.enums.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    REG_CYCLIC_TYPE,
+)
 from ingenialink.register import Register
 
 
@@ -43,7 +49,7 @@ class EthernetRegister(Register):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: str = "CONFIG",
+        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -33,8 +33,8 @@ class PDOMapItem:
 
     """
 
-    ACCEPTED_CYCLIC: Optional[REG_CYCLIC_TYPE] = None
-    """Accepted cyclic: CYCLIC_TX or CYCLIC_RX."""
+    ACCEPTED_CYCLIC: REG_CYCLIC_TYPE
+    """Accepted cyclic: CYCLIC_TX, CYCLIC_RX or CYCLIC_TXRX."""
 
     def __init__(
         self,
@@ -50,7 +50,7 @@ class PDOMapItem:
                 subnode=0,
                 idx=0x0000,
                 subidx=0x00,
-                cyclic=REG_CYCLIC_TYPE(self.ACCEPTED_CYCLIC),
+                cyclic=self.ACCEPTED_CYCLIC,
                 dtype=REG_DTYPE.STR,
                 access=REG_ACCESS.RW,
             )
@@ -65,10 +65,10 @@ class PDOMapItem:
         Raises:
             ILError: Tf the register is not mappable.
         """
-        if self.register.cyclic != self.ACCEPTED_CYCLIC:
+        if self.register.cyclic not in [self.ACCEPTED_CYCLIC, REG_CYCLIC_TYPE.TXRX]:
             raise ILError(
-                f"Incorrect cyclic. It should be {self.ACCEPTED_CYCLIC}, obtained:"
-                f" {self.register.cyclic}"
+                f"Incorrect cyclic. It should be {self.ACCEPTED_CYCLIC} or {REG_CYCLIC_TYPE.TXRX},"
+                f" obtained: {self.register.cyclic}"
             )
 
     @property

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union, Dict
 import bitarray
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
+from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILError
 from ingenialink.servo import Servo
@@ -33,7 +33,7 @@ class PDOMapItem:
 
     """
 
-    ACCEPTED_CYCLIC: REG_CYCLIC_TYPE
+    ACCEPTED_CYCLIC: RegCyclicType
     """Accepted cyclic: CYCLIC_TX, CYCLIC_RX or CYCLIC_TXRX."""
 
     def __init__(
@@ -65,9 +65,9 @@ class PDOMapItem:
         Raises:
             ILError: Tf the register is not mappable.
         """
-        if self.register.cyclic not in [self.ACCEPTED_CYCLIC, REG_CYCLIC_TYPE.TXRX]:
+        if self.register.cyclic not in [self.ACCEPTED_CYCLIC, RegCyclicType.TXRX]:
             raise ILError(
-                f"Incorrect cyclic. It should be {self.ACCEPTED_CYCLIC} or {REG_CYCLIC_TYPE.TXRX},"
+                f"Incorrect cyclic. It should be {self.ACCEPTED_CYCLIC} or {RegCyclicType.TXRX},"
                 f" obtained: {self.register.cyclic}"
             )
 
@@ -158,7 +158,7 @@ class PDOMapItem:
 class RPDOMapItem(PDOMapItem):
     """Class to represent RPDO mapping items."""
 
-    ACCEPTED_CYCLIC = REG_CYCLIC_TYPE.RX
+    ACCEPTED_CYCLIC = RegCyclicType.RX
 
     def __init__(
         self,
@@ -189,7 +189,7 @@ class RPDOMapItem(PDOMapItem):
 class TPDOMapItem(PDOMapItem):
     """Class to represent TPDO mapping items."""
 
-    ACCEPTED_CYCLIC = REG_CYCLIC_TYPE.TX
+    ACCEPTED_CYCLIC = RegCyclicType.TX
 
 
 class PDOMap:

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union, Dict
 import bitarray
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS
+from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_CYCLIC_TYPE
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILError
 from ingenialink.servo import Servo
@@ -33,7 +33,7 @@ class PDOMapItem:
 
     """
 
-    ACCEPTED_CYCLIC = ""
+    ACCEPTED_CYCLIC: Optional[REG_CYCLIC_TYPE] = None
     """Accepted cyclic: CYCLIC_TX or CYCLIC_RX."""
 
     def __init__(
@@ -50,7 +50,7 @@ class PDOMapItem:
                 subnode=0,
                 idx=0x0000,
                 subidx=0x00,
-                cyclic=self.ACCEPTED_CYCLIC,
+                cyclic=REG_CYCLIC_TYPE(self.ACCEPTED_CYCLIC),
                 dtype=REG_DTYPE.STR,
                 access=REG_ACCESS.RW,
             )
@@ -158,7 +158,7 @@ class PDOMapItem:
 class RPDOMapItem(PDOMapItem):
     """Class to represent RPDO mapping items."""
 
-    ACCEPTED_CYCLIC = "CYCLIC_RX"
+    ACCEPTED_CYCLIC = REG_CYCLIC_TYPE.RX
 
     def __init__(
         self,
@@ -189,7 +189,7 @@ class RPDOMapItem(PDOMapItem):
 class TPDOMapItem(PDOMapItem):
     """Class to represent TPDO mapping items."""
 
-    ACCEPTED_CYCLIC = "CYCLIC_TX"
+    ACCEPTED_CYCLIC = REG_CYCLIC_TYPE.TX
 
 
 class PDOMap:

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -7,7 +7,7 @@ from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
     REG_DTYPE,
     REG_PHY,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
@@ -59,7 +59,7 @@ class Register(ABC):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
+        cyclic: RegCyclicType = RegCyclicType.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,
@@ -156,7 +156,7 @@ class Register(ABC):
         return self._units
 
     @property
-    def cyclic(self) -> REG_CYCLIC_TYPE:
+    def cyclic(self) -> RegCyclicType:
         """Defines if the register is cyclic."""
         return self._cyclic
 

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -2,7 +2,13 @@ from abc import ABC
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ingenialink import exceptions as exc
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.enums.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    REG_CYCLIC_TYPE,
+)
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
 dtypes_ranges: Dict[REG_DTYPE, Dict[str, Union[int, float]]] = {
@@ -53,7 +59,7 @@ class Register(ABC):
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
-        cyclic: str = "CONFIG",
+        cyclic: REG_CYCLIC_TYPE = REG_CYCLIC_TYPE.CONFIG,
         phy: REG_PHY = REG_PHY.NONE,
         subnode: int = 1,
         storage: Any = None,
@@ -150,7 +156,7 @@ class Register(ABC):
         return self._units
 
     @property
-    def cyclic(self) -> str:
+    def cyclic(self) -> REG_CYCLIC_TYPE:
         """Defines if the register is cyclic."""
         return self._cyclic
 

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -7,7 +7,7 @@ from ingenialink.canopen.register import (
     REG_DTYPE,
     REG_PHY,
     CanopenRegister,
-    REG_CYCLIC_TYPE,
+    RegCyclicType,
 )
 
 
@@ -21,7 +21,7 @@ def test_getters_canopen_register():
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
-        "cyclic": REG_CYCLIC_TYPE.CONFIG,
+        "cyclic": RegCyclicType.CONFIG,
         "phy": REG_PHY.NONE,
         "subnode": 0,
         "storage": 1,
@@ -80,7 +80,7 @@ def test_canopen_connection_register(connect_to_slave):
 
     assert register.identifier == "DRV_OP_CMD"
     assert register.units == "-"
-    assert register.cyclic == REG_CYCLIC_TYPE.RX
+    assert register.cyclic == RegCyclicType.RX
     assert register.dtype == REG_DTYPE.U16
     assert register.access, REG_ACCESS.RW
     assert register.idx == 0x2014

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -7,6 +7,7 @@ from ingenialink.canopen.register import (
     REG_DTYPE,
     REG_PHY,
     CanopenRegister,
+    REG_CYCLIC_TYPE,
 )
 
 
@@ -20,7 +21,7 @@ def test_getters_canopen_register():
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
-        "cyclic": "CONFIG",
+        "cyclic": REG_CYCLIC_TYPE.CONFIG,
         "phy": REG_PHY.NONE,
         "subnode": 0,
         "storage": 1,
@@ -79,7 +80,7 @@ def test_canopen_connection_register(connect_to_slave):
 
     assert register.identifier == "DRV_OP_CMD"
     assert register.units == "-"
-    assert register.cyclic == "CYCLIC_RX"
+    assert register.cyclic == REG_CYCLIC_TYPE.RX
     assert register.dtype == REG_DTYPE.U16
     assert register.access, REG_ACCESS.RW
     assert register.idx == 0x2014

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -50,6 +50,7 @@ def test_read_dictionary_registers():
     expected_regs_per_subnode = {
         0: [
             "DRV_DIAG_ERROR_LAST_COM",
+            "TEST_TXRX_REGISTER",
             "DRV_AXIS_NUMBER",
             "CIA301_COMMS_RPDO1_MAP",
             "CIA301_COMMS_RPDO1_MAP_1",
@@ -205,6 +206,7 @@ def test_register_default_values():
         0: {
             "DRV_DIAG_ERROR_LAST_COM": 0,
             "DRV_AXIS_NUMBER": 1,
+            "TEST_TXRX_REGISTER": 0,
             "CIA301_COMMS_RPDO1_MAP": 1,
             "CIA301_COMMS_RPDO1_MAP_1": 268451936,
         },
@@ -225,6 +227,7 @@ def test_register_description():
         0: {
             "DRV_DIAG_ERROR_LAST_COM": "Contains the last generated error",
             "DRV_AXIS_NUMBER": "",
+            "TEST_TXRX_REGISTER": "Test TXRX register",
             "CIA301_COMMS_RPDO1_MAP": "",
             "CIA301_COMMS_RPDO1_MAP_1": "",
         },

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -75,8 +75,8 @@ def test_rpdo_item_wrong_cyclic(open_dictionary):
         RPDOMapItem(register)
     assert (
         str(exc_info.value)
-        == "Incorrect cyclic. It should be REG_CYCLIC_TYPE.RX or REG_CYCLIC_TYPE.TXRX, obtained:"
-        " REG_CYCLIC_TYPE.TX"
+        == "Incorrect cyclic. It should be RegCyclicType.RX or RegCyclicType.TXRX, obtained:"
+        " RegCyclicType.TX"
     )
 
 
@@ -88,8 +88,8 @@ def test_tpdo_item_wrong_cyclic(open_dictionary):
         TPDOMapItem(register)
     assert (
         str(exc_info.value)
-        == "Incorrect cyclic. It should be REG_CYCLIC_TYPE.TX or REG_CYCLIC_TYPE.TXRX, obtained:"
-        " REG_CYCLIC_TYPE.RX"
+        == "Incorrect cyclic. It should be RegCyclicType.TX or RegCyclicType.TXRX, obtained:"
+        " RegCyclicType.RX"
     )
 
 

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -11,7 +11,7 @@ import pytest
 
 from ingenialink import EthercatNetwork
 from ingenialink.dictionary import Interface
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_CYCLIC_TYPE
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError
@@ -404,7 +404,7 @@ def test_set_pdo_map_to_slave(connect_to_slave, create_pdo_map):
 
 @pytest.mark.no_connection
 def test_pdo_item_bool():
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=REG_CYCLIC_TYPE.RX)
+    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
     rpdo_item = RPDOMapItem(register)
 
     assert rpdo_item.register == register
@@ -458,7 +458,7 @@ def test_rpdo_padding():
     size_bits = 3
     rpdo_item = RPDOMapItem(size_bits=size_bits)
     assert rpdo_item.size_bits == size_bits
-    assert rpdo_item.ACCEPTED_CYCLIC == REG_CYCLIC_TYPE.RX
+    assert rpdo_item.ACCEPTED_CYCLIC == RegCyclicType.RX
     padding_register = rpdo_item.register
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
@@ -473,7 +473,7 @@ def test_tpdo_padding():
     size_bits = 4
     tpdo_item = TPDOMapItem(size_bits=size_bits)
     assert tpdo_item.size_bits == size_bits
-    assert tpdo_item.ACCEPTED_CYCLIC == REG_CYCLIC_TYPE.TX
+    assert tpdo_item.ACCEPTED_CYCLIC == RegCyclicType.TX
     padding_register = tpdo_item.register
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
@@ -505,7 +505,7 @@ def test_map_pdo_with_bools(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[RPDO_REGISTERS[0]]
     item1 = RPDOMapItem(register)
     item2 = RPDOMapItem(register, size_bits=4)
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=REG_CYCLIC_TYPE.RX)
+    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
     item3 = RPDOMapItem(register)
     item4 = RPDOMapItem(register)
 

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -11,7 +11,7 @@ import pytest
 
 from ingenialink import EthercatNetwork
 from ingenialink.dictionary import Interface
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_CYCLIC_TYPE
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError
@@ -73,7 +73,11 @@ def test_rpdo_item_wrong_cyclic(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[TPDO_REGISTERS[0]]
     with pytest.raises(ILError) as exc_info:
         RPDOMapItem(register)
-    assert str(exc_info.value) == "Incorrect cyclic. It should be CYCLIC_RX, obtained: CYCLIC_TX"
+    assert (
+        str(exc_info.value)
+        == "Incorrect cyclic. It should be REG_CYCLIC_TYPE.RX or REG_CYCLIC_TYPE.TXRX, obtained:"
+        " REG_CYCLIC_TYPE.TX"
+    )
 
 
 @pytest.mark.no_connection
@@ -82,7 +86,11 @@ def test_tpdo_item_wrong_cyclic(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[RPDO_REGISTERS[0]]
     with pytest.raises(ILError) as exc_info:
         TPDOMapItem(register)
-    assert str(exc_info.value) == "Incorrect cyclic. It should be CYCLIC_TX, obtained: CYCLIC_RX"
+    assert (
+        str(exc_info.value)
+        == "Incorrect cyclic. It should be REG_CYCLIC_TYPE.TX or REG_CYCLIC_TYPE.TXRX, obtained:"
+        " REG_CYCLIC_TYPE.RX"
+    )
 
 
 @pytest.mark.no_connection
@@ -396,7 +404,7 @@ def test_set_pdo_map_to_slave(connect_to_slave, create_pdo_map):
 
 @pytest.mark.no_connection
 def test_pdo_item_bool():
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic="CYCLIC_RX")
+    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=REG_CYCLIC_TYPE.RX)
     rpdo_item = RPDOMapItem(register)
 
     assert rpdo_item.register == register
@@ -450,7 +458,7 @@ def test_rpdo_padding():
     size_bits = 3
     rpdo_item = RPDOMapItem(size_bits=size_bits)
     assert rpdo_item.size_bits == size_bits
-    assert rpdo_item.ACCEPTED_CYCLIC == "CYCLIC_RX"
+    assert rpdo_item.ACCEPTED_CYCLIC == REG_CYCLIC_TYPE.RX
     padding_register = rpdo_item.register
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
@@ -465,7 +473,7 @@ def test_tpdo_padding():
     size_bits = 4
     tpdo_item = TPDOMapItem(size_bits=size_bits)
     assert tpdo_item.size_bits == size_bits
-    assert tpdo_item.ACCEPTED_CYCLIC == "CYCLIC_TX"
+    assert tpdo_item.ACCEPTED_CYCLIC == REG_CYCLIC_TYPE.TX
     padding_register = tpdo_item.register
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
@@ -497,7 +505,7 @@ def test_map_pdo_with_bools(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[RPDO_REGISTERS[0]]
     item1 = RPDOMapItem(register)
     item2 = RPDOMapItem(register, size_bits=4)
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic="CYCLIC_RX")
+    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=REG_CYCLIC_TYPE.RX)
     item3 = RPDOMapItem(register)
     item4 = RPDOMapItem(register)
 

--- a/tests/resources/test_dict_ecat_eoe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_v3.0.xdf
@@ -34,6 +34,15 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
+					<CANopenObject index="0x5E49" subnode="0">
+						<Subitems>
+							<Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="TEST_TXRX_REGISTER" cyclic="CYCLIC_TXRX" desc="Test TXRX register" default="00000000" cat_id="OTHERS">
+								<Labels>
+									<Label lang="en_US">Test TXRX register</Label>
+								</Labels>
+							</Subitem>
+						</Subitems>
+					</CANopenObject>
 					<CANopenObject index="0x58A0" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">


### PR DESCRIPTION
### Description

Support cyclic TXRX in dictionary v 3

Fixes # INGK-861

### Type of change

- Create an enum for the register cyclic attribute.
- Add cyclic TXRX as an accepted cyclic type in the PDOMapItem class.


### Tests
- [x] Run tests.

I added a new register with cyclic type TXRX to the EtherCAT V3 example dictionary, updated the necessary tests, and checked that all the tests passed.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.