### PR TITLE
INGK-957 If dictionary is wrong show an error instead of crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Coco product code attribute to the Dictionary class.
 - Enable working with FSoE PDOs and regular PDOs at the same time.
 
+### Changed
+- Set the default values of the firmware version, product code, revision number, and part number of the dictionary class to None.
+
 ## [7.3.3] - 2024-07-15
 
 ### Added

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -196,16 +196,16 @@ class Dictionary(ABC):
 
     version: str
     """Version of the dictionary."""
-    firmware_version: Optional[str]
+    firmware_version: Optional[str] = None
     """Firmware version declared in the dictionary."""
-    product_code: int
+    product_code: Optional[int] = None
     """Product code declared in the dictionary."""
     coco_product_code: Optional[int] = None
     """CoCo product code declared in the dictionary.
     Only used when a COM-KIT and a CORE dictionary are merged."""
-    part_number: Optional[str]
+    part_number: Optional[str] = None
     """Part number declared in the dictionary."""
-    revision_number: int
+    revision_number: Optional[int] = None
     """Revision number declared in the dictionary."""
     interface: Interface
     """Interface declared in the dictionary."""

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -397,6 +397,11 @@ class Servo:
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
             raise ILError("Invalid subnode")
 
+        drive_info = self.info
+        prod_code = drive_info["product_code"]
+        rev_number = drive_info["revision_number"]
+        firmware_version = drive_info["firmware_version"]
+
         tree = ET.Element("IngeniaDictionary")
         header = ET.SubElement(tree, "Header")
         version = ET.SubElement(header, "Version")
@@ -415,12 +420,12 @@ class Servo:
         device.set("Interface", interface)
         if self.dictionary.part_number is not None:
             device.set("PartNumber", self.dictionary.part_number)
-        if self.dictionary.product_code is not None:
-            device.set("ProductCode", str(self.dictionary.product_code))
-        if self.dictionary.revision_number is not None:
-            device.set("RevisionNumber", str(self.dictionary.revision_number))
-        if self.dictionary.firmware_version is not None:
-            device.set("firmwareVersion", self.dictionary.firmware_version)
+        if prod_code is not None:
+            device.set("ProductCode", str(prod_code))
+        if rev_number is not None:
+            device.set("RevisionNumber", str(rev_number))
+        if isinstance(firmware_version, str):
+            device.set("firmwareVersion", firmware_version)
 
         access_ops = {value: key for key, value in self.dictionary.access_xdf_options.items()}
         dtype_ops = {value: key for key, value in self.dictionary.dtype_xdf_options.items()}
@@ -1379,20 +1384,32 @@ class Servo:
             return {}
 
     @property
-    def info(self) -> Dict[str, Union[str, int]]:
+    def info(self) -> Dict[str, Union[None, str, int]]:
         """Servo information."""
-        serial_number = self.__read_coco_moco_register(
-            self.SERIAL_NUMBER_REGISTERS[0], self.SERIAL_NUMBER_REGISTERS[1]
-        )
-        sw_version = self.__read_coco_moco_register(
-            self.SOFTWARE_VERSION_REGISTERS[0], self.SOFTWARE_VERSION_REGISTERS[1]
-        )
-        product_code = self.__read_coco_moco_register(
-            self.PRODUCT_ID_REGISTERS[0], self.PRODUCT_ID_REGISTERS[1]
-        )
-        revision_number = self.__read_coco_moco_register(
-            self.REVISION_NUMBER_REGISTERS[0], self.REVISION_NUMBER_REGISTERS[1]
-        )
+        try:
+            serial_number = self.__read_coco_moco_register(
+                self.SERIAL_NUMBER_REGISTERS[0], self.SERIAL_NUMBER_REGISTERS[1]
+            )
+        except ILError:
+            serial_number = None
+        try:
+            sw_version = self.__read_coco_moco_register(
+                self.SOFTWARE_VERSION_REGISTERS[0], self.SOFTWARE_VERSION_REGISTERS[1]
+            )
+        except ILError:
+            sw_version = None
+        try:
+            product_code = self.__read_coco_moco_register(
+                self.PRODUCT_ID_REGISTERS[0], self.PRODUCT_ID_REGISTERS[1]
+            )
+        except ILError:
+            product_code = None
+        try:
+            revision_number = self.__read_coco_moco_register(
+                self.REVISION_NUMBER_REGISTERS[0], self.REVISION_NUMBER_REGISTERS[1]
+            )
+        except ILError:
+            revision_number = None
         hw_variant = "A"
 
         return {

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -396,7 +396,6 @@ class Servo:
         """
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
             raise ILError("Invalid subnode")
-        prod_code, rev_number = self._get_drive_identification(subnode)
 
         tree = ET.Element("IngeniaDictionary")
         header = ET.SubElement(tree, "Header")
@@ -416,9 +415,12 @@ class Servo:
         device.set("Interface", interface)
         if self.dictionary.part_number is not None:
             device.set("PartNumber", self.dictionary.part_number)
-        device.set("ProductCode", str(prod_code))
-        device.set("RevisionNumber", str(rev_number))
-        device.set("firmwareVersion", str(self.dictionary.firmware_version))
+        if self.dictionary.product_code is not None:
+            device.set("ProductCode", str(self.dictionary.product_code))
+        if self.dictionary.revision_number is not None:
+            device.set("RevisionNumber", str(self.dictionary.revision_number))
+        if self.dictionary.firmware_version is not None:
+            device.set("firmwareVersion", self.dictionary.firmware_version)
 
         access_ops = {value: key for key, value in self.dictionary.access_xdf_options.items()}
         dtype_ops = {value: key for key, value in self.dictionary.dtype_xdf_options.items()}

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -4,6 +4,7 @@ import shutil
 import time
 import xml.etree.ElementTree as ET
 from pathlib import Path
+from packaging import version
 
 import pytest
 
@@ -117,7 +118,10 @@ def test_save_configuration(connect_to_slave):
         else servo.DICTIONARY_INTERFACE_ATTR_ETH
     )
     assert device.attrib.get("Interface") == interface
-    assert device.attrib.get("firmwareVersion") == servo.dictionary.firmware_version
+    # The firmware version from the drive has trailing zeros and the one from the dictionary does not
+    assert version.parse(device.attrib.get("firmwareVersion")) == version.parse(
+        servo.dictionary.firmware_version
+    )
     # TODO: check name and family? These are not stored at the dictionary
 
     assert len(saved_registers) > 0


### PR DESCRIPTION
### Description

Add default values to the device description attributes of the Dictionary class.

Fixes # INGK-957

### Type of change
- Set the default values of the firmware version, product code, revision number, and part number to None.
- Update the save configuration method accordingly.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.


### Documentation

- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
