### PR TITLE
INGK-905 Update the CANopen bustype argument

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -231,7 +231,7 @@ class CanopenNetwork(Network):
         self.__fw_load_errors_enabled = True
 
         self.__connection_args = {
-            "bustype": self.__device,
+            "interface": self.__device,
             "channel": self.__channel,
             "bitrate": self.__baudrate,
         }


### PR DESCRIPTION
### Description

Update the deprecated CAN bus argument.

Fixes # INGK-905

### Type of change

Please add a description and delete options that are not relevant.

- Change the bus argument from _bustype_ to _interface_


### Tests
- Run the CANopen pytest tests.
- Check that the tests pass.
- Check that the DeprecationWarning message is no longer shown.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
