### PR TITLE
INGK-936 Fix numpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuptools.setup(
         "ingenialogger>=0.2.1",
         "ping3==4.0.3",
         "pysoem>=1.1.6, <1.2.0",
-        "numpy==1.26.3",
+        "numpy>=1.26.0",
         "scipy==1.12.0",
         "bitarray==2.9.2",
     ],


### PR DESCRIPTION
### Description

Allow NumPy versions higher than 1.26.0.

Fixes # INGK-936

### Type of change

- Update setup.py

### Tests

- Create a virtual environment.
- Install NumPy 1.26.4.
- Install ingenialink.
- Check that there are no conflicts between the requirements.

### Others

- [x] Set fix version field in the Jira issue.
