### PR TITLE
INGK-864 Add TEST_BOOLEAN register manually

### DIFF
--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -13,7 +13,7 @@ TEST_PORT = 82
 server = VirtualDrive(TEST_PORT)
 
 
-@pytest.fixture(autouse=True, scope="function")
+@pytest.fixture(scope="function")
 def stop_virtual_drive():
     yield
     server.stop()
@@ -221,6 +221,7 @@ def test_register_mapped_address(subnode, address, mapped_address_eth, mapped_ad
         (True, True),
     ],
 )
+@pytest.mark.usefixtures("stop_virtual_drive")
 @pytest.mark.no_connection
 def test_bit_register(connect_virtual_drive_with_bool_register, write_value, expected_read_value):
     dictionary = os.path.join("virtual_drive/resources/", "virtual_drive.xdf")
@@ -236,6 +237,7 @@ def test_bit_register(connect_virtual_drive_with_bool_register, write_value, exp
     [2, "one"],
 )
 @pytest.mark.no_connection
+@pytest.mark.usefixtures("stop_virtual_drive")
 def test_bit_register_write_invalid_value(connect_virtual_drive_with_bool_register, write_value):
     dictionary = os.path.join("virtual_drive/resources/", "virtual_drive.xdf")
     servo, _ = connect_virtual_drive_with_bool_register(dictionary)

--- a/virtual_drive/resources/virtual_drive.xdf
+++ b/virtual_drive/resources/virtual_drive.xdf
@@ -2868,11 +2868,6 @@
             <Label lang="en_US">User over voltage level</Label>
           </Labels>
         </Register>
-        <Register access="rw" address_type="NVM_NONE" address="0x0200" dtype="bool" id="TEST_BOOLEAN" units="-" subnode="1" cyclic="CONFIG" desc="Boolean register for testing purposes" cat_id="Others">
-          <Labels>
-            <Label lang="en_US">Test boolean</Label>
-          </Labels>
-        </Register>
 		<Register access="rw" address_type="NVM_CFG" address="0x0631" dtype="float" id="DRV_PROT_USER_UNDER_VOLT" units="V" subnode="1" cyclic="CONFIG" desc="Indicates the minimum voltage required by the user for a proper operation" cat_id="PROTECTIONS">
           <Labels>
             <Label lang="en_US">User under voltage level</Label>


### PR DESCRIPTION
## Add TEST_BOOLEAN register manually 

### Description

In this PR the TEST_BOOLEAN is removed from the virtual drive dictionary and is added manually in the tests.

Fixes # INGK-864

### Type of change

Please add a description and delete options that are not relevant.

- [x] Remove TEST_BOOLEAN from virtual drive diccionary.
- [x] Update tests to add this register manually.

### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.