### PR TITLE
INGK-865 Add method to set the PDO watchdog timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support to socketcan so the canopen communication can be used in Linux.
 - Default value and description attributes to registers.
 - Read/write functionalities for bit register type.
+- Method to set the PDO watchdog time.
 
 ### Changed
 - Dictionary class properties, such as subnodes and interface.

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -53,6 +53,9 @@ class EthercatServo(PDOServo):
     TIMEOUT_WORKING_COUNTER = -5
     NOFRAME_WORKING_COUNTER = -1
 
+    ETHERCAT_PDO_WATCHDOG = "processdata"
+    SECONDS_TO_MS_CONVERSION_FACTOR = 1000
+
     interface = Interface.ECAT
 
     def __init__(
@@ -244,6 +247,17 @@ class EthercatServo(PDOServo):
         if output is None:
             return
         self.__slave.output = self._process_rpdo()
+
+    def set_pdo_watchdog_time(self, timeout: float) -> None:
+        """Set the process data watchdog time.
+
+        Args:
+            timeout: Time in seconds.
+
+        """
+        self.slave.set_watchdog(
+            self.ETHERCAT_PDO_WATCHDOG, self.SECONDS_TO_MS_CONVERSION_FACTOR * timeout
+        )
 
     @property
     def slave(self) -> "CdefSlave":


### PR DESCRIPTION
### Description

Add a method to set the PDO watchdog timeout

Fixes # INGK-865

### Type of change

- Add the set_pdo_watchdog_time method

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.