### PR TITLE
INGK-985 Allow users to subscribe to EMCY messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Method to subscribe to emergency messages.
 
 ### Fixed
 - Restore CoE communication after a power cycle.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -370,6 +370,7 @@ class CanopenNetwork(Network):
                 servo = CanopenServo(
                     target, node, dictionary, servo_status_listener=servo_status_listener
                 )
+                servo.emcy_subscribe(servo._emcy_callback)
                 self.servos.append(servo)
                 self._set_servo_state(target, NET_STATE.CONNECTED)
                 if net_status_listener:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -370,7 +370,6 @@ class CanopenNetwork(Network):
                 servo = CanopenServo(
                     target, node, dictionary, servo_status_listener=servo_status_listener
                 )
-                servo.emcy_subscribe(servo._emcy_callback)
                 self.servos.append(servo)
                 self._set_servo_state(target, NET_STATE.CONNECTED)
                 if net_status_listener:

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -167,10 +167,6 @@ class CanopenServo(Servo):
             subnode, ipb_address, dtype, size
         )
 
-    def _emcy_callback(self, emergency_msg: EmcyError) -> None:
-        """Log the emergency messages"""
-        logger.warning(f"Emergency message received from node {self.target}: {emergency_msg}")
-
     @property
     def node(self) -> canopen.RemoteNode:
         """Remote node of the servo."""

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -95,7 +95,7 @@ class CanopenServo(Servo):
             return bytes()
         return value
 
-    def emcy_subscribe(self, callback: Callable[["EmcyError"], None]) -> None:
+    def emcy_subscribe(self, callback: Callable[[EmcyError], None]) -> None:
         """Subscribe to emergency messages.
 
         Args:

--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -108,10 +108,10 @@ class CanopenServo(Servo):
         self.__emcy_observers.append(callback)
 
     def emcy_unsubscribe(self, callback: Callable[[EmergencyMessage], None]) -> None:
-        """Subscribe to emergency messages.
+        """Unsubscribe from emergency messages.
 
         Args:
-            callback: Callable that takes a EmergencyMessage instance as argument.
+            callback: Subscribed callback.
 
         """
         self.__emcy_observers.remove(callback)

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 try:
     import pysoem
@@ -38,22 +38,22 @@ class EmergencyMessage:
         else:
             raise NotImplementedError
 
-    def get_desc(self) -> str:
+    def get_desc(self) -> Optional[str]:
         """Get the error description from the servo's dictionary"""
         error_code = self.error_code & 0xFFFF
         if (
             self.servo.dictionary.errors is None
             or error_code not in self.servo.dictionary.errors.errors
         ):
-            return ""
+            return None
         error_description = self.servo.dictionary.errors.errors[error_code][-1]
         if error_description is None:
-            return ""
+            return None
         return error_description
 
     def __str__(self) -> str:
         text = "Error code 0x{:04X}".format(self.error_code)
         description = self.get_desc()
-        if description:
+        if description is not None:
             text = text + ", " + description
         return text

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -40,13 +40,12 @@ class EmergencyMessage:
 
     def get_desc(self) -> Optional[str]:
         """Get the error description from the servo's dictionary"""
-        error_code = self.error_code & 0xFFFF
         if (
             self.servo.dictionary.errors is None
-            or error_code not in self.servo.dictionary.errors.errors
+            or self.error_code not in self.servo.dictionary.errors.errors
         ):
             return None
-        error_description = self.servo.dictionary.errors.errors[error_code][-1]
+        error_description = self.servo.dictionary.errors.errors[self.error_code][-1]
         if error_description is None:
             return None
         return error_description

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -9,7 +9,7 @@ from canopen.emcy import EmcyError
 if TYPE_CHECKING:
     from pysoem import Emergency
 
-from ingenialink import Servo
+    from ingenialink import Servo
 
 
 class EmergencyMessage:
@@ -21,7 +21,7 @@ class EmergencyMessage:
 
     """
 
-    def __init__(self, servo: Servo, emergency_msg: Union["Emergency", EmcyError]):
+    def __init__(self, servo: "Servo", emergency_msg: Union["Emergency", EmcyError]):
         self.servo = servo
         if isinstance(emergency_msg, pysoem.Emergency):
             self.error_code = emergency_msg.error_code

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -1,0 +1,53 @@
+from typing import Union
+
+import pysoem
+from canopen.emcy import EmcyError
+
+from ingenialink import Servo
+
+
+class EmergencyMessage:
+    """Emergency message class.
+
+    Args:
+        servo: The servo that generated the emergency error.
+        emergency_msg: The emergency message instance from PySOEM or canopen.
+
+    """
+
+    def __init__(self, servo: Servo, emergency_msg: Union[pysoem.Emergency, EmcyError]):
+        self.servo = servo
+        if isinstance(emergency_msg, pysoem.Emergency):
+            self.error_code = emergency_msg.error_code
+            self.register = emergency_msg.error_reg
+            self.data = (
+                emergency_msg.b1.to_bytes(1, "little")
+                + emergency_msg.w1.to_bytes(2, "little")
+                + emergency_msg.w2.to_bytes(2, "little")
+            )
+        elif isinstance(emergency_msg, EmcyError):
+            self.error_code = emergency_msg.code
+            self.register = emergency_msg.register
+            self.data = emergency_msg.data
+        else:
+            raise NotImplementedError
+
+    def get_desc(self) -> str:
+        """Get the error description from the servo's dictionary"""
+        error_code = self.error_code & 0xFFFF
+        if (
+            self.servo.dictionary.errors is None
+            or error_code not in self.servo.dictionary.errors.errors
+        ):
+            return ""
+        error_description = self.servo.dictionary.errors.errors[error_code][-1]
+        if error_description is None:
+            return ""
+        return error_description
+
+    def __str__(self) -> str:
+        text = "Error code 0x{:04X}".format(self.error_code)
+        description = self.get_desc()
+        if description:
+            text = text + ", " + description
+        return text

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -51,8 +51,8 @@ class EmergencyMessage:
         return error_description
 
     def __str__(self) -> str:
