### PR TITLE
INGK-904 Load config always returns done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - Raise an exception when a CAN transceiver's driver is not installed.
 - Add optional password for the FOE bootloader.
+- Add strict mode to the load configuration method.
 
 ### Fixed
 - SDO Error after a store/restore parameters operation.

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -342,15 +342,17 @@ class Servo:
         Args:
             config_file: Path to the dictionary.
             subnode: Subnode of the axis.
-            strict: Whether to raise an exception if any error occurs during the loading configuration process.
-            If false, all errors will only be ignored. `False` by default.
+            strict: Whether to raise an exception if any error occurs during the loading
+            configuration process. If false, all errors will only be ignored.
+            `False` by default.
 
         Raises:
             FileNotFoundError: If the configuration file cannot be found.
             ValueError: If a configuration file from a subnode different from 0
                 is attempted to be loaded to subnode 0.
             ValueError: If an invalid subnode is provided.
-            ILError: If strict is set to True and any error occurs during the loading configuration process.
+            ILError: If strict is set to True and any error occurs during the loading
+            configuration process.
 
         """
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
@@ -375,7 +377,10 @@ class Servo:
                     subnode=element_subnode,
                 )
             except ILError as e:
-                exception_message = f"Exception during load_configuration, register {str(element.attrib['id'])}: {e}"
+                exception_message = (
+                    "Exception during load_configuration, "
+                    f"register {str(element.attrib['id'])}: {e}"
+                )
                 if strict:
                     raise ILError(exception_message)
                 logger.error(exception_message)

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -375,11 +375,10 @@ class Servo:
                     subnode=element_subnode,
                 )
             except ILError as e:
+                exception_message = f"Exception during load_configuration, register {str(element.attrib['id'])}: {e}"
                 if strict:
-                    raise e
-                logger.error(
-                    f"Exception during load_configuration, register {str(element.attrib['id']): {e}}"
-                )
+                    raise ILError(exception_message)
+                logger.error(exception_message)
 
     def save_configuration(self, config_file: str, subnode: Optional[int] = None) -> None:
         """Read all dictionary registers content and put it to the dictionary

--- a/tests/resources/test_config_file.xcf
+++ b/tests/resources/test_config_file.xcf
@@ -9,7 +9,7 @@
         <Register access="r" address="0x580F00" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" subnode="0" />
         <Register access="r" address="0x58AA00" dtype="str" id="DRV_BOOT_COCO_VERSION" subnode="0" />
         <Register access="r" address="0x5E4900" dtype="s32" id="DRV_DIAG_SYS_ERROR_LAST" subnode="0" />
-        <Register access="r" address="0x5E4A00" dtype="u16" id="DRV_DIAG_SYS_ERROR_TOTAL_COM" subnode="0" />
+        <Register access="rw" address="0x5E4A00" dtype="u16" id="DRV_DIAG_SYS_ERROR_TOTAL_COM" subnode="0" storage="0"/>
       </Registers>
     </Device>
   </Body>


### PR DESCRIPTION
### Description

Add a strict mode to the load configuration method. If set, any exception that occurs during the loading configuration process will be raised.

Fixes # INGK-904

### Type of change

- Add the strict flag.
- Code improvement.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
