### PR TITLE
INGK-873 Set the RPDOMap values by byte string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- Set RPDOMap values by byte string.
+
 ## [7.3.0] - 2024-04-23
 
 ### Add

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -310,6 +310,28 @@ class PDOMap:
             map_bytes += pdo_map_item.register_mapping
         return map_bytes
 
+    def set_item_bytes(self, data_bytes: bytes) -> None:
+        """Set the items raw data from a byte array received from the slave.
+
+        Args:
+            data_bytes: Byte array received from the slave.
+
+        Raises:
+            ILError: If the length of the received data does not coincide.
+        """
+        if len(data_bytes) != self.data_length_bytes:
+            raise ILError(
+                f"The length of the data array is incorrect. Expected {self.data_length_bytes},"
+                f" obtained {len(data_bytes)}"
+            )
+        data_bits = bitarray.bitarray(endian=BIT_ENDIAN)
+        data_bits.frombytes(data_bytes)
+
+        offset = 0
+        for item in self.items:
+            item.raw_data_bits = data_bits[offset : item.size_bits + offset]
+            offset += item.size_bits
+
 
 class RPDOMap(PDOMap):
     """Class to store RPDO mapping information."""
@@ -358,28 +380,6 @@ class TPDOMap(PDOMap):
     """Class to store TPDO mapping information."""
 
     _PDO_MAP_ITEM_CLASS = TPDOMapItem
-
-    def set_item_bytes(self, data_bytes: bytes) -> None:
-        """Set the items raw data from a byte array received from the slave.
-
-        Args:
-            data_bytes: Byte array received from the slave.
-
-        Raises:
-            ILError: If the length of the received data does not coincide.
-        """
-        if len(data_bytes) != self.data_length_bytes:
-            raise ILError(
-                f"The length of the data array is incorrect. Expected {self.data_length_bytes},"
-                f" obtained {len(data_bytes)}"
-            )
-        data_bits = bitarray.bitarray(endian=BIT_ENDIAN)
-        data_bits.frombytes(data_bytes)
-
-        offset = 0
-        for item in self.items:
-            item.raw_data_bits = data_bits[offset : item.size_bits + offset]
-            offset += item.size_bits
 
 
 class PDOServo(Servo):

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -311,10 +311,10 @@ class PDOMap:
         return map_bytes
 
     def set_item_bytes(self, data_bytes: bytes) -> None:
-        """Set the items raw data from a byte array received from the slave.
+        """Set the items raw data from a byte array.
 
         Args:
-            data_bytes: Byte array received from the slave.
+            data_bytes: Byte array.
 
         Raises:
             ILError: If the length of the received data does not coincide.
@@ -332,14 +332,8 @@ class PDOMap:
             item.raw_data_bits = data_bits[offset : item.size_bits + offset]
             offset += item.size_bits
 
-
-class RPDOMap(PDOMap):
-    """Class to store RPDO mapping information."""
-
-    _PDO_MAP_ITEM_CLASS = RPDOMapItem
-
     def get_item_bits(self) -> bitarray.bitarray:
-        """Return the concatenated items raw data to be sent to the slave (in bits).
+        """Return the concatenated items raw data (in bits).
 
         Raises:
             ILError: Raw data is empty.
@@ -363,7 +357,7 @@ class RPDOMap(PDOMap):
         return data_bits
 
     def get_item_bytes(self) -> bytes:
-        """Return the concatenated items raw data to be sent to the slave (in bytes).
+        """Return the concatenated items raw data (in bytes).
 
         Raises:
             ILError: Raw data is empty.
@@ -374,6 +368,12 @@ class RPDOMap(PDOMap):
         """
         item_bits = self.get_item_bits()
         return item_bits.tobytes()
+
+
+class RPDOMap(PDOMap):
+    """Class to store RPDO mapping information."""
+
+    _PDO_MAP_ITEM_CLASS = RPDOMapItem
 
 
 class TPDOMap(PDOMap):

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -578,3 +578,25 @@ def test_remove_tpdo_map_exceptions(connect_to_slave, create_pdo_map):
         servo.remove_tpdo_map(rpdo_map)
     with pytest.raises(IndexError):
         servo.remove_tpdo_map(tpdo_map_index=1)
+
+
+@pytest.mark.no_connection
+def test_rpdo_map_set_items_bytes(create_pdo_map):
+    _, rpdo_map = create_pdo_map
+    data_bytes = bytes()
+    for idx, item in enumerate(rpdo_map.items):
+        data_bytes += convert_dtype_to_bytes(idx, item.register.dtype)
+    rpdo_map.set_item_bytes(data_bytes)
+    for idx, item in enumerate(rpdo_map.items):
+        assert item.value == idx
+
+
+@pytest.mark.no_connection
+def test_tpdo_map_set_items_bytes(create_pdo_map):
+    tpdo_map, _ = create_pdo_map
+    data_bytes = bytes()
+    for idx, item in enumerate(tpdo_map.items):
+        data_bytes += convert_dtype_to_bytes(idx, item.register.dtype)
+    tpdo_map.set_item_bytes(data_bytes)
+    for idx, item in enumerate(tpdo_map.items):
+        assert item.value == idx


### PR DESCRIPTION
### Description

Set the RPDOMap values by byte string. 

Fixes # INGK-873

### Type of change

- [x] Move the set_item_bytes method to the base PDOMap class.
- [x] Add tests.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.