### PR TITLE
INGK-988 Use a dataclass to represent a dictionary error

### DIFF
--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1,9 +1,9 @@
 import enum
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import astuple, dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple, Union
 
 import ingenialogger
 
@@ -116,17 +116,20 @@ class DictionaryCategories:
 
 @dataclass
 class DictionaryError:
-    id: int
+    id: str
     """The error ID."""
 
-    description: Optional[str]
-    """The error description."""
+    affected_module: str
+    """The module affected by the error."""
 
     error_type: str
     """The error type."""
 
-    affected_module: str
-    """The module affected by the error."""
+    description: Optional[str]
+    """The error description."""
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(astuple(self))
 
 
 class DictionaryErrors:
@@ -154,7 +157,7 @@ class DictionaryErrors:
             error_type = element.attrib["error_type"].capitalize()
             error_affected_module = element.attrib["affected_module"]
             self._errors[error_id] = DictionaryError(
-                error_id, error_description, error_type, error_affected_module
+                element.attrib["id"], error_affected_module, error_type, error_description
             )
 
     @property

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1,7 +1,7 @@
 import enum
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
-from dataclasses import astuple, dataclass
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple, Union
 
@@ -116,7 +116,7 @@ class DictionaryCategories:
 
 @dataclass
 class DictionaryError:
-    id: str
+    id: int
     """The error ID."""
 
     affected_module: str
@@ -128,8 +128,9 @@ class DictionaryError:
     description: Optional[str]
     """The error description."""
 
-    def __iter__(self) -> Iterator[str]:
-        return iter(astuple(self))
+    def __iter__(self) -> Iterator[Union[str, None]]:
+        id_hex_string = f"0x{self.id:08X}"
+        return iter((id_hex_string, self.affected_module, self.error_type, self.description))
 
 
 class Dictionary(ABC):
@@ -409,7 +410,7 @@ class Dictionary(ABC):
             error_type = element.attrib["error_type"].capitalize()
             error_affected_module = element.attrib["affected_module"]
             self.errors[error_id] = DictionaryError(
-                element.attrib["id"], error_affected_module, error_type, error_description
+                error_id, error_affected_module, error_type, error_description
             )
 
     @property

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -42,10 +42,10 @@ class EmergencyMessage:
         """Get the error description from the servo's dictionary"""
         if (
             self.servo.dictionary.errors is None
-            or self.error_code not in self.servo.dictionary.errors.errors
+            or self.error_code not in self.servo.dictionary.errors
         ):
             return None
-        error_description = self.servo.dictionary.errors.errors[self.error_code][-1]
+        error_description = self.servo.dictionary.errors[self.error_code].description
         if error_description is None:
             return None
         return error_description

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -19,7 +19,7 @@ from ingenialink.constants import (
     PASSWORD_STORE_ALL,
     PASSWORD_STORE_RESTORE_SUB_0,
 )
-from ingenialink.dictionary import Dictionary, DictionaryV3, Interface, SubnodeType
+from ingenialink.dictionary import Dictionary, DictionaryError, DictionaryV3, Interface, SubnodeType
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
 from ingenialink.enums.servo import SERVO_STATE
@@ -1472,12 +1472,9 @@ class Servo:
         return self.dictionary.subnodes
 
     @property
-    def errors(self) -> Dict[int, List[Optional[str]]]:
+    def errors(self) -> Dict[int, DictionaryError]:
         """Errors."""
-        if self.dictionary.errors:
-            return self.dictionary.errors.errors
-        else:
-            return {}
+        return self.dictionary.errors
 
     @property
     def info(self) -> Dict[str, Union[None, str, int]]:

--- a/tests/canopen/test_canopen_dictionary_v2.py
+++ b/tests/canopen/test_canopen_dictionary_v2.py
@@ -115,7 +115,7 @@ def test_read_dictionary_errors():
 
     canopen_dict = CanopenDictionaryV2(dictionary_path)
 
-    assert [error for error in canopen_dict.errors.errors] == expected_errors
+    assert [error for error in canopen_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -105,7 +105,7 @@ def test_read_dictionary_errors():
 
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
 
-    assert [error for error in canopen_dict.errors.errors] == expected_errors
+    assert [error for error in canopen_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/eoe/test_eoe_dictionary_v3.py
+++ b/tests/eoe/test_eoe_dictionary_v3.py
@@ -80,7 +80,7 @@ def test_read_dictionary_errors():
 
     ethercat_dict = DictionaryV3(dictionary_path, Interface.EoE)
 
-    assert [error for error in ethercat_dict.errors.errors] == expected_errors
+    assert [error for error in ethercat_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/ethercat/test_ethercat_dictionary_v2.py
+++ b/tests/ethercat/test_ethercat_dictionary_v2.py
@@ -120,7 +120,7 @@ def test_read_dictionary_errors():
 
     ethercat_dict = EthercatDictionaryV2(dictionary_path)
 
-    assert [error for error in ethercat_dict.errors.errors] == expected_errors
+    assert [error for error in ethercat_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -89,7 +89,7 @@ def test_read_dictionary_errors():
 
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
 
-    assert [error for error in ethercat_dict.errors.errors] == expected_errors
+    assert [error for error in ethercat_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/ethernet/test_ethernet_dictionary_v2.py
+++ b/tests/ethernet/test_ethernet_dictionary_v2.py
@@ -104,7 +104,7 @@ def test_read_dictionary_errors():
 
     ethernet_dict = EthernetDictionaryV2(dictionary_path)
 
-    assert [error for error in ethernet_dict.errors.errors] == expected_errors
+    assert [error for error in ethernet_dict.errors] == expected_errors
 
 
 @pytest.mark.no_connection

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -88,12 +88,12 @@ def test_merge_dictionaries_errors():
     moco_dict_path = f"{PATH_RESOURCE}comkit/core.xdf"
     coco_dict = EthernetDictionaryV2(coco_dict_path)
     moco_dict = EthernetDictionaryV2(moco_dict_path)
-    coco_num_errors = len(coco_dict.errors.errors)
+    coco_num_errors = len(coco_dict.errors)
     assert coco_num_errors == 1
-    moco_num_errors = len(moco_dict.errors.errors)
+    moco_num_errors = len(moco_dict.errors)
     assert moco_num_errors == 1
     merged_dict = coco_dict + moco_dict
-    merged_dict_num_errors = len(merged_dict.errors.errors)
+    merged_dict_num_errors = len(merged_dict.errors)
     assert merged_dict_num_errors == coco_num_errors + moco_num_errors
 
 
@@ -139,7 +139,7 @@ def test_merge_dictionaries_order_invariant():
     dict_b = EthernetDictionaryV2(moco_dict_path) + EthernetDictionaryV2(coco_dict_path)
     assert dict_a.registers(0).keys() == dict_b.registers(0).keys()
     assert dict_a.registers(1).keys() == dict_b.registers(1).keys()
-    assert dict_a.errors.errors == dict_b.errors.errors
+    assert dict_a.errors == dict_b.errors
     assert dict_a.product_code == dict_b.product_code
     assert dict_a.revision_number == dict_b.revision_number
     assert dict_a.firmware_version == dict_b.firmware_version


### PR DESCRIPTION
### Description

Use a dataclass to represent a dictionary error.

Fixes # INGK-988

### Type of change

- Create the DictionaryError class.
- Remove the DictionaryErrors class.


### Tests
- Update tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.


### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
