### PR TITLE
INGK-928 Disable the servo status listener if the slave cannot reach PreOp state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - SDO Error after a store/restore parameters operation.
 - EoE service initialization error when a slave cannot reach the PreOp state. 
 - EoE connection recovery after a power cycle.
+- Stop the servo status listener when a EtherCAT drive cannot reach the PreOp state.
 
 ### Added 
 - Support to dictionaries V3 in the virtual drive.

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -210,6 +210,8 @@ class EthercatNetwork(Network):
             slave, slave_id, dictionary, self._connection_timeout, servo_status_listener
         )
         if not self._change_nodes_state(servo, pysoem.PREOP_STATE):
+            if servo_status_listener:
+                servo.stop_status_listener()
             raise ILStateError("Slave can not reach PreOp state")
         servo.reset_pdo_mapping()
         self.servos.append(servo)


### PR DESCRIPTION
### Description

If a drive cannot reach PreOp an exception is raised and the connection is considered unsuccessful. If the servo status listener was active, it remained active after the failed connection.

Fixes # INGK-928

### Type of change

- Stop the servo status listener if the drive cannot reach PreOp.

### Tests
- Try to connect to a drive (in ERR INIT state) with the servo status listener flag set to True.
- An ILStateError exception is raised.
- Check that the servo status listener is stopped.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
