### PR TITLE
INGK-960 Unload kvaser library only in connection teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [7.3.4]
 
 ### Fixed
-- CANopen multiple drive connection
+- CANopen multiple drive connection with Kvaser
 
 ## [7.3.3] - 2024-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-# [7.3.3] - 2024-07-15
+## [7.3.4]
+
+### Fixed
+- CANopen multiple drive connection
+
+## [7.3.3] - 2024-07-15
 
 ### Added
 - Methods to read/write to the ESC EEPROM.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1072,7 +1072,8 @@ class CanopenNetwork(Network):
         """
         if not KVASER_DRIVER_INSTALLED:
             return []
-        self._reload_kvaser_lib()
+        if self.__device == CAN_DEVICE.KVASER.value and not self.servos:
+            self._reload_kvaser_lib()
         num_channels = ctypes.c_int(0)
         with contextlib.suppress(CANLIBError, NameError):
             canGetNumberOfChannels(ctypes.byref(num_channels))
@@ -1082,11 +1083,10 @@ class CanopenNetwork(Network):
             if "Virtual" not in can.interfaces.kvaser.get_channel_info(channel)
         ]
 
-    def _reload_kvaser_lib(self) -> None:
-        """Reload the Kvaser library to refresh the connected transceivers.
-        Only when no drives are connected"""
-        if self.__device == CAN_DEVICE.KVASER.value and not self.servos:
-            canUnLoadLibrary = get_canlib_function("canUnloadLibrary")
-            canInitializeLibrary = get_canlib_function("canInitializeLibrary")
-            canUnLoadLibrary()
-            canInitializeLibrary()
+    @staticmethod
+    def _reload_kvaser_lib() -> None:
+        """Reload the Kvaser library to refresh the connected transceivers."""
+        canUnLoadLibrary = get_canlib_function("canUnloadLibrary")
+        canInitializeLibrary = get_canlib_function("canInitializeLibrary")
+        canUnLoadLibrary()
+        canInitializeLibrary()

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1046,7 +1046,11 @@ class CanopenNetwork(Network):
         self.__servos_state[node_id] = state
 
     def get_available_devices(self) -> List[Tuple[str, Union[str, int]]]:
-        """Get the available CAN devices and their channels"""
+        """Get the available CAN devices and their channels
+
+        Returns:
+            List of tuples with device name and channel
+        """
         unavailable_devices = [CAN_DEVICE.KVASER, CAN_DEVICE.VIRTUAL]
         if platform.system() == "Windows":
             unavailable_devices.append(CAN_DEVICE.SOCKETCAN)
@@ -1061,7 +1065,11 @@ class CanopenNetwork(Network):
         ]
 
     def _get_available_kvaser_devices(self) -> List[Dict[str, Any]]:
-        """Get the available Kvaser devices and their channels"""
+        """Get the available Kvaser devices and their channels
+
+        Returns:
+            List of dictionaries compatible with :func:`can.detect_available_configs` output.
+        """
         if not KVASER_DRIVER_INSTALLED:
             return []
         self._reload_kvaser_lib()


### PR DESCRIPTION
Fix multiple drive connections with Kvaser CANopen transceiver.

Fixes # INGK-960

### Type of change

- [x] Reload Kvaser lib only of no drives are connected


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

#### Manual test

1. Scan slaves
2. Connect to slave A
3. Scan slaves
4. Connect to Slave B
5. Scan slaves
6. Disconnect from A and B

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
