### PR TITLE
INGK-874 Fix FoE when there are blank spaces in the bin path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [7.3.1]
+
+### Fixed
+- Bug that when the path to the FoE binary has blank spaces.
+
 ## [7.3.0] - 2024-04-23
 
 ### Add

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,28 +1,24 @@
-from .network import NET_PROT, NET_STATE, NET_DEV_EVT, NET_TRANS_PROT, Network, EEPROM_FILE_FORMAT
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY
 from ingenialink.enums.servo import (
-    SERVO_STATE,
     SERVO_FLAGS,
     SERVO_MODE,
-    SERVO_UNITS_TORQUE,
-    SERVO_UNITS_POS,
-    SERVO_UNITS_VEL,
+    SERVO_STATE,
     SERVO_UNITS_ACC,
+    SERVO_UNITS_POS,
+    SERVO_UNITS_TORQUE,
+    SERVO_UNITS_VEL,
 )
+from ingenialink.poller import Poller
 from ingenialink.servo import Servo
 
+from .canopen.dictionary import CanopenDictionaryV2
+from .canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from .canopen.register import CanopenRegister
+from .canopen.servo import CanopenServo
+from .ethercat.network import EthercatNetwork
 from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
-
-from .ethercat.network import EthercatNetwork
-
-from .canopen.servo import CanopenServo
-from .canopen.network import CanopenNetwork, CAN_DEVICE, CAN_DEVICE, CAN_BAUDRATE
-from .canopen.register import CanopenRegister
-from .canopen.dictionary import CanopenDictionaryV2
-
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY
-
-from ingenialink.poller import Poller
+from .network import EEPROM_FILE_FORMAT, NET_DEV_EVT, NET_PROT, NET_STATE, NET_TRANS_PROT, Network
 
 __all__ = [
     "EEPROM_FILE_FORMAT",
@@ -54,4 +50,4 @@ __all__ = [
     "CanopenDictionaryV2",
 ]
 
-__version__ = "7.3.0"
+__version__ = "7.3.1"

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -450,12 +450,20 @@ class EthercatNetwork(Network):
             except subprocess.CalledProcessError as e:
                 raise ILFirmwareLoadError("Could not change the FoE binary permissions.") from e
         try:
-            subprocess.run(
-                f"{exec_path} {self.interface_name} {slave_id} {fw_file}",
-                check=True,
-                shell=True,
-                encoding="utf-8",
-            )
+            if sys_name == "linux":
+                subprocess.run(
+                    f"{exec_path} {self.interface_name} {slave_id} {fw_file}",
+                    check=True,
+                    shell=True,
+                    encoding="utf-8",
+                )
+            else:
+                subprocess.run(
+                    [exec_path, self.interface_name, f"{slave_id}", fw_file],
+                    check=True,
+                    shell=True,
+                    encoding="utf-8",
+                )
         except subprocess.CalledProcessError as e:
             foe_return_error = self.FOE_ERRORS.get(e.returncode, self.UNKNOWN_FOE_ERROR)
             raise ILFirmwareLoadError(


### PR DESCRIPTION
## Fix FoE when there are blank spaces in the bin path

### Description

This PR fixes the bug when there are spaces in the path to FoE binary in Windows.

Fixes # INGK-874 

### Type of change

- [x] Back to the previous way to pass the attributes to the FoE binary in Windows.

### Tests
- [x] Test it in ML3.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [ ] Set fix version field in the Jira issue.
