### PR TITLE
INGK-386 Check for the available CAN devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- Raise an exception when a CAN transceiver's driver is not installed.
+
 ## [7.3.2] - 2024-06-05
 
 ### Added

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -243,7 +243,7 @@ class CanopenNetwork(Network):
             Containing all the detected node IDs.
 
         """
-        if self.__device not in self._get_available_devices():
+        if self.__device not in self.get_available_devices():
             raise ILError(
                 f"The {self.__device.upper()} transceiver is not detected. "
                 "Make sure that it's connected and its drivers are installed."
@@ -1079,7 +1079,7 @@ class CanopenNetwork(Network):
         self.__servos_state[node_id] = state
 
     @staticmethod
-    def _get_available_devices() -> List[str]:
+    def get_available_devices() -> List[str]:
         if platform.system() == "Linux":
             return [CAN_DEVICE.SOCKETCAN.name]
         return [

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1080,17 +1080,14 @@ class CanopenNetwork(Network):
 
     @staticmethod
     def get_available_devices() -> List[str]:
-        if platform.system() == "Linux":
-            return [CAN_DEVICE.SOCKETCAN.name]
+        unavailable_devices = [CAN_DEVICE.VIRTUAL]
+        if platform.system() == "Windows":
+            unavailable_devices.append(CAN_DEVICE.SOCKETCAN)
         return list(
             {
                 available_device["interface"]
                 for available_device in can.detect_available_configs(
-                    [
-                        device.value
-                        for device in CAN_DEVICE
-                        if device not in [CAN_DEVICE.SOCKETCAN, CAN_DEVICE.VIRTUAL]
-                    ]
+                    [device.value for device in CAN_DEVICE if device not in unavailable_devices]
                 )
             }
         )

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -243,6 +243,11 @@ class CanopenNetwork(Network):
             Containing all the detected node IDs.
 
         """
+        if self.__device not in self._get_available_devices():
+            raise ILError(
+                f"The {self.__device.upper()} transceiver is not detected. Make sure that it's connected "
+                "and its drivers are installed."
+            )
         is_connection_created = False
         if self._connection is None:
             is_connection_created = True
@@ -1072,3 +1077,14 @@ class CanopenNetwork(Network):
 
     def _set_servo_state(self, node_id: int, state: NET_STATE) -> None:
         self.__servos_state[node_id] = state
+
+    @staticmethod
+    def _get_available_devices() -> List[str]:
+        if platform.system() == "Linux":
+            return [CAN_DEVICE.SOCKETCAN.name]
+        return [
+            available_device["interface"]
+            for available_device in can.detect_available_configs(
+                [device.value for device in CAN_DEVICE if device not in [CAN_DEVICE.SOCKETCAN]]
+            )
+        ]

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1082,9 +1082,15 @@ class CanopenNetwork(Network):
     def get_available_devices() -> List[str]:
         if platform.system() == "Linux":
             return [CAN_DEVICE.SOCKETCAN.name]
-        return [
-            available_device["interface"]
-            for available_device in can.detect_available_configs(
-                [device.value for device in CAN_DEVICE if device not in [CAN_DEVICE.SOCKETCAN]]
-            )
-        ]
+        return list(
+            {
+                available_device["interface"]
+                for available_device in can.detect_available_configs(
+                    [
+                        device.value
+                        for device in CAN_DEVICE
+                        if device not in [CAN_DEVICE.SOCKETCAN, CAN_DEVICE.VIRTUAL]
+                    ]
+                )
+            }
+        )

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -245,8 +245,8 @@ class CanopenNetwork(Network):
         """
         if self.__device not in self._get_available_devices():
             raise ILError(
-                f"The {self.__device.upper()} transceiver is not detected. Make sure that it's connected "
-                "and its drivers are installed."
+                f"The {self.__device.upper()} transceiver is not detected. "
+                "Make sure that it's connected and its drivers are installed."
             )
         is_connection_created = False
         if self._connection is None:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -243,7 +243,7 @@ class CanopenNetwork(Network):
             Containing all the detected node IDs.
 
         """
-        if self.__device not in self.get_available_devices():
+        if (self.__device, self.__channel) not in self.get_available_devices():
             raise ILError(
                 f"The {self.__device.upper()} transceiver is not detected. "
                 "Make sure that it's connected and its drivers are installed."
@@ -1079,15 +1079,14 @@ class CanopenNetwork(Network):
         self.__servos_state[node_id] = state
 
     @staticmethod
-    def get_available_devices() -> List[str]:
+    def get_available_devices() -> List[Tuple[str, Union[str, int]]]:
+        """Get the available CAN devices and their channels"""
         unavailable_devices = [CAN_DEVICE.VIRTUAL]
         if platform.system() == "Windows":
             unavailable_devices.append(CAN_DEVICE.SOCKETCAN)
-        return list(
-            {
-                available_device["interface"]
-                for available_device in can.detect_available_configs(
-                    [device.value for device in CAN_DEVICE if device not in unavailable_devices]
-                )
-            }
-        )
+        return [
+            (available_device["interface"], available_device["channel"])
+            for available_device in can.detect_available_configs(
+                [device.value for device in CAN_DEVICE if device not in unavailable_devices]
+            )
+        ]

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -76,6 +76,23 @@ def test_scan_slaves_none_nodes(virtual_network):
     assert len(nodes) == 0
 
 
+@pytest.mark.no_connection
+@pytest.mark.parametrize("can_device", [CAN_DEVICE.PCAN, CAN_DEVICE.KVASER, CAN_DEVICE.IXXAT])
+def test_scan_slaves_missing_drivers(can_device):
+    net = CanopenNetwork(
+        device=can_device,
+        channel=0,
+        baudrate=CAN_BAUDRATE.Baudrate_1M,
+    )
+    with pytest.raises(ILError) as exc_info:
+        net.scan_slaves()
+    assert (
+        str(exc_info.value)
+        == f"The {can_device.value.upper()} transceiver is not detected. Make sure that it's connected and"
+        " its drivers are installed."
+    )
+
+
 @pytest.mark.canopen
 def test_scan_slaves_info(read_config):
     net = CanopenNetwork(

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -71,12 +71,6 @@ def test_scan_slaves(read_config):
 
 
 @pytest.mark.no_connection
-def test_scan_slaves_none_nodes(virtual_network):
-    nodes = virtual_network.scan_slaves()
-    assert len(nodes) == 0
-
-
-@pytest.mark.no_connection
 @pytest.mark.parametrize("can_device", [CAN_DEVICE.PCAN, CAN_DEVICE.KVASER, CAN_DEVICE.IXXAT])
 def test_scan_slaves_missing_drivers(can_device):
     net = CanopenNetwork(


### PR DESCRIPTION
### Description

Check the available CAN devices upon scanning.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- Raise an exception upon scanning if a transceiver is not connected or its driver is not installed.

### Tests
- Try to connect to a CAN device with a transceiver that is not installed.
- Check that an exception is raised.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
