### PR TITLE
INGK-945 Fix mapped address for subnode 0

### DIFF
--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -95,5 +95,6 @@ class EthernetRegister(Register):
     @property
     def mapped_address(self) -> int:
         """Register mapped address used for monitoring/disturbance."""
-        address_offset = self.MAP_ADDRESS_OFFSET * (self.subnode - 1)
-        return self.address + address_offset
+        if self.subnode > 1:
+            return self.address + self.MAP_ADDRESS_OFFSET * (self.subnode - 1)
+        return self.address

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -184,6 +184,7 @@ def test_register_range():
 @pytest.mark.parametrize(
     "subnode, address, mapped_address_eth, mapped_address_can",
     [
+        (0, 0x0000, 0x0000, 0x0000),
         (1, 0x0010, 0x0010, 0x0010),
         (2, 0x0020, 0x0820, 0x0020),
         (3, 0x0030, 0x1030, 0x0030),


### PR DESCRIPTION
### Description

Fix mapped address for subnode 0.

Fixes # INGK-945

### Type of change

- Fix mapped address for subnode 0.

### Tests
- Mapped a subnode 0 register.
- Check that no error occurs.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
