### PR TITLE
INGK-639 Reconnection is not supported when using new soem service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fix
 - SDO Error after a store/restore parameters operation.
+- EoE connection recovery after a power cycle.
 
 ## [7.3.2] - 2024-06-05
 

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -13,7 +13,7 @@ from ingenialink import constants
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.ethernet.servo import EthernetServo
 from ingenialink.exceptions import ILError, ILIOError, ILTimeoutError
-from ingenialink.network import SlaveInfo, NET_DEV_EVT
+from ingenialink.network import NET_DEV_EVT, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 


### PR DESCRIPTION
### Description

Recover the EoE connection after a power cycle

Fixes # INGK-639

### Type of change
- After a disconnection, restart the EoE service until communication the slaves is re-established.

### Tests
- Connect to a drive via the EoE Network.
- Perform a power cycle
- Check that the connection is recovered.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
