### PR TITLE
Ingk 989 implement node id depending registers in xdf v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Added
 - Method to subscribe to emergency messages.
+- Add is_node_id_dependent property to CanopenRegister
 
 ### Fixed
 - Restore CoE communication after a power cycle.

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -106,6 +106,6 @@ class CanopenRegister(Register):
         return self.idx
 
     @property
-    def is_node_id_dependent(self):
+    def is_node_id_dependent(self) -> bool:
         """True if register values depends on Node Id"""
         return self.__is_node_id_dependent

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -64,6 +64,7 @@ class CanopenRegister(Register):
         address_type: Optional[REG_ADDRESS_TYPE] = None,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
+        is_node_id_dependent: bool = False,
     ):
         super().__init__(
             dtype,
@@ -87,6 +88,7 @@ class CanopenRegister(Register):
 
         self.__idx = idx
         self.__subidx = subidx
+        self.__is_node_id_dependent = is_node_id_dependent
 
     @property
     def idx(self) -> int:
@@ -102,3 +104,8 @@ class CanopenRegister(Register):
     def mapped_address(self) -> int:
         """Register mapped address used for monitoring/disturbance."""
         return self.idx
+
+    @property
+    def is_node_id_dependent(self):
+        """True if register values depends on Node Id"""
+        return self.__is_node_id_dependent

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -433,6 +433,8 @@ class DictionaryV3(Dictionary):
     DEFAULT_ATTR = "default"
     CAT_ID_ATTR = "cat_id"
     UNITS_ATTR = "units"
+    IS_NODE_ID_DEPENDENT_ATTR = "is_node_id_dependent"
+    IS_NODE_ID_DEPENDENT_TRUE_ATTR_VALUE = "true"
 
     CANOPEN_OBJECTS_ELEMENT = "CANopenObjects"
     CANOPEN_OBJECT_ELEMENT = "CANopenObject"
@@ -877,6 +879,10 @@ class DictionaryV3(Dictionary):
         default = bytes.fromhex(subitem.attrib[self.DEFAULT_ATTR])
         cat_id = subitem.attrib[self.CAT_ID_ATTR]
         units = subitem.attrib.get(self.UNITS_ATTR)
+        is_node_id_dependent = (
+            subitem.attrib.get(self.IS_NODE_ID_DEPENDENT_ATTR)
+            == self.IS_NODE_ID_DEPENDENT_TRUE_ATTR_VALUE
+        )
         # Labels
         labels_element = self.__find_and_check(subitem, self.LABELS_ELEMENT)
         labels = self.__read_labels(labels_element)
@@ -903,6 +909,7 @@ class DictionaryV3(Dictionary):
             address_type=address_type,
             description=description,
             default=default,
+            is_node_id_dependent=is_node_id_dependent,
         )
         if subnode not in self._registers:
             self._registers[subnode] = {}

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -219,8 +219,9 @@ def test_register_description(dictionary_path):
                 == expected_description_per_subnode[subnode][register.identifier]
             )
 
+
 @pytest.mark.no_connection
-def test_register_description():
+def test_register_is_node_id_dependent():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
     assert canopen_dict.registers(0)["CIA301_COMMS_RPDO1_1"].is_node_id_dependent

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -203,6 +203,10 @@ def test_register_description(dictionary_path):
             "DRV_AXIS_NUMBER": "",
             "CIA301_COMMS_RPDO1_MAP": "",
             "CIA301_COMMS_RPDO1_MAP_1": "",
