### PR TITLE
INGK-929 Reload the Kvaser lib to refresh the connected transceivers

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1096,13 +1096,14 @@ class CanopenNetwork(Network):
                 can.detect_available_configs(
                     [device.value for device in CAN_DEVICE if device not in unavailable_devices]
                 )
-                + self._get_available_kvaser_devices()
+                + CanopenNetwork._get_available_kvaser_devices()
             )
         ]
 
-    def _get_available_kvaser_devices(self) -> List[Dict[str, Any]]:
+    @staticmethod
+    def _get_available_kvaser_devices() -> List[Dict[str, Any]]:
         """Get the available Kvaser devices and their channels"""
-        self._reload_kvaser_lib()
+        CanopenNetwork._reload_kvaser_lib()
         num_channels = ctypes.c_int(0)
         with contextlib.suppress(CANLIBError, NameError):
             canGetNumberOfChannels(ctypes.byref(num_channels))

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1085,7 +1085,8 @@ class CanopenNetwork(Network):
     def _set_servo_state(self, node_id: int, state: NET_STATE) -> None:
         self.__servos_state[node_id] = state
 
-    def get_available_devices(self) -> List[Tuple[str, Union[str, int]]]:
+    @staticmethod
+    def get_available_devices() -> List[Tuple[str, Union[str, int]]]:
         """Get the available CAN devices and their channels"""
         unavailable_devices = [CAN_DEVICE.KVASER, CAN_DEVICE.VIRTUAL]
         if platform.system() == "Windows":

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -18,7 +18,6 @@ from can.interfaces.kvaser.canlib import (
     CANLIBOperationError,
     canGetNumberOfChannels,
     CANLIBError,
-    CANLIBInitializationError,
 )
 from can.interfaces.kvaser.canlib import __get_canlib_function as get_canlib_function
 

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -14,11 +14,17 @@ import can
 import canopen
 import ingenialogger
 from can import CanError
-from can.interfaces.kvaser.canlib import (
-    CANLIBOperationError,
-    canGetNumberOfChannels,
-    CANLIBError,
-)
+
+KVASER_DRIVER_INSTALLED = True
+try:
+    from can.interfaces.kvaser.canlib import (
+        CANLIBOperationError,
+        canGetNumberOfChannels,
+        CANLIBError,
+    )
+except ImportError:
+    KVASER_DRIVER_INSTALLED = False
+
 from can.interfaces.kvaser.canlib import __get_canlib_function as get_canlib_function
 
 from ingenialink.canopen.register import CanopenRegister
@@ -1103,6 +1109,8 @@ class CanopenNetwork(Network):
     @staticmethod
     def _get_available_kvaser_devices() -> List[Dict[str, Any]]:
         """Get the available Kvaser devices and their channels"""
+        if not KVASER_DRIVER_INSTALLED:
+            return []
         CanopenNetwork._reload_kvaser_lib()
         num_channels = ctypes.c_int(0)
         with contextlib.suppress(CANLIBError, NameError):

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -14,17 +14,6 @@ import can
 import canopen
 import ingenialogger
 from can import CanError
-
-KVASER_DRIVER_INSTALLED = True
-try:
-    from can.interfaces.kvaser.canlib import (
-        CANLIBOperationError,
-        canGetNumberOfChannels,
-        CANLIBError,
-    )
-except ImportError:
-    KVASER_DRIVER_INSTALLED = False
-
 from can.interfaces.kvaser.canlib import __get_canlib_function as get_canlib_function
 
 from ingenialink.canopen.register import CanopenRegister
@@ -42,6 +31,16 @@ if platform.system() == "Windows":
 else:
     VCIError = None
 from canopen import Network as NetworkLib
+
+KVASER_DRIVER_INSTALLED = True
+try:
+    from can.interfaces.kvaser.canlib import (
+        CANLIBError,
+        CANLIBOperationError,
+        canGetNumberOfChannels,
+    )
+except ImportError:
+    KVASER_DRIVER_INSTALLED = False
 
 logger = ingenialogger.get_logger(__name__)
 


### PR DESCRIPTION
### Description

Reload the Kvaser lib to refresh the connected transceivers.

Fixes # INGK-929

### Type of change

- Added the _get_available_kvaser_devices method
- Added the _reload_kvaser_lib method

### Tests
- Install the Kvaser driver
- Connect a Kvaser transceiver
- In a loop:
  - Call the get_available_devices
  - The transceiver appears as available
  - Disconnect the transceiver
  - Call the get_available_devices
  - No transceiver appears as available.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
