### PR TITLE
INGK-893 Recover EEPROM write functionality for manufacturing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Methods to read/write to the ESC EEPROM.
+
 ### Changed
 - Raise an exception when a CAN transceiver's driver is not installed.
 

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -59,6 +59,8 @@ class EthercatServo(PDOServo):
 
     DEFAULT_STORE_RECOVERY_TIMEOUT = 1
 
+    DEFAULT_EEPROM_OPERATION_TIMEOUT_uS = 200_000
+
     def __init__(
         self,
         slave: "CdefSlave",
@@ -319,6 +321,39 @@ class EthercatServo(PDOServo):
         self.slave.set_watchdog(
             self.ETHERCAT_PDO_WATCHDOG, self.SECONDS_TO_MS_CONVERSION_FACTOR * timeout
         )
+
+    def read_eeprom(
+        self, address: int, timeout: int = DEFAULT_EEPROM_OPERATION_TIMEOUT_uS
+    ) -> bytes:
+        """Read from the ESC EEPROM.
+
+        Args:
+            address: EEPROM address to be read.
+            timeout: Operation timeout (microseconds). By default, 200.000 us.
+
+        Returns:
+            EEPROM data. The read data is 2 words (4 bytes).
+
+        """
+        data = self.slave.eeprom_read(address, timeout)
+        if not isinstance(data, bytes):
+            raise ValueError(
+                f"Error reading EEPROM. Expected the data to be of type bytes, got {type(data)}"
+            )
+        return data
+
+    def write_eeprom(
+        self, address: int, data: bytes, timeout: int = DEFAULT_EEPROM_OPERATION_TIMEOUT_uS
+    ) -> None:
+        """Write to the ESC EEPROM.
+
+        Args:
+            address: EEPROM address to be written.
+            data: Data to be written. The data must be a word (2 bytes).
+            timeout: Operation timeout (microseconds). By default, 200.000 us.
+
+        """
+        self.slave.eeprom_write(address, data, timeout)
 
     @property
     def slave(self) -> "CdefSlave":

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -1,3 +1,4 @@
+import os
 import time
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
@@ -375,6 +376,22 @@ class EthercatServo(PDOServo):
             self.slave.eeprom_write(start_address, data[:2], timeout)
             data = data[2:]
             start_address += 1
+
+    def _write_esc_eeprom_from_file(self, file_path: str) -> None:
+        """Load a binary file to the ESC EEPROM.
+
+        Args:
+            file_path: Path to the binary file to be loaded.
+
+        Raises:
+            FileNotFoundError: If the binary file cannot be found.
+
+        """
+        if not os.path.isfile(file_path):
+            raise FileNotFoundError(f"Could not find {file_path}.")
+        with open(file_path, "rb") as file:
+            data = file.read()
+        self._write_esc_eeprom(address=0, data=data)
 
     @property
     def slave(self) -> "CdefSlave":

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -347,10 +347,9 @@ class EthercatServo(PDOServo):
         if length < 1:
             raise ValueError("The minimum length is 1 byte.")
         data = bytes()
-        start_address = address
         while len(data) < length:
-            data += self.slave.eeprom_read(start_address, timeout)
-            start_address += 2
+            data += self.slave.eeprom_read(address, timeout)
+            address += 2
         if len(data) > length:
             data = data[:length]
         return data

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -339,7 +339,12 @@ class EthercatServo(PDOServo):
         Returns:
             EEPROM data. The read data.
 
+        Raises:
+            ValueError: If the length to be read has an invalid value.
+
         """
+        if length < 1:
+            raise ValueError("The minimum length is 1 byte.")
         data = bytes()
         start_address = address
         while len(data) < length:
@@ -359,7 +364,12 @@ class EthercatServo(PDOServo):
             data: Data to be written. The data length must be a multiple of 2 bytes.
             timeout: Operation timeout (microseconds). By default, 200.000 us.
 
+        Raises:
+            ValueError: If the data has the wrong size.
+
         """
+        if len(data) % 2 != 0:
+            raise ValueError("The data length must be a multiple of 2 bytes.")
         start_address = address
         while data:
             self.slave.eeprom_write(start_address, data[:2], timeout)

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -323,7 +323,7 @@ class EthercatServo(PDOServo):
             self.ETHERCAT_PDO_WATCHDOG, self.SECONDS_TO_MS_CONVERSION_FACTOR * timeout
         )
 
