### PR TITLE
Volcano 611 in dictionary v 3 default volcano parser and ingenialink parser does not match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - Restore CoE communication after a power cycle.
 - Catch exception on disconnection when the PCAN is in bus-off state.
+- Default of byteArray512 are in bytes
 
 ### Changed
 - CiA 301 PDO related registers are not saved to the configuration file. 

--- a/examples/ethercat/process_data_objects.py
+++ b/examples/ethercat/process_data_objects.py
@@ -111,7 +111,7 @@ class ProcessDataExample:
         for index, _ in enumerate(self.servos):
             sys.stdout.write(f"Drive: {index} ")
             console_output = " ".join(
-                f"{item.register.identifier}: {item.value}" for item in self.tpdo_maps[index].items
+                f"{item.register.identifier}: {item.value!r}" for item in self.tpdo_maps[index].items
             )
             sys.stdout.write(console_output + " ")
         sys.stdout.flush()

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -118,7 +118,7 @@ class PDOMapItem:
         self.raw_data_bits = data_bits
 
     @property
-    def value(self) -> Union[int, float, bool]:
+    def value(self) -> Union[int, float, bool, bytes]:
         """Register value. Converts the raw data bytes into the register value.
 
         Raises:
@@ -128,7 +128,7 @@ class PDOMapItem:
         Returns:
             Register value.
         """
-        value: Union[bool, int, float, str]
+        value: Union[bool, int, float, str, bytes]
         if self.register.identifier == PADDING_REGISTER_IDENTIFIER:
             raise NotImplementedError(
                 "The register value must be read by the raw_data_bytes attribute."
@@ -168,7 +168,7 @@ class RPDOMapItem(PDOMapItem):
         super().__init__(register, size_bits)
 
     @property
-    def value(self) -> Union[int, float]:
+    def value(self) -> Union[int, float, bytes]:
         return super().value
 
     @value.setter

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -256,7 +256,7 @@ class Register(ABC):
         return self._description
 
     @property
-    def default(self) -> Union[None, int, float, str]:
+    def default(self) -> Union[None, int, float, str, bytes]:
         """Register default value"""
         if self._default is None:
             return self._default

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1285,8 +1285,6 @@ class Servo:
             raise ILAccessError("Register is Write-only")
 
         raw_read = self._read_raw(_reg, **kwargs)
-        if _reg.dtype == REG_DTYPE.BYTE_ARRAY_512:
-            return raw_read
         value = convert_bytes_to_dtype(raw_read, _reg.dtype)
         self._notify_register_update(_reg, value)
         return value

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -192,7 +192,7 @@ class INT_SIZES(Enum):
     U64_MAX = 18446744073709551615
 
 
-def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, str]:
+def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, str, bytes]:
     """Convert data in bytes to corresponding dtype.
 
     Bytes have to be ordered in LSB.
@@ -221,6 +221,8 @@ def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, s
             value = data.split(b"\x00")[0].decode("utf-8")
         except UnicodeDecodeError as e:
             raise ILValueError(f"Can't decode {e.object!r} to utf-8 string") from e
+    elif dtype == REG_DTYPE.BYTE_ARRAY_512:
+        return data
     else:
         value = int.from_bytes(data, "little", signed=signed)
     if dtype == REG_DTYPE.BOOL:
@@ -230,7 +232,7 @@ def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, s
     return value
 
 
-def convert_dtype_to_bytes(data: Union[int, float, str], dtype: REG_DTYPE) -> bytes:
+def convert_dtype_to_bytes(data: Union[int, float, str, bytes], dtype: REG_DTYPE) -> bytes:
     """Convert data in dtype to bytes.
 
     Bytes will be ordered in LSB.

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -15,6 +15,7 @@ logger = ingenialogger.get_logger(__name__)
 
 POLLING_MAX_TRIES = 5  # Seconds
 
