### PR TITLE
INGK-914 Add a retry after a communication timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Added 
 - Support to dictionaries V3 in the virtual drive.
 - Arguments in examples and tests.
+- Retry sending an Ethernet request after a communication timeout.
 
 ## [7.3.2] - 2024-06-05
 

--- a/ingenialink/ethernet/servo.py
+++ b/ingenialink/ethernet/servo.py
@@ -142,6 +142,10 @@ class EthernetServo(Servo):
             except ILWrongRegisterError as e:
                 logger.error(e)
                 return self.__receive_mcb_frame(reg)
+            except ILTimeoutError as e:
+                logger.error(f"{e}. Retrying..")
+                self.socket.sendall(frame)
+                return self.__receive_mcb_frame(reg)
         finally:
             self._lock.release()
 


### PR DESCRIPTION
### Description

Attempt a retry after an Ethernet communication timeout.

Fixes # IINGK-914

### Type of change

- Add a retry after a communication timeout

### Tests

- Continuously read/write registers while pinging the servo drive.
- Check that the communication can be maintained.

### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