-        text = "Error code 0x{:04X}".format(self.error_code)
+        text = f"Error code 0x{self.error_code:04X}"
         description = self.get_desc()
         if description is not None:
-            text = text + ", " + description
+            text = f"{text}, {description}"
         return text

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -1,7 +1,13 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
 
-import pysoem
+try:
+    import pysoem
+except ImportError:
+    pysoem = None
 from canopen.emcy import EmcyError
+
+if TYPE_CHECKING:
+    from pysoem import Emergency
 
 from ingenialink import Servo
 
@@ -15,7 +21,7 @@ class EmergencyMessage:
 
     """
 
-    def __init__(self, servo: Servo, emergency_msg: Union[pysoem.Emergency, EmcyError]):
+    def __init__(self, servo: Servo, emergency_msg: Union["Emergency", EmcyError]):
         self.servo = servo
         if isinstance(emergency_msg, pysoem.Emergency):
             self.error_code = emergency_msg.error_code

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -213,7 +213,6 @@ class EthercatNetwork(Network):
         if slave_id not in self.__last_init_nodes:
             raise ILError(f"Slave {slave_id} was not found.")
         slave = self._ecat_master.slaves[slave_id - 1]
-        slave.add_emergency_callback(self._emcy_callback)
         servo = EthercatServo(
             slave, slave_id, dictionary, self._connection_timeout, servo_status_listener
         )
@@ -540,10 +539,3 @@ class EthercatNetwork(Network):
             )
         logger.warning(log_message)
         return all_drives_in_preop
-
-    def _emcy_callback(self, emergency_msg: "pysoem.Emergency") -> None:
-        """Log the emergency messages"""
-        slave_id = emergency_msg.slave_pos
-        if servo := next((servo for servo in self.servos if servo.slave_id == slave_id), None):
-            error_description = servo.get_emergency_description(emergency_msg.error_code)
-            logger.warning(f"Emergency message received from slave {slave_id}: {error_description}")

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -1,7 +1,7 @@
 import os
 import time
 from enum import Enum
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import ingenialogger
 
@@ -263,6 +263,15 @@ class EthercatServo(PDOServo):
             subnode, ipb_address, dtype, size
         )
         return mapped_address
+
+    def emcy_subscribe(self, callback: Callable[[pysoem.Emergency], None]) -> None:
+        """Subscribe to emergency messages.
+
+        Args:
+            callback: Callable that takes a pysoem.Emergency instance as argument.
+
+        """
+        self.slave.add_emergency_callback(callback)
 
     def get_emergency_description(self, error_code: int) -> Optional[str]:
         """Get the error description from the error code.

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -278,10 +278,10 @@ class EthercatServo(PDOServo):
         self.__emcy_observers.append(callback)
 
     def emcy_unsubscribe(self, callback: Callable[[EmergencyMessage], None]) -> None:
-        """Subscribe to emergency messages.
+        """Unsubscribe from emergency messages.
 
         Args:
-            callback: Callable that takes a EmergencyMessage instance as argument.
+            callback: Subscribed callback.
 
         """
         self.__emcy_observers.remove(callback)

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -264,7 +264,7 @@ class EthercatServo(PDOServo):
         )
         return mapped_address
 
-    def emcy_subscribe(self, callback: Callable[[pysoem.Emergency], None]) -> None:
+    def emcy_subscribe(self, callback: Callable[["pysoem.Emergency"], None]) -> None:
         """Subscribe to emergency messages.
 
         Args:

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -9,6 +9,8 @@ from xml.dom import minidom
 
 import ingenialogger
 import numpy as np
