### PR TITLE
INGK-927 Discard KVASER virtual channels

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1088,10 +1088,10 @@ class CanopenNetwork(Network):
         for available_device in can.detect_available_configs(
             [device.value for device in CAN_DEVICE if device not in unavailable_devices]
         ):
-            if available_device[
-                "interface"
-            ] == CAN_DEVICE.KVASER.value and "Kvaser Virtual CAN Driver" in can.interfaces.kvaser.get_channel_info(
-                available_device["channel"]
+            if (
+                available_device["interface"] == CAN_DEVICE.KVASER.value
+                and "Kvaser Virtual CAN Driver"
+                in can.interfaces.kvaser.get_channel_info(available_device["channel"])
             ):
                 continue
             available_devices.append((available_device["interface"], available_device["channel"]))

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1081,12 +1081,18 @@ class CanopenNetwork(Network):
     @staticmethod
     def get_available_devices() -> List[Tuple[str, Union[str, int]]]:
         """Get the available CAN devices and their channels"""
+        available_devices = []
         unavailable_devices = [CAN_DEVICE.VIRTUAL]
         if platform.system() == "Windows":
             unavailable_devices.append(CAN_DEVICE.SOCKETCAN)
-        return [
-            (available_device["interface"], available_device["channel"])
-            for available_device in can.detect_available_configs(
-                [device.value for device in CAN_DEVICE if device not in unavailable_devices]
-            )
-        ]
+        for available_device in can.detect_available_configs(
+            [device.value for device in CAN_DEVICE if device not in unavailable_devices]
+        ):
+            if available_device[
+                "interface"
+            ] == CAN_DEVICE.KVASER.value and "Kvaser Virtual CAN Driver" in can.interfaces.kvaser.get_channel_info(
+                available_device["channel"]
+            ):
+                continue
+            available_devices.append((available_device["interface"], available_device["channel"]))
+        return available_devices


### PR DESCRIPTION
### Description

When the KVASER driver is installed, virtual channels always appear as available configurations even though no transceiver is connected.

Fixes # INGK-927

### Type of change

- Discard KVASER virtual channels

### Tests
- Install the KVASER driver.
- Check that the get_available_devices method returns no KVASER device.
- Connect a KVASER transceiver.
- Call the get_available_devices and check that a KVASER device is available.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
