### PR TITLE
INGK-877 Fix the interface attribute in the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Bug that when the path to the FoE binary has blank spaces.
+- The Interface attribute format in the configuration file.
 
 ## [7.3.0] - 2024-04-23
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -206,6 +206,9 @@ class Servo:
     DISTURBANCE_ADD_REGISTERS_OLD = "DIST_CMD_ADD_REG"
     MONITORING_ADD_REGISTERS_OLD = "MON_OP_ADD_REG"
 
+    DICTIONARY_INTERFACE_ATTR_CAN = "CAN"
+    DICTIONARY_INTERFACE_ATTR_ETH = "ETH"
+
     interface: Interface
 
     def __init__(
@@ -336,8 +339,12 @@ class Servo:
         body = ET.SubElement(tree, "Body")
         device = ET.SubElement(body, "Device")
         registers = ET.SubElement(device, "Registers")
-
-        device.set("Interface", str(self.dictionary.interface))
+        interface = (
+            self.DICTIONARY_INTERFACE_ATTR_CAN
+            if self.dictionary.interface == Interface.CAN
+            else self.DICTIONARY_INTERFACE_ATTR_ETH
+        )
+        device.set("Interface", interface)
         if self.dictionary.part_number is not None:
             device.set("PartNumber", self.dictionary.part_number)
         device.set("ProductCode", str(prod_code))


### PR DESCRIPTION
### Description

Match the interface attribute from the servo dictionary in the configuration file.

Fixes # INGK-877

### Type of change

-  Fix the interface attribute in the configuration file.

### Tests
- Connect to a drive.
- Save the configuration file.
- Check that the Interface attribute in the configuration file matches the one in the dictionary file.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
