### PR TITLE
INGK-878 Store newly created node object

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -429,8 +429,8 @@ class CanopenNetwork(Network):
                 bustype=self.__device, channel=self.__channel, bitrate=self.__baudrate
             )
             for servo in self.servos:
-                node = self._connection.add_node(servo.target)
-                node.nmt.start_node_guarding(1)
+                servo.node = self._connection.add_node(servo.target)
+                servo.node.nmt.start_node_guarding(1)
         except BaseException as e:
             logger.error("Connection failed. Exception: %s", e)
 

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -151,3 +151,8 @@ class CanopenServo(Servo):
     def node(self) -> canopen.RemoteNode:
         """Remote node of the servo."""
         return self.__node
+
+    @node.setter
+    def node(self, node: canopen.RemoteNode) -> None:
+        """Remote node of the servo."""
+        self.__node = node


### PR DESCRIPTION
### Description

The CANopen connection does not work after a power cycle.

Fixes #  INGK-878

### Type of change

- Update the node object of the servo instance after a reconnection.

### Tests
Test 1
- Connect to a drive via ML3
- Open the display widget
- Check that the values are being read.
- Turn the power supply off
- Check that the drive is disconnected
- Turn the power supply on
- Check that the drive is reconnected
- Open the display widget
- Check that the values are being read.

Test 2
- Connect to a drive via ML3
- Open the display widget
- Check that the values are being read.
- Disconnect the transceiver
- Check that the drive is disconnected
- Connect the transceiver
- Check that the drive is reconnected
- Open the display widget
- Check that the values are being read.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
