### PR TITLE
INGK-882 Autoscan with ixxat transciever connected raises an exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Bug that when the path to the FoE binary has blank spaces.
 - The Interface attribute format in the configuration file.
 - CANopen communication re-establishment after a power cycle.
+- Exception when scanning drives using an IXXAT tranceiver.
 
 ## [7.3.0] - 2024-04-23
 

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -224,8 +224,9 @@ class CanopenNetwork(Network):
         is_connection_created = False
         if self._connection is None:
             is_connection_created = True
+            scan_with_ixxat = self.__device == CAN_DEVICE.IXXAT.value
             try:
-                self._setup_connection()
+                self._setup_connection(scan_with_ixxat)
             except ILError:
                 self._teardown_connection()
                 return []
@@ -360,9 +361,15 @@ class CanopenNetwork(Network):
         if not self.servos:
             self._teardown_connection()
 
-    def _setup_connection(self) -> None:
+    def _setup_connection(self, scan_with_ixxat: bool = False) -> None:
         """Creates a network interface object establishing an empty connection
-        with all the network attributes already specified."""
+        with all the network attributes already specified.
+
+        Args:
+            scan_with_ixxat: If the connection will only be used to scan drives using
+             an IXXAT tranceiver.
+
+        """
         if self._connection is None:
             self._connection = canopen.Network()
             connection_args = {
@@ -372,6 +379,8 @@ class CanopenNetwork(Network):
             }
             if self.__device == CAN_DEVICE.PCAN.value:
                 connection_args["auto_reset"] = True
+            if scan_with_ixxat:
+                connection_args["fd"] = True
             try:
                 self._connection.connect(**connection_args)
             except CanError as e:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -455,7 +455,7 @@ class CanopenNetwork(Network):
             "bitrate": self.__baudrate,
         }
         if self.__device == CAN_DEVICE.IXXAT.value:
-            connection_args["fd"] = True
+            self._connection.listeners.append(CustomIXXATListener())
         try:
             self._connection.connect(**connection_args)
             for servo in self.servos:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -187,6 +187,7 @@ class CanopenNetwork(Network):
     DRIVE_INFO_INDEX = 0x1018
     PRODUCT_CODE_SUB_IX = 2
     REVISION_NUMBER_SUB_IX = 3
+    NODE_GUARDING_PERIOD_S = 1
 
     def __init__(
         self,
@@ -326,7 +327,7 @@ class CanopenNetwork(Network):
             try:
                 node = self._connection.add_node(target)
 
-                node.nmt.start_node_guarding(1)
+                node.nmt.start_node_guarding(self.NODE_GUARDING_PERIOD_S)
 
                 servo = CanopenServo(
                     target, node, dictionary, servo_status_listener=servo_status_listener
@@ -439,7 +440,7 @@ class CanopenNetwork(Network):
             self._connection.connect(**connection_args)
             for servo in self.servos:
                 servo.node = self._connection.add_node(servo.target)
-                servo.node.nmt.start_node_guarding(1)
+                servo.node.nmt.start_node_guarding(self.NODE_GUARDING_PERIOD_S)
         except BaseException as e:
             logger.error(f"Connection failed. Exception: {e}")
 
@@ -960,7 +961,7 @@ class CanopenNetwork(Network):
         # Reset all nodes to default state
         self._connection.lss.send_switch_state_global(self._connection.lss.WAITING_STATE)
 
-        self._connection.nodes[target_node].nmt.start_node_guarding(1)
+        self._connection.nodes[target_node].nmt.start_node_guarding(self.NODE_GUARDING_PERIOD_S)
 
     def subscribe_to_status(self, node_id: int, callback: Callable[[NET_DEV_EVT], Any]) -> None:  # type: ignore [override]
         """Subscribe to network state changes.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -379,20 +379,21 @@ class CanopenNetwork(Network):
             try:
                 self._connection.connect(**connection_args)
             except CanError as e:
-                logger.error("Transceiver not found in network. Exception: %s", e)
+                logger.error(f"Transceiver not found in network. Exception: {e}")
                 raise ILError(
                     "Error connecting to the transceiver. "
                     "Please verify the transceiver "
                     "is properly connected."
                 )
             except OSError as e:
-                logger.error("Transceiver drivers not properly installed. Exception: %s", e)
+                logger.error(f"Transceiver drivers not properly installed. Exception: {e}")
                 if hasattr(e, "winerror") and e.winerror == 126:
                     e.strerror = "Driver module not found. Drivers might not be properly installed."
                 raise ILError(e)
             except Exception as e:
-                logger.error("Failed trying to connect. Exception: %s", e)
-                raise ILError("Failed trying to connect. {}".format(e))
+                error_message = f"Failed trying to connect. Exception: {e}"
+                logger.error(error_message)
+                raise ILError(error_message)
         else:
             logger.info("Connection already established")
 
@@ -417,7 +418,7 @@ class CanopenNetwork(Network):
         try:
             self._connection.disconnect()
         except BaseException as e:
-            logger.error("Disconnection failed. Exception: %", e)
+            logger.error(f"Disconnection failed. Exception: {e}")
 
         try:
             for node in self._connection.scanner.nodes:
@@ -440,7 +441,7 @@ class CanopenNetwork(Network):
                 servo.node = self._connection.add_node(servo.target)
                 servo.node.nmt.start_node_guarding(1)
         except BaseException as e:
-            logger.error("Connection failed. Exception: %s", e)
+            logger.error(f"Connection failed. Exception: {e}")
 
     def load_firmware(  # type: ignore [override]
         self,


### PR DESCRIPTION
### Description

Autoscan with IXXAT transciever connected raises an exception

Fixes # INGK-882

### Type of change

- Use the IXXAT CAN-FD implementation when scanning for drives.

### Tests

- Using an IXXAT transceiver scan for drives.
- Check that no unhandled exception occurs.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
