### PR TITLE
INGK-959 Catch SDO errors when reading the CANopen identity object

### DIFF
--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Union
 
 import ingenialogger
 
@@ -52,8 +52,8 @@ class NET_TRANS_PROT(Enum):
 
 @dataclass
 class SlaveInfo:
-    product_code: int
-    revision_number: int
+    product_code: Optional[int] = None
+    revision_number: Optional[int] = None
 
 
 class Network(ABC):


### PR DESCRIPTION
### Description

Catch SDO errors when reading the CANopen identity object.

Fixes # INGK-959

### Type of change

- Catch the SDO exceptions.
- Add a None as the default value to the SlaveInfo attributes.

### Tests
- Connect to a CANopen device.
- Perform a scan with info.
- Force an SDOAbortedError.
- Check that the exception is logged.
- Check that the SlaveInfo attributes for the node are both None.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
