### PR TITLE
INGK-653 Increase the socket timeout upon the EoE service initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- EoE service initialization error when a slave cannot reach the PreOp state. 
+
+
 ## [7.3.2] - 2024-06-05
 
 ### Added

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -49,7 +49,10 @@ class EoENetwork(EthernetNetwork):
 
     ECAT_SERVICE_NETWORK = ipaddress.ip_network("192.168.3.0/24")
 
-    EOE_GATEWAY_STATE_CHANGE_TIMEOUT = 9.0
+    # The timeout used by the EoE Service is 4 times the EC_TIMEOUTSTATE
+    # https://github.com/OpenEtherCATsociety/SOEM/blob/v1.4.0/soem/ethercattype.h#L76
+    # An extra second is added to compensate for the communication delays.
+    EOE_SERVICE_STATE_CHANGE_TIMEOUT = 9.0
 
     def __init__(
         self, ifname: str, connection_timeout: float = constants.DEFAULT_ETH_CONNECTION_TIMEOUT
@@ -269,7 +272,7 @@ class EoENetwork(EthernetNetwork):
         data = self.ifname
         msg = self._build_eoe_command_msg(EoECommand.INIT.value, data=data.encode("utf-8"))
         self._eoe_socket.settimeout(
-            max(self.EOE_GATEWAY_STATE_CHANGE_TIMEOUT, self.__connection_timeout)
+            max(self.EOE_SERVICE_STATE_CHANGE_TIMEOUT, self.__connection_timeout)
         )
         try:
             r = self._send_command(msg)


### PR DESCRIPTION
### Description

Increase the socket timeout upon the EoE service initialization

Fixes # INGK-653

### Type of change

- Set the EOE_GATEWAY_STATE_CHANGE_TIMEOUT during the EoE service initialization.

### Tests
Setup:
- 1 EVE-XCR-E
- 1 CAP-NET-E (in boot mode)
- Daisy chain connection

Test 1:
- Connect to the EVE-XCR-E.
- Read a register.
- Check that no error occurs.

Test 2:
- Perform a network scan.
- Check that no error occurs.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
