### PR TITLE
INGK-667 Use context manager to close firmware file

### DIFF
--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -105,43 +105,31 @@ class EthernetNetwork(Network):
         if not os.path.isfile(fw_file):
             raise FileNotFoundError(f"Could not find {fw_file}.")
 
-        try:
-            file = open(fw_file, "rb")
-            ftp_output = None
-            ftp = FTP()
-
-            # Start a FTP session. Drive must be in BOOT mode.
-            logger.info("Starting FTP session...")
-            ftp_output = ftp.connect(target)
+        # Start a FTP session. Drive must be in BOOT mode.
+        logger.info("Starting FTP session...")
+        with FTP() as ftp:
+            try:
+                ftp_output = ftp.connect(target)
+            except ConnectionError as e:
+                raise ILFirmwareLoadError("Unable to create the FTP session") from e
             logger.info(ftp_output)
             if FTP_SESSION_OK_CODE not in ftp_output:
-                raise ILError("Unable to open FTP session")
-
+                raise ILFirmwareLoadError("Unable to open the FTP session")
             # Login into FTP session.
             logger.info("Logging into FTP session...")
             ftp_output = ftp.login(ftp_user, ftp_pwd)
             logger.info(ftp_output)
             if FTP_LOGIN_OK_CODE not in ftp_output:
-                raise ILError("Unable to login the FTP session")
-
+                raise ILFirmwareLoadError("Unable to login the FTP session")
             # Load file through FTP.
             logger.info("Uploading firmware file...")
             ftp.set_pasv(False)
-            ftp_output = ftp.storbinary(f"STOR {os.path.basename(file.name)}", file)
+            with open(fw_file, "rb") as file:
+                ftp_output = ftp.storbinary(f"STOR {os.path.basename(file.name)}", file)
             logger.info(ftp_output)
             if FTP_FILE_TRANSFER_OK_CODE not in ftp_output:
-                raise ILError("Unable to load the FW file through FTP")
-
-            # Close FTP session.
-            logger.info("Closing FTP session...")
-            ftp.close()
-
-            # Close the temporal file
-            file.close()
-
-        except Exception as e:
-            logger.error(e)
-            raise ILFirmwareLoadError("Error during bootloader process.")
+                raise ILFirmwareLoadError("Unable to load the FW file through FTP")
+        logger.info("FTP session closed.")
 
     @staticmethod
     def load_firmware_moco(node: int, subnode: int, ip: str, port: int, moco_file: str) -> None:


### PR DESCRIPTION
### Description

Make sure to close the firmware file in case an exception occurs.

Fixes # INGK-667

### Type of change

- Use a context manager for opening the firmware file.
- Use a context manager for the FTP connection.


### Test

- Connect to an EVE-NET-C using ML3
- Load a firmware file using the FTP Bootloader
- Check that the firmware is loaded successfully.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
