### PR TITLE
INGK-955 Test not being run on EtherCAT

### DIFF
--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -112,6 +112,7 @@ def create_disturbance(connect_to_slave, pytestconfig):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_save_configuration(connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -211,6 +212,7 @@ def test_check_configuration(virtual_drive, read_config, pytestconfig):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_load_configuration(connect_to_slave, read_config, pytestconfig):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -287,6 +289,7 @@ def test_read_configuration_file():
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_load_configuration_file_not_found(connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -299,6 +302,7 @@ def test_load_configuration_file_not_found(connect_to_slave):
 @pytest.mark.parametrize("subnode", [-1, "1"])
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_load_configuration_invalid_subnode(read_config, pytestconfig, connect_to_slave, subnode):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -311,6 +315,7 @@ def test_load_configuration_invalid_subnode(read_config, pytestconfig, connect_t
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_load_configuration_to_subnode_zero(read_config, pytestconfig, connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -395,6 +400,7 @@ def test_restore_parameters(connect_to_slave, connect_to_rack_service):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_read(connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -405,6 +411,7 @@ def test_read(connect_to_slave):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_write(connect_to_slave):
     servo, net = connect_to_slave
     assert servo is not None and net is not None
@@ -423,6 +430,7 @@ def test_write(connect_to_slave):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_monitoring_enable_disable(connect_to_slave):
     servo, net = connect_to_slave
     skip_if_monitoring_is_not_available(servo)
@@ -434,6 +442,7 @@ def test_monitoring_enable_disable(connect_to_slave):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_monitoring_remove_data(create_monitoring):
     servo, net = create_monitoring
     servo.monitoring_enable()
@@ -445,6 +454,7 @@ def test_monitoring_remove_data(create_monitoring):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_monitoring_map_register(connect_to_slave, pytestconfig):
     protocol = pytestconfig.getoption("--protocol")
     servo, net = connect_to_slave
@@ -472,6 +482,7 @@ def test_monitoring_map_register(connect_to_slave, pytestconfig):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_monitoring_data_size(create_monitoring):
     servo, net = create_monitoring
     servo.monitoring_enable()
@@ -484,6 +495,7 @@ def test_monitoring_data_size(create_monitoring):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_monitoring_read_data(create_monitoring):
     servo, net = create_monitoring
     servo.monitoring_enable()
@@ -501,6 +513,7 @@ def test_monitoring_read_data(create_monitoring):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_disturbance_enable_disable(connect_to_slave):
     servo, net = connect_to_slave
     skip_if_monitoring_is_not_available(servo)
@@ -512,6 +525,7 @@ def test_disturbance_enable_disable(connect_to_slave):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_disturbance_remove_data(create_disturbance):
     servo, net = create_disturbance
     servo.disturbance_enable()
@@ -525,6 +539,7 @@ def test_disturbance_remove_data(create_disturbance):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_disturbance_map_register(connect_to_slave, pytestconfig):
     protocol = pytestconfig.getoption("--protocol")
     servo, net = connect_to_slave
@@ -552,6 +567,7 @@ def test_disturbance_map_register(connect_to_slave, pytestconfig):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_disturbance_data_size(create_disturbance):
     servo, net = create_disturbance
     servo.disturbance_enable()
@@ -561,6 +577,7 @@ def test_disturbance_data_size(create_disturbance):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_enable_disable(connect_to_slave):
     servo, net = connect_to_slave
     servo.enable()
@@ -571,6 +588,7 @@ def test_enable_disable(connect_to_slave):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_fault_reset(connect_to_slave):
     servo, net = connect_to_slave
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
@@ -584,6 +602,7 @@ def test_fault_reset(connect_to_slave):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_is_alive(connect_to_slave):
     servo, net = connect_to_slave
     assert servo.is_alive()
@@ -591,6 +610,7 @@ def test_is_alive(connect_to_slave):
 
 @pytest.mark.canopen
 @pytest.mark.ethernet
+@pytest.mark.ethercat
 def test_status_word_wait_change(connect_to_slave):
     servo, net = connect_to_slave
     subnode = 1
@@ -602,6 +622,7 @@ def test_status_word_wait_change(connect_to_slave):
 
 @pytest.mark.ethernet
 @pytest.mark.canopen
+@pytest.mark.ethercat
 def test_disturbance_overflow(connect_to_slave, pytestconfig):
     protocol = pytestconfig.getoption("--protocol")
     servo, net = connect_to_slave

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from ingenialink.enums.register import REG_DTYPE
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
 
+@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "v_input, v_output, dtype",
     [
@@ -19,6 +20,7 @@ def test_convert_bytes_to_dtype(v_input, v_output, dtype):
     assert convert_bytes_to_dtype(v_input, dtype) == v_output
 
 
+@pytest.mark.no_connection
 def test_convert_bytes_to_dtype_wrong_string():
     wrong_data = b"\xff\xff\xff\xff\xff\x00"
     with pytest.raises(ILValueError):


### PR DESCRIPTION
### Type of change

- Add missing EtherCAT mark.
- Only test utils tests once.

### Tests
- [x] Run tests.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
