### PR TITLE
INGK-888 Fix virtual drive with a dictionary of an EVE canopen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Set RPDOMap values by byte string.
 
+### Fixed
+- Issue when connecting to the virtual drive using an EVE CANopen dictionary.
+
 ## [7.3.1] - 2024-05-10
 
 ### Fixed

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1255,6 +1255,8 @@ class VirtualDrive(Thread):
 
         self._init_registers()
         self._update_registers()
+        if self.is_monitoring_available:
+            self._create_monitoring_disturbance_registers()
         self._init_register_signals()
         self.__set_motor_ready_to_switch_on()
 
@@ -1404,9 +1406,8 @@ class VirtualDrive(Thread):
                 self.__reg_address_to_id[subnode][reg.address] = reg_id
                 self.__dictionary.registers(subnode)[reg_id].storage_valid = True
 
-        if not self.is_monitoring_available:
-            return
-
+    def _create_monitoring_disturbance_registers(self) -> None:
+        """Create the monitoring and disturbance data registers."""
         custom_regs = {
             "MONITORING_DATA": self.__dictionary.registers(0)[EthernetServo.MONITORING_DATA],
             "DISTURBANCE_DATA": self.__dictionary.registers(0)[EthernetServo.DIST_DATA],


### PR DESCRIPTION
## Fix virtual drive with a dictionary of an EVE canopen

### Description

This PR fixes the issue when connecting the virtual drive using an EVE canopen dictionary.

Fixes # INGK-888

### Type of change

Please add a description and delete options that are not relevant.

- [x] Do not initialize monitoring registers if monitoring data is not in the dictionary.

### Tests
- [x] Test in in ML3.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
