### PR TITLE
INGK-770 Fix ethercat tests

### DIFF
--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -68,7 +68,6 @@ def test_connect_to_slave_invalid_id(read_config, slave_id):
 
 @pytest.mark.ethercat
 def test_connect_to_slave_no_slaves_detected(read_config):
-
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     slaves = net.scan_slaves()
     slave_id = slaves[-1] + 1

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -58,24 +58,23 @@ def test_load_firmware_not_implemented_error(mocker, read_config):
         net.load_firmware("dummy_file.lfu", False)
 
 
-@pytest.mark.eoe
+@pytest.mark.ethercat
 @pytest.mark.parametrize("slave_id", [-1, "one", None])
 def test_connect_to_slave_invalid_id(read_config, slave_id):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     with pytest.raises(ValueError):
-        net.connect_to_slave(slave_id)
+        net.connect_to_slave(slave_id, read_config["ethercat"]["dictionary"])
 
 
-@pytest.mark.eoe
-def test_connect_to_slave_no_slaves_detected(mocker, read_config):
+@pytest.mark.ethercat
+def test_connect_to_slave_no_slaves_detected(read_config):
+
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
+    slaves = net.scan_slaves()
+    slave_id = slaves[-1] + 1
 
-    def scan_slaves():
-        return []
-
-    mocker.patch.object(net, "scan_slaves", scan_slaves)
     with pytest.raises(ILError):
-        net.connect_to_slave(1)
+        net.connect_to_slave(slave_id, read_config["ethercat"]["dictionary"])
 
 
 @pytest.mark.ethercat

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -67,7 +67,7 @@ def test_connect_to_slave_invalid_id(read_config, slave_id):
 
 
 @pytest.mark.ethercat
-def test_connect_to_slave_no_slaves_detected(read_config):
+def test_connect_to_no_detected_slave(read_config):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     slaves = net.scan_slaves()
     slave_id = slaves[-1] + 1


### PR DESCRIPTION
##  Fix ethercat tests

### Description

This PR fixes the ethercat tests.

Fixes # INGK-770

### Type of change

Please add a description and delete options that are not relevant.

- [x] Fix `test_connect_to_slave_invalid_id`
- [x] Fix `test_connect_to_slave_no_slaves_detected`


### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
