### PR TITLE
INGK-944 Start PDOs with FSoE and custom PDOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Coco product code attribute to the Dictionary class.
+- Enable working with FSoE PDOs and regular PDOs at the same time.
 
 ## [7.3.3] - 2024-07-15
 

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -620,6 +620,7 @@ class PDOServo(Servo):
         for tpdo_map in self._tpdo_maps:
             map_bytes = input_data[: tpdo_map.data_length_bytes]
             tpdo_map.set_item_bytes(map_bytes)
+            input_data = input_data[tpdo_map.data_length_bytes :]
 
     def _process_rpdo(self) -> Optional[bytes]:
         """Retrieve the RPDO raw data from each map.

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -265,7 +265,7 @@ class PDOMap:
         if self.map_register_index is None:
             raise ValueError("map_register_index is None")
         else:
-            return self.map_register_index.to_bytes(4, "little")
+            return self.map_register_index.to_bytes(2, "little")
 
     @property
     def map_register_index(self) -> Optional[int]:
@@ -385,7 +385,7 @@ class TPDOMap(PDOMap):
 class PDOServo(Servo):
     """Abstract class to implement PDOs in a Servo class."""
 
-    AVAILABLE_PDOS = 1
+    AVAILABLE_PDOS = 2
 
     RPDO_ASSIGN_REGISTER_SUB_IDX_0 = "RPDO_ASSIGN_REGISTER_SUB_IDX_0"
     RPDO_ASSIGN_REGISTER_SUB_IDX_1 = "RPDO_ASSIGN_REGISTER_SUB_IDX_1"

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -217,7 +217,7 @@ def test_servo_add_maps(connect_to_slave, create_pdo_map):
         tpdo_map.map_register_index
         == servo.dictionary.registers(0)[servo.TPDO_MAP_REGISTER_SUB_IDX_0[0]].idx
     )
-    assert tpdo_map.map_register_index_bytes == tpdo_map.map_register_index.to_bytes(4, "little")
+    assert tpdo_map.map_register_index_bytes == tpdo_map.map_register_index.to_bytes(2, "little")
     assert servo.read(EthercatServo.TPDO_MAP_REGISTER_SUB_IDX_0[0], subnode=0) == len(
         TPDO_REGISTERS
     )
@@ -232,7 +232,7 @@ def test_servo_add_maps(connect_to_slave, create_pdo_map):
         rpdo_map.map_register_index
         == servo.dictionary.registers(0)[servo.RPDO_MAP_REGISTER_SUB_IDX_0[0]].idx
     )
-    assert rpdo_map.map_register_index_bytes == rpdo_map.map_register_index.to_bytes(4, "little")
+    assert rpdo_map.map_register_index_bytes == rpdo_map.map_register_index.to_bytes(2, "little")
     assert servo.read(EthercatServo.RPDO_MAP_REGISTER_SUB_IDX_0[0], subnode=0) == len(
         RPDO_REGISTERS
     )


### PR DESCRIPTION
### Description

Enable working with FSoE PDOs and regular PDOs at the same time.

Fixes # INGK-944

### Type of change

Please add a description and delete options that are not relevant.

- Allow more than one PDOMap.
- Fix PDO Map register index size.
- Fix TxPDO data slicing.

### Tests
- Run the [FSoE example](https://github.com/ingeniamc/ingeniamotion/blob/0.8.2/examples/safety_torque_off.py) alongside regular PDOs.
- Check that both PDOs work as expected.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