+            "CIA301_COMMS_RPDO1": "",
+            "CIA301_COMMS_RPDO1_1": "COB-Id used",
+            "CIA301_COMMS_RPDO1_2": "Transmission type",
+            "CIA301_COMMS_RPDO1_3": "Inhibit time",
         },
         1: {
             "COMMU_ANGLE_SENSOR": "Indicates the sensor used for angle readings",

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -48,6 +48,10 @@ def test_read_dictionary_registers():
         0: [
             "DRV_DIAG_ERROR_LAST_COM",
             "DRV_AXIS_NUMBER",
+            "CIA301_COMMS_RPDO1",
+            "CIA301_COMMS_RPDO1_1",
+            "CIA301_COMMS_RPDO1_2",
+            "CIA301_COMMS_RPDO1_3",
             "CIA301_COMMS_RPDO1_MAP",
             "CIA301_COMMS_RPDO1_MAP_1",
         ],
@@ -171,6 +175,10 @@ def test_register_default_values(dictionary_path):
             "DRV_AXIS_NUMBER": 1,
             "CIA301_COMMS_RPDO1_MAP": 1,
             "CIA301_COMMS_RPDO1_MAP_1": 268451936,
+            "CIA301_COMMS_RPDO1": 3,
+            "CIA301_COMMS_RPDO1_1": 2,
+            "CIA301_COMMS_RPDO1_2": 1,
+            "CIA301_COMMS_RPDO1_3": 0,
         },
         1: {
             "COMMU_ANGLE_SENSOR": 4,
@@ -210,3 +218,11 @@ def test_register_description(dictionary_path):
                 register.description
                 == expected_description_per_subnode[subnode][register.identifier]
             )
+
+@pytest.mark.no_connection
+def test_register_description():
+    dictionary_path = join_path(path_resources, dict_can_v3)
+    canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
+    assert canopen_dict.registers(0)["CIA301_COMMS_RPDO1_1"].is_node_id_dependent
+    assert not canopen_dict.registers(0)["CIA301_COMMS_RPDO1_2"].is_node_id_dependent
+    assert not canopen_dict.registers(0)["CIA301_COMMS_RPDO1_3"].is_node_id_dependent

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -31,6 +31,7 @@ def test_getters_canopen_register():
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
         "address_type": REG_ADDRESS_TYPE.NVM,
+        "is_node_id_dependent": True
     }
 
     register = CanopenRegister(
@@ -60,6 +61,7 @@ def test_getters_canopen_register():
     assert register.enums == reg_kwargs["enums"]
     assert register.enums_count == 2
     assert register.storage_valid == True
+    assert register.is_node_id_dependent is True
 
 
 @pytest.mark.canopen
@@ -95,3 +97,4 @@ def test_canopen_connection_register(connect_to_slave):
     assert register.cat_id == "TARGET"
     assert register.scat_id is None
     assert register.internal_use == 0
+    assert register.is_node_id_dependent is False

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -31,7 +31,7 @@ def test_getters_canopen_register():
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
         "address_type": REG_ADDRESS_TYPE.NVM,
-        "is_node_id_dependent": True
+        "is_node_id_dependent": True,
     }
 
     register = CanopenRegister(

--- a/tests/resources/canopen/test_dict_can_v3.0.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0.xdf
@@ -42,6 +42,30 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
+					<CANopenObject index="0x1400" subnode="0">
+						<Subitems>
+							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="CIA301_COMMS_RPDO1" cyclic="CONFIG" desc="" default="0300" cat_id="CIA402">
+								<Labels>
+									<Label lang="en_US">Highest subindex supported</Label>
+								</Labels>
+							</Subitem>
+							<Subitem subindex="1" address_type="NVM" access="rw" dtype="u32" id="CIA301_COMMS_RPDO1_1" cyclic="CONFIG" desc="COB-Id used" default="02000000" cat_id="CIA402" is_node_id_dependent="true">
+								<Labels>
+									<Label lang="en_US">COB-Id used</Label>
+								</Labels>
+							</Subitem>
+							<Subitem subindex="2" address_type="NVM" access="rw" dtype="u8" id="CIA301_COMMS_RPDO1_2" cyclic="CONFIG" desc="Transmission type" default="0100" cat_id="CIA402" is_node_id_dependent="false">
+								<Labels>
+									<Label lang="en_US">Transmission type</Label>
+								</Labels>
+							</Subitem>
+							<Subitem subindex="3" address_type="NVM" access="rw" dtype="u16" id="CIA301_COMMS_RPDO1_3" cyclic="CONFIG" desc="Inhibit time" default="000000" cat_id="CIA402">
+								<Labels>
+									<Label lang="en_US">Inhibit time</Label>
+								</Labels>
+							</Subitem>
+						</Subitems>
+					</CANopenObject >
 					<CANopenObject index="0x1600" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>


### PR DESCRIPTION
### Description

Implement register property to mark register as node id dependent

Fixes # INGK-989

### Type of change

- [x] Update CanopenRegister class
- [x] Update Dictionary v3 register read function

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
