### PR TITLE
INGK-910 Fix get_drive_identification method

### DIFF
--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -504,17 +504,18 @@ class Servo:
             Product code. None if the corresponding register does not exist.
             Revision number. None if the corresponding register does not exist.
         """
-        prod_code = None
-        re_number = None
+        subnode = 0 if subnode is None else subnode
+        reg_index = 0 if subnode == 0 else 1
+        try:
+            prod_code = int(self.read(self.PRODUCT_ID_REGISTERS[reg_index], subnode=subnode))
+        except ILRegisterNotFoundError:
+            prod_code = None
+        try:
+            rev_number = int(self.read(self.REVISION_NUMBER_REGISTERS[reg_index], subnode=subnode))
+        except ILRegisterNotFoundError:
+            rev_number = None
 
-        if subnode is None or subnode == 0:
-            prod_code = int(self.read(self.PRODUCT_ID_REGISTERS[0], 0))
-            re_number = int(self.read(self.REVISION_NUMBER_REGISTERS[0], 0))
-        else:
-            prod_code = int(self.read(self.PRODUCT_ID_REGISTERS[1], subnode=subnode))
-            re_number = int(self.read(self.REVISION_NUMBER_REGISTERS[1], subnode))
-
-        return prod_code, re_number
+        return prod_code, rev_number
 
     def enable(self, subnode: int = 1, timeout: int = DEFAULT_PDS_TIMEOUT) -> None:
         """Enable PDS.

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -35,11 +35,7 @@ from ingenialink.exceptions import (
 )
 from ingenialink.register import Register
 from ingenialink.utils import constants
-from ingenialink.utils._utils import (
-    convert_bytes_to_dtype,
-    convert_dtype_to_bytes,
-    get_drive_identification,
-)
+from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_bytes
 from ingenialink.virtual.dictionary import VirtualDictionary
 
 logger = ingenialogger.get_logger(__name__)
@@ -327,7 +323,7 @@ class Servo:
         """
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
             raise ILError("Invalid subnode")
-        prod_code, rev_number = get_drive_identification(self, subnode)
+        prod_code, rev_number = self._get_drive_identification(subnode)
 
         tree = ET.Element("IngeniaDictionary")
         header = ET.SubElement(tree, "Header")
@@ -494,6 +490,31 @@ class Servo:
                 )
         finally:
             time.sleep(1.5)
+
+    def _get_drive_identification(
+        self,
+        subnode: Optional[int] = None,
+    ) -> Tuple[Optional[int], Optional[int]]:
+        """Gets the identification information of a given subnode.
+
+        Args:
+            subnode: subnode to be targeted.
+
+        Returns:
+            Product code. None if the corresponding register does not exist.
+            Revision number. None if the corresponding register does not exist.
+        """
+        prod_code = None
+        re_number = None
+
+        if subnode is None or subnode == 0:
+            prod_code = int(self.read(self.PRODUCT_ID_REGISTERS[0], 0))
+            re_number = int(self.read(self.REVISION_NUMBER_REGISTERS[0], 0))
+        else:
+            prod_code = int(self.read(self.PRODUCT_ID_REGISTERS[1], subnode=subnode))
+            re_number = int(self.read(self.REVISION_NUMBER_REGISTERS[1], subnode))
+
+        return prod_code, re_number
 
     def enable(self, subnode: int = 1, timeout: int = DEFAULT_PDS_TIMEOUT) -> None:
         """Enable PDS.

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -4,16 +4,12 @@ import struct
 import warnings
 import xml.etree.ElementTree as ET
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import ingenialogger
 
 from ingenialink.enums.register import REG_DTYPE
 from ingenialink.exceptions import ILValueError
-
-if TYPE_CHECKING:
-    from ingenialink.servo import Servo
-
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -145,33 +141,6 @@ def cleanup_register(register: ET.Element) -> None:
     pop_element(register.attrib, "address_type")
 
     register.text = ""
-
-
-def get_drive_identification(
-    servo: "Servo", subnode: Optional[int] = None
-) -> Tuple[Optional[int], Optional[int]]:
-    """Gets the identification information of a given subnode.
-
-    Args:
-        servo: Instance of the servo Class.
-        subnode: subnode to be targeted.
-
-    Returns:
-        int, Product code and revision number of the targeted subnode.
-    """
-    prod_code = None
-    re_number = None
-    try:
-        if subnode is None or subnode == 0:
-            prod_code = int(servo.read("DRV_ID_PRODUCT_CODE_COCO", 0))
-            re_number = int(servo.read("DRV_ID_REVISION_NUMBER_COCO", 0))
-        else:
-            prod_code = int(servo.read("DRV_ID_PRODUCT_CODE", subnode=subnode))
-            re_number = int(servo.read("DRV_ID_REVISION_NUMBER", subnode))
-    except Exception:
-        pass
-
-    return prod_code, re_number
 
 
 def convert_ip_to_int(ip: str) -> int:

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -11,7 +11,6 @@ from ingenialink.ethernet.register import REG_DTYPE
 from ingenialink.exceptions import ILStateError, ILTimeoutError, ILValueError
 from ingenialink.register import REG_ADDRESS_TYPE
 from ingenialink.servo import SERVO_STATE
-from ingenialink.utils._utils import get_drive_identification
 
 MONITORING_CH_DATA_SIZE = 4
 MONITORING_NUM_SAMPLES = 100
@@ -82,7 +81,7 @@ def test_save_configuration(connect_to_slave):
 
     device, saved_registers = servo._read_configuration_file(filename)
 
-    prod_code, rev_number = get_drive_identification(servo)
+    prod_code, rev_number = servo._get_drive_identification()
     if "ProductCode" in device.attrib and prod_code is not None:
         assert int(device.attrib.get("ProductCode")) == prod_code
     if "RevisionNumber" in device.attrib and rev_number is not None:


### PR DESCRIPTION
## Fix get_drive_identification method

Fixes # INGK-910

### Type of change

- [x] Move `get_drive_identification` from utils to the Servo class.
- [x] Remove the try-except clause to avoid masking communication errors.

### Tests
- [x] Update test_save_configuration accordingly
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