+import pysoem
+from canopen.emcy import EmcyError
 
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
 from ingenialink.constants import (
@@ -1354,6 +1356,17 @@ class Servo:
 
         Raises:
             ILIOError: Error writing the register.
+
+        """
+        raise NotImplementedError
+
+    def emcy_subscribe(
+        self, callback: Callable[[Union[EmcyError, pysoem.Emergency]], None]
+    ) -> None:
+        """Subscribe to emergency messages.
+
+        Args:
+            callback: Callable that takes an EmcyError instance as argument.
 
         """
         raise NotImplementedError

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -9,8 +9,6 @@ from xml.dom import minidom
 
 import ingenialogger
 import numpy as np
-import pysoem
-from canopen.emcy import EmcyError
 
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
 from ingenialink.constants import (
@@ -1361,7 +1359,7 @@ class Servo:
         raise NotImplementedError
 
     def emcy_subscribe(
-        self, callback: Callable[[Union[EmcyError, pysoem.Emergency]], None]
+        self, callback: Callable[[Any], None]
     ) -> None:
         """Subscribe to emergency messages.
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1358,9 +1358,7 @@ class Servo:
         """
         raise NotImplementedError
 
-    def emcy_subscribe(
-        self, callback: Callable[[Any], None]
-    ) -> None:
+    def emcy_subscribe(self, callback: Callable[[Any], None]) -> None:
         """Subscribe to emergency messages.
 
         Args:

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -20,6 +20,7 @@ from ingenialink.constants import (
     PASSWORD_STORE_RESTORE_SUB_0,
 )
 from ingenialink.dictionary import Dictionary, DictionaryV3, Interface, SubnodeType
+from ingenialink.emcy import EmergencyMessage
 from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
@@ -1358,11 +1359,20 @@ class Servo:
         """
         raise NotImplementedError
 
-    def emcy_subscribe(self, callback: Callable[[Any], None]) -> None:
+    def emcy_subscribe(self, callback: Callable[[EmergencyMessage], None]) -> None:
         """Subscribe to emergency messages.
 
         Args:
-            callback: Callable that takes an EmcyError instance as argument.
+            callback: Callable that takes an EmergencyMessage instance as argument.
+
+        """
+        raise NotImplementedError
+
+    def emcy_unsubscribe(self, callback: Callable[[EmergencyMessage], None]) -> None:
+        """Unsubscribe from emergency messages.
+
+        Args:
+            callback: Subscribed callback.
 
         """
         raise NotImplementedError

--- a/tests/test_emcy.py
+++ b/tests/test_emcy.py
@@ -4,21 +4,30 @@ from ingenialink.exceptions import ILStateError
 
 
 class EmcyTest:
-    def emcy_test(emcy_msg):
-        pass
+    def __init__(self):
+        self.messages = []
+
+    def emcy_callback(self, emcy_msg):
+        self.messages.append(emcy_msg)
 
 
 @pytest.mark.canopen
 @pytest.mark.ethercat
-def test_emcy_callback(mocker, connect_to_slave):
+def test_emcy_callback(connect_to_slave):
     servo, _ = connect_to_slave
-    mocked = mocker.patch.object(EmcyTest, "emcy_test")
-    servo.emcy_subscribe(EmcyTest.emcy_test)
+    emcy_test = EmcyTest()
+    servo.emcy_subscribe(emcy_test.emcy_callback)
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
     servo.write("DRV_PROT_USER_OVER_VOLT", data=10.0, subnode=1)
     with pytest.raises(ILStateError):
         servo.enable()
     servo.fault_reset()
-    assert mocked.call_count == 2
+    assert len(emcy_test.messages) == 2
+    first_emcy = emcy_test.messages[0]
+    assert first_emcy.error_code == 0x3231
+    assert first_emcy.get_desc() == "User Over-voltage detected"
+    second_emcy = emcy_test.messages[1]
+    assert second_emcy.error_code == 0x0000
+    assert second_emcy.get_desc() == "No error"
     servo.write("DRV_PROT_USER_OVER_VOLT", data=prev_val, subnode=1)
-    servo.emcy_unsubscribe(EmcyTest.emcy_test)
+    servo.emcy_unsubscribe(emcy_test.emcy_callback)

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -252,7 +252,7 @@ def test_load_configuration_strict(mocker, connect_virtual_drive):
 
 
 @pytest.mark.no_connection
-def test_read_configuration_file(mocker):
+def test_read_configuration_file():
     test_file = "./tests/resources/test_config_file.xcf"
     device, registers = CanopenServo._read_configuration_file(test_file)
 

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -252,10 +252,9 @@ def test_load_configuration_strict(mocker, connect_virtual_drive):
 
 
 @pytest.mark.no_connection
-def test_read_configuration_file():
+def test_read_configuration_file(mocker):
     test_file = "./tests/resources/test_config_file.xcf"
-    servo = CanopenServo("test", 0, "./tests/resources/canopen/test_dict_can.xdf")
-    device, registers = servo._read_configuration_file(test_file)
+    device, registers = CanopenServo._read_configuration_file(test_file)
 
     assert device.attrib.get("PartNumber") == "EVE-NET-C"
     assert device.attrib.get("Interface") == "CAN"


### PR DESCRIPTION
### Description

Allow users to subscribe to EMCY messages.

Fixes # INGK-985

### Type of change

- Fix CANopen subscription.
- Add a method to subscribe to EtherCAT emergency messages.


### Tests
- Connect to CANopen / EtherCAT drive
- Subscribe to emergency messages
- Generate emergency messages
- Check that the callback function receives the emergency messages.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
