### PR TITLE
INGK-980 Exclude the PDO related registers from the configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- CiA 301 PDO related registers are not saved to the configuration file. 
+
 ## [7.3.5] - 2025-08-23
 
 ### Added

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -128,9 +128,11 @@ class CanopenServo(Servo):
         if not is_register_valid:
             return is_register_valid
         # Exclude the RxPDO and TxPDO related registers
-        if register.identifier is not None and "CIA301_COMMS" in register.identifier:
-            return not is_register_valid
-        return is_register_valid
+        if register.identifier is not None and register.identifier.startswith(
+            ("CIA301_COMMS_TPDO", "CIA301_COMMS_RPDO")
+        ):
+            return False
+        return True
 
     @staticmethod
     def _monitoring_disturbance_map_can_address(address: int, subnode: int) -> int:

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -123,6 +123,15 @@ class CanopenServo(Servo):
         """Changes the SDO timeout of the node."""
         self.__node.sdo.RESPONSE_TIMEOUT = value
 
+    def _is_register_valid_for_configuration_file(self, register: Register) -> bool:
+        is_register_valid = super()._is_register_valid_for_configuration_file(register)
+        if not is_register_valid:
+            return is_register_valid
+        # Exclude the RxPDO and TxPDO related registers
+        if register.identifier is not None and "CIA301_COMMS" in register.identifier:
+            return not is_register_valid
+        return is_register_valid
+
     @staticmethod
     def _monitoring_disturbance_map_can_address(address: int, subnode: int) -> int:
         """Map CAN register address to IPB register address."""

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -128,6 +128,7 @@ class CanopenServo(Servo):
         if not is_register_valid:
             return is_register_valid
         # Exclude the RxPDO and TxPDO related registers
+        # Check INGK-980
         if register.identifier is not None and register.identifier.startswith(
             ("CIA301_COMMS_TPDO", "CIA301_COMMS_RPDO")
         ):


### PR DESCRIPTION
### Description

Exclude the RxPDO and TxPDO related registers from the configuration file of CANopen drives.

Fixes # INGK-980

### Tests
- Connect to a CANopen drive.
- Generate its configuration file.
- Check that no RxPDO and TxPDO related registers are present in the file.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
