### PR TITLE
INGK-839 Use the operation mode display register for the TxPDO

### DIFF
--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -328,8 +328,8 @@ def test_start_stop_pdo(connect_to_all_slave):
     servos, net = connect_to_all_slave
     operation_mode_uid = "DRV_OP_CMD"
     rpdo_registers = [operation_mode_uid]
-    status_word_uid = "DRV_STATE_STATUS"
-    tpdo_registers = [status_word_uid]
+    operation_mode_display_uid = "DRV_OP_VALUE"
+    tpdo_registers = [operation_mode_display_uid]
     default_operation_mode = 1
     current_operation_mode = {}
     new_operation_mode = {}
@@ -346,10 +346,10 @@ def test_start_stop_pdo(connect_to_all_slave):
     for index, servo in enumerate(servos):
         # Check that RPDOs are being received by the slave
         assert servo._rpdo_maps[0].items[0].value == servo.read(operation_mode_uid)
-        # Restore the previous operation mode
-        servo.write(operation_mode_uid, current_operation_mode[index])
         # Check that TPDOs are being sent by the slave
         assert servo._tpdo_maps[0].items[0].value == servo.read(tpdo_registers[0])
+        # Restore the previous operation mode
+        servo.write(operation_mode_uid, current_operation_mode[index])
     # Check that PDOs can be re-started with the same configuration
     start_stop_pdos(net)
     # Re-configure the PDOs and re-start the PDO exchange

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -328,6 +328,8 @@ def test_start_stop_pdo(connect_to_all_slave):
     servos, net = connect_to_all_slave
     operation_mode_uid = "DRV_OP_CMD"
     rpdo_registers = [operation_mode_uid]
+    status_word_uid = "DRV_STATE_STATUS"
+    tpdo_registers = [status_word_uid]
     default_operation_mode = 1
     current_operation_mode = {}
     new_operation_mode = {}
@@ -336,7 +338,7 @@ def test_start_stop_pdo(connect_to_all_slave):
         new_operation_mode[index] = default_operation_mode
         if current_operation_mode[index] == default_operation_mode:
             new_operation_mode[index] += 1
-        rpdo_map, tpdo_map = create_pdo_maps(servo, rpdo_registers, TPDO_REGISTERS)
+        rpdo_map, tpdo_map = create_pdo_maps(servo, rpdo_registers, tpdo_registers)
         for item in rpdo_map.items:
             item.value = new_operation_mode[index]
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
@@ -347,10 +349,7 @@ def test_start_stop_pdo(connect_to_all_slave):
         # Restore the previous operation mode
         servo.write(operation_mode_uid, current_operation_mode[index])
         # Check that TPDOs are being sent by the slave
-        # TODO: Confirm this approx is needed in INGK-839
-        assert pytest.approx(servo._tpdo_maps[0].items[0].value, abs=2) == servo.read(
-            TPDO_REGISTERS[0]
-        )
+        assert servo._tpdo_maps[0].items[0].value == servo.read(tpdo_registers[0])
     # Check that PDOs can be re-started with the same configuration
     start_stop_pdos(net)
     # Re-configure the PDOs and re-start the PDO exchange


### PR DESCRIPTION
### Description

Fix the start_stop_pdo test.

Fixes # INGK-839

### Type of change

Please add a description and delete options that are not relevant.

- Use the operation mode display register for the TxPDO

### Tests
- Run the pytest test.
- Check that it is successful.

### Code formatting

- [x] Use black package to format the code: `black -l 100 ingenialink tests`. It is recommended to configure the code editor to automatically format the code using black with a max length line of 100.

### Others

- [x] Set fix version field in the Jira issue.
