### PR TITLE
INGK-875 Sort imports

### DIFF
--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,28 +1,31 @@
-from .network import NET_PROT, NET_STATE, NET_DEV_EVT, NET_TRANS_PROT, Network, EEPROM_FILE_FORMAT
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY
 from ingenialink.enums.servo import (
-    SERVO_STATE,
     SERVO_FLAGS,
     SERVO_MODE,
-    SERVO_UNITS_TORQUE,
-    SERVO_UNITS_POS,
-    SERVO_UNITS_VEL,
+    SERVO_STATE,
     SERVO_UNITS_ACC,
+    SERVO_UNITS_POS,
+    SERVO_UNITS_TORQUE,
+    SERVO_UNITS_VEL,
 )
+from ingenialink.poller import Poller
 from ingenialink.servo import Servo
 
+from .canopen.dictionary import CanopenDictionaryV2
+from .canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from .canopen.register import CanopenRegister
+from .canopen.servo import CanopenServo
+from .ethercat.network import EthercatNetwork
 from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
-
-from .ethercat.network import EthercatNetwork
-
-from .canopen.servo import CanopenServo
-from .canopen.network import CanopenNetwork, CAN_DEVICE, CAN_DEVICE, CAN_BAUDRATE
-from .canopen.register import CanopenRegister
-from .canopen.dictionary import CanopenDictionaryV2
-
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, REG_PHY
-
-from ingenialink.poller import Poller
+from .network import (
+    EEPROM_FILE_FORMAT,
+    NET_DEV_EVT,
+    NET_PROT,
+    NET_STATE,
+    NET_TRANS_PROT,
+    Network,
+)
 
 __all__ = [
     "EEPROM_FILE_FORMAT",

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,10 +1,15 @@
-from typing import Optional, List
-
-from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.canopen.register import CanopenRegister, REG_DTYPE, REG_ACCESS, RegCyclicType
+import xml.etree.ElementTree as ET
+from typing import List, Optional
 
 import ingenialogger
-import xml.etree.ElementTree as ET
+
+from ingenialink.canopen.register import (
+    REG_ACCESS,
+    REG_DTYPE,
+    CanopenRegister,
+    RegCyclicType,
+)
+from ingenialink.dictionary import DictionaryV2, Interface
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -13,7 +13,6 @@ import canopen
 import ingenialogger
 from can import CanError
 
-
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.canopen.servo import (
     CANOPEN_SDO_RESPONSE_TIMEOUT,
@@ -24,7 +23,7 @@ from ingenialink.canopen.servo import (
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILObjectNotExist
 from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
-from ingenialink.utils._utils import convert_bytes_to_dtype, DisableLogger
+from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
 
 if platform.system() == "Windows":

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -4,10 +4,10 @@ import canopen
 import ingenialogger
 from canopen.emcy import EmcyConsumer
 
-from ingenialink.dictionary import Interface
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.constants import CAN_MAX_WRITE_SIZE
+from ingenialink.dictionary import Interface
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
 from ingenialink.exceptions import ILIOError
 from ingenialink.register import Register

--- a/ingenialink/constants.py
+++ b/ingenialink/constants.py
@@ -1,6 +1,5 @@
 from ingenialink.register import REG_DTYPE
 
-
 DIST_FRAME_SIZE_BYTES = 128
 DIST_FRAME_SIZE = 512
 

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -7,11 +7,17 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import ingenialogger
 
-from ingenialink.exceptions import ILDictionaryParseError
-from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, Register, RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
+from ingenialink.ethernet.register import EthernetRegister
+from ingenialink.exceptions import ILDictionaryParseError
+from ingenialink.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    RegCyclicType,
+    Register,
+)
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -1,20 +1,20 @@
-from typing import Optional, List
 import xml.etree.ElementTree as ET
+from typing import List, Optional
 
 import ingenialogger
 
-from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethercat.register import (
-    EthercatRegister,
-    REG_DTYPE,
-    REG_ACCESS,
-    REG_ADDRESS_TYPE,
-    RegCyclicType,
-)
 from ingenialink.constants import (
     CANOPEN_ADDRESS_OFFSET,
     CANOPEN_SUBNODE_0_ADDRESS_OFFSET,
     MAP_ADDRESS_OFFSET,
+)
+from ingenialink.dictionary import DictionaryV2, Interface
+from ingenialink.ethercat.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    EthercatRegister,
+    RegCyclicType,
 )
 
 logger = ingenialogger.get_logger(__name__)

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -22,7 +22,12 @@ if TYPE_CHECKING:
 
 from ingenialink import bin as bin_module
 from ingenialink.ethercat.servo import EthercatServo
-from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILStateError, ILWrongWorkingCount
+from ingenialink.exceptions import (
+    ILError,
+    ILFirmwareLoadError,
+    ILStateError,
+    ILWrongWorkingCount,
+)
 from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -1,6 +1,6 @@
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, List, Optional, Dict, Any
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 import ingenialogger
 
@@ -13,12 +13,16 @@ except ImportError as ex:
 if TYPE_CHECKING:
     from pysoem import CdefSlave
 
-from ingenialink.constants import CAN_MAX_WRITE_SIZE, CANOPEN_ADDRESS_OFFSET, MAP_ADDRESS_OFFSET
+from ingenialink.constants import (
+    CAN_MAX_WRITE_SIZE,
+    CANOPEN_ADDRESS_OFFSET,
+    MAP_ADDRESS_OFFSET,
+)
+from ingenialink.dictionary import Interface
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.exceptions import ILIOError, ILTimeoutError, ILError
+from ingenialink.exceptions import ILError, ILIOError, ILTimeoutError
 from ingenialink.pdo import PDOServo, RPDOMap, TPDOMap
 from ingenialink.register import REG_ACCESS, REG_DTYPE
-from ingenialink.dictionary import Interface
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -1,10 +1,15 @@
-from typing import Optional, Dict, List
 import xml.etree.ElementTree as ET
+from typing import Dict, List, Optional
 
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import EthernetRegister, REG_DTYPE, REG_ACCESS, RegCyclicType
+from ingenialink.ethernet.register import (
+    REG_ACCESS,
+    REG_DTYPE,
+    EthernetRegister,
+    RegCyclicType,
+)
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/ethernet/servo.py
+++ b/ingenialink/ethernet/servo.py
@@ -2,19 +2,28 @@ import ipaddress
 import socket
 from typing import Optional
 
-from ingenialink.dictionary import Interface
-from ingenialink.exceptions import ILError, ILTimeoutError, ILIOError, ILWrongRegisterError
-from ingenialink.constants import PASSWORD_STORE_RESTORE_TCP_IP
-from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.constants import MCB_CMD_READ, MCB_CMD_WRITE, ETH_MAX_WRITE_SIZE, ETH_BUF_SIZE
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS
-from ingenialink.servo import Servo
-from ingenialink.utils.mcb import MCB
-from ingenialink.utils._utils import convert_ip_to_int
-
-from ingenialink.ethernet.dictionary import EthernetDictionaryV2
-
 import ingenialogger
+
+from ingenialink.constants import (
+    ETH_BUF_SIZE,
+    ETH_MAX_WRITE_SIZE,
+    MCB_CMD_READ,
+    MCB_CMD_WRITE,
+    PASSWORD_STORE_RESTORE_TCP_IP,
+)
+from ingenialink.dictionary import Interface
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.ethernet.dictionary import EthernetDictionaryV2
+from ingenialink.ethernet.register import EthernetRegister
+from ingenialink.exceptions import (
+    ILError,
+    ILIOError,
+    ILTimeoutError,
+    ILWrongRegisterError,
+)
+from ingenialink.servo import Servo
+from ingenialink.utils._utils import convert_ip_to_int
+from ingenialink.utils.mcb import MCB
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -1,9 +1,9 @@
-from typing import List, Optional, Union, Dict
+from typing import Dict, List, Optional, Union
 
 import bitarray
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_DTYPE, REG_ACCESS, RegCyclicType
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, RegCyclicType
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILError
 from ingenialink.servo import Servo

--- a/ingenialink/poller.py
+++ b/ingenialink/poller.py
@@ -1,18 +1,18 @@
 from datetime import datetime
-from threading import Timer, Lock
-from typing import List, Dict, Tuple, Union, Callable, Optional, Any
+from threading import Lock, Timer
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import ingenialogger
 
 from ingenialink.exceptions import (
     ILAlreadyInitializedError,
     ILIOError,
     ILStateError,
-    ILValueError,
     ILTimeoutError,
+    ILValueError,
 )
-from ingenialink.servo import Servo
 from ingenialink.register import Register
-
-import ingenialogger
+from ingenialink.servo import Servo
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -9,10 +9,7 @@ from xml.dom import minidom
 
 import ingenialogger
 
-from ingenialink.ethernet.dictionary import EthernetDictionaryV2
-from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
-from ingenialink.virtual.dictionary import VirtualDictionary
 from ingenialink.constants import (
     DEFAULT_DRIVE_NAME,
     DEFAULT_PDS_TIMEOUT,
@@ -21,18 +18,20 @@ from ingenialink.constants import (
     PASSWORD_STORE_ALL,
     PASSWORD_STORE_RESTORE_SUB_0,
 )
-from ingenialink.dictionary import Dictionary, SubnodeType, Interface, DictionaryV3
+from ingenialink.dictionary import Dictionary, DictionaryV3, Interface, SubnodeType
 from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
 from ingenialink.enums.servo import SERVO_STATE
+from ingenialink.ethercat.dictionary import EthercatDictionaryV2
+from ingenialink.ethernet.dictionary import EthernetDictionaryV2
 from ingenialink.exceptions import (
     ILAccessError,
+    ILDictionaryParseError,
     ILError,
     ILIOError,
     ILRegisterNotFoundError,
     ILStateError,
     ILTimeoutError,
     ILValueError,
-    ILDictionaryParseError,
 )
 from ingenialink.register import Register
 from ingenialink.utils import constants
@@ -41,6 +40,7 @@ from ingenialink.utils._utils import (
     convert_dtype_to_bytes,
     get_drive_identification,
 )
+from ingenialink.virtual.dictionary import VirtualDictionary
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/utils/mcb.py
+++ b/ingenialink/utils/mcb.py
@@ -1,10 +1,10 @@
+import io
 import struct
 from binascii import crc_hqx
-import io
 from typing import Optional, Tuple, Type, TypeVar
 
-from ingenialink.exceptions import ILWrongCRCError, ILNACKError, ILWrongRegisterError
 from ingenialink.constants import MCB_CMD_ACK
+from ingenialink.exceptions import ILNACKError, ILWrongCRCError, ILWrongRegisterError
 
 T = TypeVar("T", bound="MCB")
 

--- a/ingenialink/utils/udp.py
+++ b/ingenialink/utils/udp.py
@@ -1,10 +1,10 @@
+import binascii
 import socket
 import struct
-import binascii
-
-from ..exceptions import *
 
 import ingenialogger
+
+from ..exceptions import *
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/tests/canopen/test_canopen_dictionary_v2.py
+++ b/tests/canopen/test_canopen_dictionary_v2.py
@@ -1,9 +1,9 @@
-import pytest
 from os.path import join as join_path
 
-from ingenialink.dictionary import Interface, SubnodeType
-from ingenialink.canopen.dictionary import CanopenDictionaryV2
+import pytest
 
+from ingenialink.canopen.dictionary import CanopenDictionaryV2
+from ingenialink.dictionary import Interface, SubnodeType
 
 path_resources = "./tests/resources/canopen/"
 SINGLE_AXIS_BASE_SUBNODES = {0: SubnodeType.COMMUNICATION, 1: SubnodeType.MOTION}

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -1,9 +1,10 @@
-import pytest
 from os.path import join as join_path
 
-from ingenialink.exceptions import ILDictionaryParseError
+import pytest
+
 from ingenialink import CanopenRegister
-from ingenialink.dictionary import Interface, SubnodeType, DictionaryV3
+from ingenialink.dictionary import DictionaryV3, Interface, SubnodeType
+from ingenialink.exceptions import ILDictionaryParseError
 
 path_resources = "./tests/resources/canopen/"
 dict_can_v3 = "test_dict_can_v3.0.xdf"

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -2,7 +2,12 @@ import platform
 
 import pytest
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, NET_STATE, CanopenNetwork
+from ingenialink.canopen.network import (
+    CAN_BAUDRATE,
+    CAN_DEVICE,
+    NET_STATE,
+    CanopenNetwork,
+)
 from ingenialink.dictionary import Interface
 from ingenialink.exceptions import ILError
 from ingenialink.servo import DictionaryFactory

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ingenialink.dictionary import Dictionary
 from ingenialink.canopen.register import (
     REG_ACCESS,
     REG_ADDRESS_TYPE,
@@ -9,6 +8,7 @@ from ingenialink.canopen.register import (
     CanopenRegister,
     RegCyclicType,
 )
+from ingenialink.dictionary import Dictionary
 
 
 @pytest.mark.no_connection

--- a/tests/canopen/test_canopen_servo.py
+++ b/tests/canopen/test_canopen_servo.py
@@ -1,5 +1,4 @@
 import pytest
-
 from canopen.network import RemoteNode
 
 

--- a/tests/eoe/test_eoe_dictionary_v3.py
+++ b/tests/eoe/test_eoe_dictionary_v3.py
@@ -1,7 +1,8 @@
-import pytest
 from os.path import join as join_path
 
-from ingenialink.dictionary import Interface, SubnodeType, DictionaryV3
+import pytest
+
+from ingenialink.dictionary import DictionaryV3, Interface, SubnodeType
 
 path_resources = "./tests/resources/"
 dict_eoe_v3 = "test_dict_ecat_eoe_v3.0.xdf"

--- a/tests/eoe/test_eoe_network.py
+++ b/tests/eoe/test_eoe_network.py
@@ -1,10 +1,11 @@
-import pytest
-import socket
 import ipaddress
+import socket
 
-from ingenialink.ethernet.servo import EthernetServo
+import pytest
+
+from ingenialink.eoe.network import EoECommand, EoENetwork
 from ingenialink.ethernet.network import NET_PROT
-from ingenialink.eoe.network import EoENetwork, EoECommand
+from ingenialink.ethernet.servo import EthernetServo
 
 
 @pytest.fixture()

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -1,9 +1,15 @@
-import pytest
 from os.path import join as join_path
 
-from ingenialink.exceptions import ILDictionaryParseError
+import pytest
+
 from ingenialink import CanopenRegister
-from ingenialink.dictionary import Interface, SubnodeType, DictionaryV3, DictionarySafetyPDO
+from ingenialink.dictionary import (
+    DictionarySafetyPDO,
+    DictionaryV3,
+    Interface,
+    SubnodeType,
+)
+from ingenialink.exceptions import ILDictionaryParseError
 
 path_resources = "./tests/resources/"
 dict_ecat_v3 = "test_dict_ecat_eoe_v3.0.xdf"

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -5,9 +5,9 @@ except ImportError:
 import pytest
 
 from ingenialink.dictionary import Interface
-from ingenialink.servo import DictionaryFactory
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
+from ingenialink.servo import DictionaryFactory
 
 
 @pytest.mark.docker

--- a/tests/ethernet/test_ethernet_dictionary_v2.py
+++ b/tests/ethernet/test_ethernet_dictionary_v2.py
@@ -1,9 +1,9 @@
-import pytest
 from os.path import join as join_path
+
+import pytest
 
 from ingenialink.dictionary import Interface, SubnodeType
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
-
 
 path_resources = "./tests/resources/ethernet/"
 SINGLE_AXIS_BASE_SUBNODES = {0: SubnodeType.COMMUNICATION, 1: SubnodeType.MOTION}

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -4,7 +4,12 @@ import time
 
 import pytest
 
-from ingenialink.ethernet.network import NET_DEV_EVT, NET_PROT, NET_STATE, EthernetNetwork
+from ingenialink.ethernet.network import (
+    NET_DEV_EVT,
+    NET_PROT,
+    NET_STATE,
+    EthernetNetwork,
+)
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,7 +1,13 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY, dtypes_ranges
+from ingenialink.register import (
+    REG_ACCESS,
+    REG_ADDRESS_TYPE,
+    REG_DTYPE,
+    REG_PHY,
+    dtypes_ranges,
+)
 
 
 @pytest.mark.no_connection

--- a/tests/resources/Scripts/load_FWs.py
+++ b/tests/resources/Scripts/load_FWs.py
@@ -1,16 +1,16 @@
+import argparse
+import json
 import os
 import time
-import json
-import argparse
-import ingenialogger
-from ping3 import ping
 from functools import partial
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE
-from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.canopen.network import CanopenNetwork
+import ingenialogger
+from ping3 import ping
+
+from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
+from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 logger = ingenialogger.get_logger("load_FWs")
 ingenialogger.configure_logger(level=ingenialogger.LoggingLevel.INFO)

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -6,10 +6,10 @@ from xml.dom import minidom
 
 import pytest
 
-from ingenialink.dictionary import Interface, DictionaryV3
+from ingenialink.canopen.dictionary import CanopenDictionaryV2
+from ingenialink.dictionary import DictionaryV3, Interface
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
-from ingenialink.canopen.dictionary import CanopenDictionaryV2
 from ingenialink.servo import DictionaryFactory
 
 PATH_RESOURCE = "./tests/resources/"

--- a/tests/test_mcb.py
+++ b/tests/test_mcb.py
@@ -1,10 +1,10 @@
 import pytest
 
-from ingenialink.ethernet.register import REG_DTYPE
-from ingenialink.utils._utils import convert_dtype_to_bytes, convert_bytes_to_dtype
-from ingenialink.utils.mcb import MCB
 from ingenialink.constants import MCB_CMD_READ, MCB_CMD_WRITE
-from ingenialink.exceptions import ILWrongCRCError, ILNACKError, ILWrongRegisterError
+from ingenialink.ethernet.register import REG_DTYPE
+from ingenialink.exceptions import ILNACKError, ILWrongCRCError, ILWrongRegisterError
+from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_bytes
+from ingenialink.utils.mcb import MCB
 
 
 @pytest.mark.no_connection

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ingenialink.exceptions import ILValueError
 from ingenialink.enums.register import REG_DTYPE
+from ingenialink.exceptions import ILValueError
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
 


### PR DESCRIPTION
### Description

Sort imports using the isort library.

Fixes # INGK-875

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
