### PR TITLE
INGK-962 Update python-can

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setuptools.setup(
     ],
     install_requires=[
         "canopen==2.2.0",
-        "python-can==4.3.1",
+        "python-can==4.4.2",
         "ingenialogger>=0.2.1",
         "ping3==4.0.3",
         "pysoem>=1.1.7, <1.2.0",


### PR DESCRIPTION
### Description

Update the python-can library version to 4.4.2.

Fixes # INGK-962

### Type of change
- Update setup.py


### Tests
- Test ML3 with python-can 4.4.2
- Check that everything works as expected.

### Others
- [x] Set fix version field in the Jira issue.
