### PR TITLE
INGK-933 Correct expected working counter calculation

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -101,6 +101,8 @@ class EthercatNetwork(Network):
     ECAT_STATE_CHANGE_TIMEOUT_NS = 50_000
     ECAT_PROCESSDATA_TIMEOUT_S = 0.1
 
+    EXPECTED_WKC_PROCESS_DATA = 3
+
     def __init__(
         self,
         interface_name: str,
@@ -311,7 +313,7 @@ class EthercatNetwork(Network):
         else:
             self._ecat_master.send_processdata()
         processdata_wkc = self._ecat_master.receive_processdata(timeout=int(timeout * 1_000_000))
-        if processdata_wkc != self._ecat_master.expected_wkc:
+        if processdata_wkc != self.EXPECTED_WKC_PROCESS_DATA * (len(self.servos)):
             self._ecat_master.read_state()
             servos_state_msg = ""
             for servo in self.servos:

--- a/tests/config.json
+++ b/tests/config.json
@@ -20,7 +20,7 @@
   {
     "ifname": "\\Device\\NPF_{B24AA996-414A-4F95-95E6-2828D346209A}",
     "slave": 1,
-    "dictionary": "C:\\Users\\martin.acosta\\OneDrive - Novanta\\Documents\\issues\\INGK-767\\cap-net-e_eoe_2.4.1.xdf",
+    "dictionary": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-e_eoe_2.4.0.xdf",
     "fw_file": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-e_2.4.0.sfu",
     "boot_in_app": true
   }

--- a/tests/config.json
+++ b/tests/config.json
@@ -20,7 +20,7 @@
   {
     "ifname": "\\Device\\NPF_{B24AA996-414A-4F95-95E6-2828D346209A}",
     "slave": 1,
-    "dictionary": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-e_eoe_2.4.0.xdf",
+    "dictionary": "C:\\Users\\martin.acosta\\OneDrive - Novanta\\Documents\\issues\\INGK-767\\cap-net-e_eoe_2.4.1.xdf",
     "fw_file": "//awe-srv-max-prd/distext/products/EVE-XCR/firmware/2.4.0/eve-xcr-e_2.4.0.sfu",
     "boot_in_app": true
   }


### PR DESCRIPTION
### Description

Correctly calculate the expected working counter for the process data.

Fixes # INGK-933

### Type of change

- Update the expected process data working counter.

### Tests
- Connect to an EtherCAT drive (with a EOLT slave tool attached)
- Check that the drive can reach the Op state.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
