### PR TITLE
INGM-501 Find alternative to IO_IN_VALUE set in motion_controller fixture

### DIFF
--- a/virtual_drive/__init__.py
+++ b/virtual_drive/__init__.py
@@ -1,0 +1,1 @@
+from .core import VirtualDrive

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -5,7 +5,7 @@ import socket
 import time
 from enum import Enum, IntEnum
 from threading import Thread, Timer
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -22,6 +22,10 @@ from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_by
 from ingenialink.utils.constants import IL_MC_CW_EO
 from ingenialink.utils.mcb import MCB
 from ingenialink.virtual.dictionary import VirtualDictionary
+
+from .environment import Environment
+from .gpios import Gpios
+from .signals import Signal
 
 R_VALUE = 1.1
 L_VALUE = 3.9e-4
@@ -1239,6 +1243,15 @@ class VirtualDrive(Thread):
         super(VirtualDrive, self).__init__()
         self.ip = self.IP_ADDRESS
         self.port = port
+
+        self.environment = Environment()
+        self.__gpios = Gpios(self.environment)
+
+        self.__register_signals: Dict[str, Signal[Any]] = {
+            "IO_IN_VALUE": self.__gpios.value,
+            "IO_IN_POLARITY": self.__gpios.polarity,
+        }
+
         default_dictionary = os.path.join(
             pathlib.Path(__file__).parent.resolve(), self.PATH_DICTIONARY_RELATIVE
         )
@@ -1627,6 +1640,9 @@ class VirtualDrive(Thread):
         Returns:
             Register value.
         """
+        if id in self.__register_signals:
+            return self.__register_signals[id].get()  # type: ignore
+
         register = self.__dictionary.registers(subnode)[id]
         value: Union[int, float]
         if len(self.reg_signals[id]) > 0:
@@ -1658,6 +1674,9 @@ class VirtualDrive(Thread):
             id: Register ID.
             value: Value to be set.
         """
+        if id in self.__register_signals:
+            self.__register_signals[id].set(value)
+
         self.__dictionary.registers(subnode)[id].storage = value
 
     def __register_exists(self, subnode: int, id: str) -> bool:

--- a/virtual_drive/environment.py
+++ b/virtual_drive/environment.py
@@ -1,0 +1,11 @@
+from .signals import Signal
+
+
+class Environment:
+    """Contains the physical values of connected, imposed or observed to the drive"""
+
+    def __init__(self) -> None:
+        self.gpi_1_status = Signal[bool](False)
+        self.gpi_2_status = Signal[bool](False)
+        self.gpi_3_status = Signal[bool](False)
+        self.gpi_4_status = Signal[bool](False)

--- a/virtual_drive/gpios.py
+++ b/virtual_drive/gpios.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+from .environment import Signal
+
+if TYPE_CHECKING:
+    from .environment import Environment
+
+
+class Gpios:
+    """General Purpose Input and Outputs"""
+
+    def __init__(self, environment: "Environment"):
+        self.value = Signal[int](0)
+        self.polarity = Signal[int](0)
+
+        self.__environment = environment
+
+        # Update the inputs value whenever the pin state changes or polarity register changes
+        environment.gpi_1_status.watch(self.__update_gpi_status)
+        environment.gpi_2_status.watch(self.__update_gpi_status)
+        environment.gpi_3_status.watch(self.__update_gpi_status)
+        environment.gpi_4_status.watch(self.__update_gpi_status)
+        self.polarity.watch(self.__update_gpi_status)
+
+    def __update_gpi_status(self) -> None:
+        gpi_status = (
+            (int(self.__environment.gpi_1_status.get()) << 0)
+            + (int(self.__environment.gpi_2_status.get()) << 1)
+            + (int(self.__environment.gpi_3_status.get()) << 2)
+            + (int(self.__environment.gpi_4_status.get()) << 3)
+        )
+
+        self.value.set(self.polarity.get() ^ gpi_status)

--- a/virtual_drive/signals.py
+++ b/virtual_drive/signals.py
@@ -1,0 +1,46 @@
+from typing import Callable, Generic, List, TypeVar
+
+T = TypeVar("T")
+
+
+class Signal(Generic[T]):
+    """Virtual Drive Signal.
+
+    Represents any physical or internal continuous signal of the drive.
+
+    Intended to use as a publisher-subscriber pattern.
+    The module signal owner publishes the signal, other modules subscribes to it
+    """
+
+    def __init__(self, initial_value: T):
+        self.__value = initial_value
+        self.__subscribers: List[Callable[[T], None]] = []
+        self.__watchers: List[Callable[[], None]] = []
+
+    def get(self) -> T:
+        """Get current value of the signal"""
+        return self.__value
+
+    def subscribe(self, callback: Callable[[T], None]) -> None:
+        """Subscribe to signal.
+
+        Args:
+            Callback that accepts signal value. Will be called when signal changes
+        """
+        self.__subscribers.append(callback)
+
+    def watch(self, callback: Callable[[], None]) -> None:
+        """Watch signal.
+
+        Args:
+            Callback. Will be called when signal changes
+        """
+        self.__watchers.append(callback)
+
+    def set(self, value: T) -> None:
+        """Set signal value."""
+        self.__value = value
+        for sub in self.__subscribers:
+            sub(value)
+        for wat in self.__watchers:
+            wat()

--- a/virtual_drive/signals.py
+++ b/virtual_drive/signals.py
@@ -14,20 +14,11 @@ class Signal(Generic[T]):
 
     def __init__(self, initial_value: T):
         self.__value = initial_value
-        self.__subscribers: List[Callable[[T], None]] = []
         self.__watchers: List[Callable[[], None]] = []
 
     def get(self) -> T:
         """Get current value of the signal"""
         return self.__value
-
-    def subscribe(self, callback: Callable[[T], None]) -> None:
-        """Subscribe to signal.
-
-        Args:
-            Callback that accepts signal value. Will be called when signal changes
-        """
-        self.__subscribers.append(callback)
 
     def watch(self, callback: Callable[[], None]) -> None:
         """Watch signal.
@@ -40,7 +31,5 @@ class Signal(Generic[T]):
     def set(self, value: T) -> None:
         """Set signal value."""
         self.__value = value
-        for sub in self.__subscribers:
-            sub(value)
         for wat in self.__watchers:
             wat()


### PR DESCRIPTION
### Description

Implemented inputs functionality in virtual drive to be able to test ingeniamotion functionality correctly:
https://github.com/ingeniamc/ingeniamotion/pull/242 

The code of virtual drive is a bit chaotic and we will organize it in the future. 
For this particular feature I've followed the pattern proposed here:
https://novantamotion.atlassian.net/wiki/x/iAHHMQ
We can discuss and change it in the future if necessary

Fixes # (issue)

### Type of change
- [x] Virtual drive Inputs functionality

### Tests
- [x] Run test_get_gpi_voltage_level of https://github.com/ingeniamc/ingeniamotion/pull/242/files#diff-26824e205001fe146a1634cf74c1dda1cdb8a07b6216545990b773a12da705d4R48

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
