### PR TITLE
INGK-444 Clear the SDO Error after the store parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fix
+- SDO Error after a store parameters operation.
+
 ## [7.3.2] - 2024-06-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Fix
-- SDO Error after a store parameters operation.
+- SDO Error after a store/restore parameters operation.
 
 ## [7.3.2] - 2024-06-05
 

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -93,6 +93,41 @@ class EthercatServo(PDOServo):
 
         """
         super().store_parameters(subnode)
+        self._wait_until_alive(timeout)
+
+    def restore_parameters(
+        self,
+        subnode: Optional[int] = None,
+        timeout: Optional[float] = DEFAULT_STORE_RECOVERY_TIMEOUT,
+    ) -> None:
+        """Restore all the current parameters of all the slave to default.
+
+        .. note::
+            The drive needs a power cycle after this
+            in order for the changes to be properly applied.
+
+        Args:
+            subnode: Subnode of the axis. `None` by default which restores
+                all the parameters.
+            timeout : how many seconds to wait for the drive to become responsive
+            after the restore operation. If ``None`` it will wait forever.
+
+        Raises:
+            ILError: Invalid subnode.
+            ILObjectNotExist: Failed to write to the registers.
+
+        """
+        super().restore_parameters(subnode)
+        self._wait_until_alive(timeout)
+
+    def _wait_until_alive(self, timeout: Optional[float]) -> None:
+        """Wait until the drive becomes responsive.
+
+        Args:
+            timeout : how many seconds to wait for the drive to become responsive.
+            If ``None`` it will wait forever.
+
+        """
         init_time = time.time()
         while not self.is_alive():
             if timeout and (init_time + timeout) < time.time():

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -130,8 +130,9 @@ class EthercatServo(PDOServo):
         """
         init_time = time.time()
         while not self.is_alive():
-            if timeout and (init_time + timeout) < time.time():
+            if timeout is not None and (init_time + timeout) < time.time():
                 logger.info("The drive is unresponsive after the recovery timeout.")
+                break
 
     def _read_raw(  # type: ignore [override]
         self,


### PR DESCRIPTION
### Description

Clear the SDO error after the store parameters operation.

Fixes # INGK-444

### Type of change

- Check the status of the drive to clear the SDO error

### Tests
The error only happens with EVE-NET-E drives.

- Read/write a register after storing the parameters.
- Check that the read/write operation is successful.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