+# Mapping type -> [Number of bytes, signedness]
 dtype_value: Dict[REG_DTYPE, Tuple[int, bool]] = {
     REG_DTYPE.U8: (1, False),
     REG_DTYPE.S8: (1, True),
@@ -194,9 +195,14 @@ class INT_SIZES(Enum):
 def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, str]:
     """Convert data in bytes to corresponding dtype.
 
+    Bytes have to be ordered in LSB.
+
     Args:
         data: data to convert
         dtype: output dtype
+
+    Returns:
+        Value formatted in data type
 
     Raises:
         ILValueError: If data can't be decoded in utf-8
@@ -226,9 +232,15 @@ def convert_bytes_to_dtype(data: bytes, dtype: REG_DTYPE) -> Union[float, int, s
 
 def convert_dtype_to_bytes(data: Union[int, float, str], dtype: REG_DTYPE) -> bytes:
     """Convert data in dtype to bytes.
+
+    Bytes will be ordered in LSB.
+
     Args:
         data: Data to convert.
         dtype: Data type.
+
+    Returns:
+        Value formatted to bytes
     """
     if (
         dtype == REG_DTYPE.BOOL

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -5,7 +5,7 @@ import pytest
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILAccessError, ILValueError
-from ingenialink.register import REG_ACCESS, REG_DTYPE, REG_PHY, Register, dtypes_ranges
+from ingenialink.register import REG_ACCESS, REG_DTYPE, REG_PHY, Register
 from ingenialink.virtual.network import VirtualNetwork
 from virtual_drive.core import VirtualDrive
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ def test_bytes_dtype_conversions(byts, value, dtype):
 
     assert convert_dtype_to_bytes(value, dtype) == byts
 
+
 @pytest.mark.no_connection
 def test_null_terminated_string():
     assert (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_by
         (b"\x34\x12\x75\x45", 0x45751234, REG_DTYPE.S32),
         (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
         (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
+        (bytes(512), bytes(512), REG_DTYPE.BYTE_ARRAY_512),
     ],
 )
 def test_bytes_dtype_conversions(byts, value, dtype):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,38 @@
 import pytest
 
-from ingenialink.exceptions import ILValueError
 from ingenialink.enums.register import REG_DTYPE
-from ingenialink.utils._utils import convert_bytes_to_dtype
+from ingenialink.exceptions import ILValueError
+from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_bytes
 
 
 @pytest.mark.parametrize(
-    "v_input, v_output, dtype",
+    "byts, value, dtype",
     [
-        (b"\x00", 0, REG_DTYPE.S32),
+        (b"\x03", 3, REG_DTYPE.U8),
+        (b"\x75\x00", 0x0075, REG_DTYPE.U16),
+        (b"\x35\x23", 0x2335, REG_DTYPE.U16),
+        (b"\x34\x12\x75\x45", 0x45751234, REG_DTYPE.U32),
+        (b"\xF2", -14, REG_DTYPE.S8),
+        (b"\x75\xF0", -3979, REG_DTYPE.S16),
+        (b"\x35\x23", 0x2335, REG_DTYPE.S16),
+        (b"\x34\x12\x75\x45", 0x45751234, REG_DTYPE.S32),
         (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
-        (b"\xFF", 255, REG_DTYPE.U16),
         (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
-        (b"\x74\x68\x61\x74\x27\x73\x20\x67\x6f\x6f\x64\x00\xca\xca", "that's good", REG_DTYPE.STR),
     ],
 )
-def test_convert_bytes_to_dtype(v_input, v_output, dtype):
-    assert convert_bytes_to_dtype(v_input, dtype) == v_output
+def test_bytes_dtype_conversions(byts, value, dtype):
+    assert convert_bytes_to_dtype(byts, dtype) == value
+
+    assert convert_dtype_to_bytes(value, dtype) == byts
+
+
+def test_null_terminated_string():
+    assert (
+        convert_bytes_to_dtype(
+            b"\x74\x68\x61\x74\x27\x73\x20\x67\x6f\x6f\x64\x00\xca\xca", REG_DTYPE.STR
+        )
+        == "that's good"
+    )
 
 
 def test_convert_bytes_to_dtype_wrong_string():


### PR DESCRIPTION
### Description

No major changes to user functionality, the default of bytearray512 is now given in bytes.
Also improved the doc and tests, to have a reference on the PR of the other project.

Fixes VOLCANO-611

### Type of change

- [x] Improved doc of utils
- [x] Improved tests of byte to value and value to bytes conversion
- [x] Default of byteArray512 are in bytes

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [ ] Set fix version field in the Jira issue.