-    def read_eeprom(
+    def _read_esc_eeprom(
         self,
         address: int,
         length: int = DEFAULT_EEPROM_READ_BYTES_LENGTH,
@@ -354,7 +354,7 @@ class EthercatServo(PDOServo):
             data = data[:length]
         return data
 
-    def write_eeprom(
+    def _write_esc_eeprom(
         self, address: int, data: bytes, timeout: int = DEFAULT_EEPROM_OPERATION_TIMEOUT_uS
     ) -> None:
         """Write to the ESC EEPROM.

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -11,6 +11,14 @@ def test_eeprom_read(connect_to_slave):
 
 
 @pytest.mark.ethercat
+def test_eeprom_read_wrong_size(connect_to_slave):
+    servo, _ = connect_to_slave
+    product_code_address = 10
+    with pytest.raises(ValueError):
+        servo.read_eeprom(product_code_address, length=0)
+
+
+@pytest.mark.ethercat
 def test_eeprom_write(connect_to_slave):
     servo, _ = connect_to_slave
     serial_number_address = 14
@@ -26,5 +34,5 @@ def test_eeprom_write(connect_to_slave):
 def test_eeprom_wrong_size(connect_to_slave):
     servo, _ = connect_to_slave
     serial_number_address = 14
-    with pytest.raises(AttributeError):
+    with pytest.raises(ValueError):
         servo.write_eeprom(serial_number_address, int(0).to_bytes(3, "little"))

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -1,0 +1,22 @@
+import pytest
+
+
+@pytest.mark.ethercat
+def test_eeprom_read(connect_to_slave):
+    servo, _ = connect_to_slave
+    product_code_address = 10
+    assert servo.read_eeprom(product_code_address) == servo.read("DRV_ID_PRODUCT_CODE").to_bytes(
+        4, "little"
+    )
+
+
+@pytest.mark.ethercat
+def test_eeprom_write(connect_to_slave):
+    servo, _ = connect_to_slave
+    serial_number_address = 14
+    serial_number = int.from_bytes(servo.read_eeprom(serial_number_address), "little")
+    new_serial_number = serial_number + 1
+    new_serial_number_bytes = new_serial_number.to_bytes(2, "little")
+    servo.write_eeprom(serial_number_address, new_serial_number_bytes)
+    assert new_serial_number == int.from_bytes(servo.read_eeprom(serial_number_address), "little")
+    servo.write_eeprom(serial_number_address, serial_number.to_bytes(2, "little"))

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -4,10 +4,10 @@ import pytest
 @pytest.mark.ethercat
 def test_eeprom_read(connect_to_slave):
     servo, _ = connect_to_slave
+    product_code_bytes = servo.read("DRV_ID_PRODUCT_CODE").to_bytes(4, "little")
     product_code_address = 10
-    assert servo.read_eeprom(product_code_address, length=4) == servo.read(
-        "DRV_ID_PRODUCT_CODE"
-    ).to_bytes(4, "little")
+    for length in range(1, 5):
+        assert product_code_bytes[:length] == servo.read_eeprom(product_code_address, length=length)
 
 
 @pytest.mark.ethercat
@@ -20,3 +20,11 @@ def test_eeprom_write(connect_to_slave):
     servo.write_eeprom(serial_number_address, new_serial_number_bytes)
     assert new_serial_number == int.from_bytes(servo.read_eeprom(serial_number_address), "little")
     servo.write_eeprom(serial_number_address, serial_number.to_bytes(4, "little"))
+
+
+@pytest.mark.ethercat
+def test_eeprom_wrong_size(connect_to_slave):
+    servo, _ = connect_to_slave
+    serial_number_address = 14
+    with pytest.raises(AttributeError):
+        servo.write_eeprom(serial_number_address, int(0).to_bytes(3, "little"))

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -7,7 +7,9 @@ def test_eeprom_read(connect_to_slave):
     product_code_bytes = servo.read("DRV_ID_PRODUCT_CODE").to_bytes(4, "little")
     product_code_address = 10
     for length in range(1, 5):
-        assert product_code_bytes[:length] == servo._read_esc_eeprom(product_code_address, length=length)
+        assert product_code_bytes[:length] == servo._read_esc_eeprom(
+            product_code_address, length=length
+        )
 
 
 @pytest.mark.ethercat
@@ -26,7 +28,9 @@ def test_eeprom_write(connect_to_slave):
     new_serial_number = serial_number + 1
     new_serial_number_bytes = new_serial_number.to_bytes(4, "little")
     servo._write_esc_eeprom(serial_number_address, new_serial_number_bytes)
-    assert new_serial_number == int.from_bytes(servo._read_esc_eeprom(serial_number_address), "little")
+    assert new_serial_number == int.from_bytes(
+        servo._read_esc_eeprom(serial_number_address), "little"
+    )
     servo._write_esc_eeprom(serial_number_address, serial_number.to_bytes(4, "little"))
 
 

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -5,9 +5,9 @@ import pytest
 def test_eeprom_read(connect_to_slave):
     servo, _ = connect_to_slave
     product_code_address = 10
-    assert servo.read_eeprom(product_code_address) == servo.read("DRV_ID_PRODUCT_CODE").to_bytes(
-        4, "little"
-    )
+    assert servo.read_eeprom(product_code_address, length=4) == servo.read(
+        "DRV_ID_PRODUCT_CODE"
+    ).to_bytes(4, "little")
 
 
 @pytest.mark.ethercat
@@ -16,7 +16,7 @@ def test_eeprom_write(connect_to_slave):
     serial_number_address = 14
     serial_number = int.from_bytes(servo.read_eeprom(serial_number_address), "little")
     new_serial_number = serial_number + 1
-    new_serial_number_bytes = new_serial_number.to_bytes(2, "little")
+    new_serial_number_bytes = new_serial_number.to_bytes(4, "little")
     servo.write_eeprom(serial_number_address, new_serial_number_bytes)
     assert new_serial_number == int.from_bytes(servo.read_eeprom(serial_number_address), "little")
-    servo.write_eeprom(serial_number_address, serial_number.to_bytes(2, "little"))
+    servo.write_eeprom(serial_number_address, serial_number.to_bytes(4, "little"))

--- a/tests/ethercat/test_eeprom.py
+++ b/tests/ethercat/test_eeprom.py
@@ -7,7 +7,7 @@ def test_eeprom_read(connect_to_slave):
     product_code_bytes = servo.read("DRV_ID_PRODUCT_CODE").to_bytes(4, "little")
     product_code_address = 10
     for length in range(1, 5):
-        assert product_code_bytes[:length] == servo.read_eeprom(product_code_address, length=length)
+        assert product_code_bytes[:length] == servo._read_esc_eeprom(product_code_address, length=length)
 
 
 @pytest.mark.ethercat
@@ -15,19 +15,19 @@ def test_eeprom_read_wrong_size(connect_to_slave):
     servo, _ = connect_to_slave
     product_code_address = 10
     with pytest.raises(ValueError):
-        servo.read_eeprom(product_code_address, length=0)
+        servo._read_esc_eeprom(product_code_address, length=0)
 
 
 @pytest.mark.ethercat
 def test_eeprom_write(connect_to_slave):
     servo, _ = connect_to_slave
     serial_number_address = 14
-    serial_number = int.from_bytes(servo.read_eeprom(serial_number_address), "little")
+    serial_number = int.from_bytes(servo._read_esc_eeprom(serial_number_address), "little")
     new_serial_number = serial_number + 1
     new_serial_number_bytes = new_serial_number.to_bytes(4, "little")
-    servo.write_eeprom(serial_number_address, new_serial_number_bytes)
-    assert new_serial_number == int.from_bytes(servo.read_eeprom(serial_number_address), "little")
-    servo.write_eeprom(serial_number_address, serial_number.to_bytes(4, "little"))
+    servo._write_esc_eeprom(serial_number_address, new_serial_number_bytes)
+    assert new_serial_number == int.from_bytes(servo._read_esc_eeprom(serial_number_address), "little")
+    servo._write_esc_eeprom(serial_number_address, serial_number.to_bytes(4, "little"))
 
 
 @pytest.mark.ethercat
@@ -35,4 +35,4 @@ def test_eeprom_wrong_size(connect_to_slave):
     servo, _ = connect_to_slave
     serial_number_address = 14
     with pytest.raises(ValueError):
-        servo.write_eeprom(serial_number_address, int(0).to_bytes(3, "little"))
+        servo._write_esc_eeprom(serial_number_address, int(0).to_bytes(3, "little"))


### PR DESCRIPTION
### Description

Add methods to read and write to the ESC EEPROM.

Fixes # INGK-893

### Type of change

- Add the read_eeprom method.
- Add the write_eeprom method.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
