### PR TITLE
INGK-993 Create a separate EMCY test for COCO MOCO drives

### DIFF
--- a/tests/test_emcy.py
+++ b/tests/test_emcy.py
@@ -2,6 +2,8 @@ import pytest
 
 from ingenialink.exceptions import ILError
 
+EVEREST_PROJECT_NUMBER = 44
+
 
 class EmcyTest:
     def __init__(self):
@@ -11,10 +13,17 @@ class EmcyTest:
         self.messages.append(emcy_msg)
 
 
+def is_coco_moco(servo):
+    product_code = servo.read("DRV_ID_PRODUCT_CODE")
+    return product_code >> 20 == EVEREST_PROJECT_NUMBER
+
+
 @pytest.mark.canopen
 @pytest.mark.ethercat
 def test_emcy_callback(connect_to_slave):
     servo, _ = connect_to_slave
+    if is_coco_moco(servo):
+        pytest.skip("The test is not supported for COCO MOCO drives")
     emcy_test = EmcyTest()
     servo.emcy_subscribe(emcy_test.emcy_callback)
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
@@ -29,5 +38,28 @@ def test_emcy_callback(connect_to_slave):
     second_emcy = emcy_test.messages[1]
     assert second_emcy.error_code == 0x0000
     assert second_emcy.get_desc() == "No error"
+    servo.write("DRV_PROT_USER_OVER_VOLT", data=prev_val, subnode=1)
+    servo.emcy_unsubscribe(emcy_test.emcy_callback)
+
+
+@pytest.mark.canopen
+@pytest.mark.ethercat
+def test_emcy_callback_coco_moco(connect_to_slave):
+    # EMCY test for COCO MOCO drives
+    # Check INGK-993
+    servo, _ = connect_to_slave
+    if not is_coco_moco(servo):
+        pytest.skip("The test is only for COCO MOCO drives")
+    emcy_test = EmcyTest()
+    servo.emcy_subscribe(emcy_test.emcy_callback)
+    prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
+    servo.write("DRV_PROT_USER_OVER_VOLT", data=10.0, subnode=1)
+    with pytest.raises(ILError):
+        servo.enable()
+    try:
+        servo.fault_reset()
+    except ILError:
+        servo.fault_reset()
+    assert len(emcy_test.messages) > 0
     servo.write("DRV_PROT_USER_OVER_VOLT", data=prev_val, subnode=1)
     servo.emcy_unsubscribe(emcy_test.emcy_callback)

--- a/tests/test_emcy.py
+++ b/tests/test_emcy.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError
 
 EVEREST_PROJECT_NUMBER = 44
@@ -22,8 +23,8 @@ def is_coco_moco(servo):
 @pytest.mark.ethercat
 def test_emcy_callback(connect_to_slave):
     servo, _ = connect_to_slave
-    if is_coco_moco(servo):
-        pytest.skip("The test is not supported for COCO MOCO drives")
+    if isinstance(servo, EthercatServo) and is_coco_moco(servo):
+        pytest.skip("The test is not supported for COCO MOCO EtherCAT drives")
     emcy_test = EmcyTest()
     servo.emcy_subscribe(emcy_test.emcy_callback)
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
@@ -42,14 +43,13 @@ def test_emcy_callback(connect_to_slave):
     servo.emcy_unsubscribe(emcy_test.emcy_callback)
 
 
-@pytest.mark.canopen
 @pytest.mark.ethercat
-def test_emcy_callback_coco_moco(connect_to_slave):
-    # EMCY test for COCO MOCO drives
+def test_emcy_callback_coco_moco_ethercat(connect_to_slave):
+    # EMCY test for COCO MOCO EtherCAT drives
     # Check INGK-993
     servo, _ = connect_to_slave
     if not is_coco_moco(servo):
-        pytest.skip("The test is only for COCO MOCO drives")
+        pytest.skip("The test is only for COCO MOCO EtherCAT drives")
     emcy_test = EmcyTest()
     servo.emcy_subscribe(emcy_test.emcy_callback)
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)


### PR DESCRIPTION
### Type of change

- Create a separate EMCY test for COCO MOCO drives

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
