### PR TITLE
INGK-978 Improve CoE reconnection after a disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- Restore CoE communication after a power cycle.
+
 ## [7.3.5] - 2025-08-23
 
 ### Added


### PR DESCRIPTION
### Description

 Improve CoE reconnection after a disconnection.

Fixes # INGK-978

### Type of change

- Retry to transition the slaves to the PreOp state.
- Only consider a drive as connected when in PreOp state.

### Tests
- Connect to an EtherCAT drive (enabling the network status listener)
- Continuously read a register and:
        1. Turn off the power supply
        2. Check that the read fails.
        3. Turn on the power supply
        4. Check that the read is successful.
        5. Repeat the previous steps several times.

### Documentation
- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
