### PR TITLE
INGK-868 Add EtherCAT connection example script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Set RPDOMap values by byte string.
+- EtherCAT connection example script.
 
 ### Changed
 - The signature of the load_firmware method of EthercatNetwork is changed to add the boot_in_app argument.

--- a/docs/examples/communication.rst
+++ b/docs/examples/communication.rst
@@ -26,3 +26,14 @@ Slave connection through Ethernet Example
 -----------------------------------------
 
 .. literalinclude:: ../../examples/ethernet/eth_connection.py
+
+Slave connection through EtherCAT Example
+-----------------------------------------
+
+.. literalinclude:: ../../examples/ethercat/ecat_connection.py
+
+In Linux, administrator privileges are needed to establish the EtherCAT connection.
+
+.. code-block:: console
+
+    sudo python3 examples/ethercat/ecat_connection.py

--- a/examples/ethercat/ecat_connection.py
+++ b/examples/ethercat/ecat_connection.py
@@ -1,0 +1,25 @@
+import platform
+
+from ingenialink.ethercat.network import EthercatNetwork
+
+
+def main():
+    # To find the network interface ID
+    # On Windows, run the command: wmic nic get name, guid
+    # On linux, run the command: ip link show
+    interface_id = ""
+    if platform.system() == "Windows":
+        interface_name = "\\Device\\NPF_" + interface_id
+    else:
+        interface_name = interface_id
+    dictionary_path = "cap-net-e_eoe_2.5.0.xdf"
+    ethercat_slave_id = 1
+    net = EthercatNetwork(interface_name)
+    servo = net.connect_to_slave(ethercat_slave_id, dictionary_path)
+    firmware_version = servo.read('DRV_ID_SOFTWARE_VERSION')
+    print(firmware_version)
+    net.disconnect_from_slave(servo)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Description

Add EtherCAT connection example script

Fixes # INGK-868

### Type of change

- Add an example connection script.

### Tests
- Run the script and check that the firmware version can be read correctly.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
