### PR TITLE
Ingk 948 run tests on development branches with only 1 or 2 python version to reduce time

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,6 @@ pipeline {
                     } else if (env.BRANCH_NAME.startsWith('release/')) {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                     } else {
-                        RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                         RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -349,9 +349,9 @@ pipeline {
                 """
                 unstash 'coverage_docker'
                 unstash 'coverage_reports'
-                bat '''
-                            venv\\Scripts\\python.exe -m tox -e coverage -- .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
-                    '''
+                sh """
+                    python${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
+                   """
                 publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]
                 archiveArtifacts artifacts: '*.xml'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
                 }
             }
         }
-        stage('Publish Ingenialink'){
+        stage('Publish Ingenialink') {
             agent {
                 docker {
                     label "worker"
@@ -332,19 +332,28 @@ pipeline {
                                 }
                             }
                         }
-                        stage('Save test results') {
-                            steps {
-                                unstash 'coverage_docker'
-                                unstash 'coverage_reports'
-                                bat '''
-                                    venv\\Scripts\\python.exe -m tox -e coverage -- .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
-                                '''
-                                publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]
-                                archiveArtifacts artifacts: '*.xml'
-                            }
-                        }
                     }
                 }
+            }
+        }
+        stage('Publish test results') {
+            agent {
+                docker {
+                    label "worker"
+                    image "ingeniacontainers.azurecr.io/docker-python:1.4"
+                }
+            }
+            steps {
+                sh """
+                    python${DEFAULT_PYTHON_VERSION} -m pip install tox==${TOX_VERSION}
+                """
+                unstash 'coverage_docker'
+                unstash 'coverage_reports'
+                bat '''
+                            venv\\Scripts\\python.exe -m tox -e coverage -- .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
+                    '''
+                publishCoverage adapters: [coberturaReportAdapter('coverage.xml')]
+                archiveArtifacts artifacts: '*.xml'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -333,7 +333,7 @@ pipeline {
                         }
                         stage('Archive') {
                             steps {
-                                stash includes: 'coverage_ethernet, .coverage_canopen', name: 'coverage_reports_canopen'
+                                stash includes: '.coverage_ethernet, .coverage_canopen', name: 'coverage_reports_canopen'
                                 archiveArtifacts artifacts: '*.xml'
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -259,7 +259,7 @@ pipeline {
                         }
                         stage('Archive') {
                             steps {
-                                stash includes: '.coverage_ethercat, .coverage_no_connection', name: 'coverage_reports'
+                                stash includes: '.coverage_ethercat, .coverage_no_connection', name: 'coverage_reports_ecat'
                                 archiveArtifacts artifacts: '*.xml'
                             }
                         }
@@ -331,6 +331,12 @@ pipeline {
                                 }
                             }
                         }
+                        stage('Archive') {
+                            steps {
+                                stash includes: 'coverage_ethernet, .coverage_canopen', name: 'coverage_reports_canopen'
+                                archiveArtifacts artifacts: '*.xml'
+                            }
+                        }
                     }
                 }
             }
@@ -347,7 +353,8 @@ pipeline {
                     python${DEFAULT_PYTHON_VERSION} -m pip install tox==${TOX_VERSION}
                 """
                 unstash 'coverage_docker'
-                unstash 'coverage_reports'
+                unstash 'coverage_reports_ecat'
+                unstash 'coverage_reports_canopen'
                 sh """
                     python${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- .coverage_docker .coverage_no_connection .coverage_ethercat .coverage_ethernet .coverage_canopen
                    """

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
     pytest-cov==2.12.1
 commands =
     python -m coverage combine {posargs}
-    python -m coverage xml --include=ingenialink/*
+    python -m coverage xml --include='*/ingenialink/*'
 
 [testenv:format]
 description = check format
@@ -61,3 +61,6 @@ commands =
 description = update firmware
 commands =
     python -m tests.resources.Scripts.load_FWs {posargs}
+
+[run]
+relative_files=True


### PR DESCRIPTION
We decided to not run all the python versions on development branches to reduce pipeline time.
Running the oldest version and newest version is significant enough, and if something is really broken on intermediate releases it will be detected quickly on develop, release and master branches.

Also I've parallelized ethercat and canopen tests to further reduce build time.
Initial reference - 1h 41min 
http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingenialink-python/job/develop/125/

Now - [PENDING]
http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingenialink-python/view/change-requests/job/PR-459/2/