### PR TITLE
Move virtual drive fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.virtual.network import VirtualNetwork
-from tests.virtual.test_virtual_network import TEST_PORT
 from virtual_drive.core import VirtualDrive
 
 DEFAULT_PROTOCOL = "no_connection"
@@ -126,8 +125,7 @@ def connect_to_slave(pytestconfig, read_config):
 
 @pytest.fixture()
 def virtual_drive():
-    test_port = 81
-    server = VirtualDrive(test_port)
+    server = VirtualDrive(81)
     server.start()
     net = VirtualNetwork()
     virtual_servo = net.connect_to_slave(server.dictionary_path, server.port)
@@ -138,7 +136,7 @@ def virtual_drive():
 @pytest.fixture()
 def virtual_drive_custom_dict():
     servers: list[VirtualDrive] = []
-    next_port = itertools.count(TEST_PORT)
+    next_port = itertools.count(81)
 
     def connect(dictionary):
         server = VirtualDrive(next(next_port), dictionary)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,8 +143,8 @@ def virtual_drive_custom_dict():
         servers.append(server)
         server.start()
         net = VirtualNetwork()
-        virtual_servo = net.connect_to_slave(server.dictionary_path, server.port)
-        return server, net, virtual_servo
+        servo = net.connect_to_slave(server.dictionary_path, server.port)
+        return server, net, servo
 
     yield connect
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -6,28 +6,12 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILAccessError, ILValueError
 from ingenialink.register import REG_ACCESS, REG_DTYPE, REG_PHY, Register
-from ingenialink.virtual.network import VirtualNetwork
-from virtual_drive.core import VirtualDrive
-
-TEST_PORT = 82
-server = VirtualDrive(TEST_PORT)
-
-
-@pytest.fixture(scope="function")
-def stop_virtual_drive():
-    yield
-    server.stop()
 
 
 @pytest.fixture
-def connect_virtual_drive_with_bool_register():
+def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
     def connect(dictionary):
-        global server
-        server.stop()
-        server = VirtualDrive(TEST_PORT, dictionary)
-        server.start()
-        net = VirtualNetwork()
-        servo = net.connect_to_slave(dictionary, TEST_PORT)
+        server, net, servo = virtual_drive_custom_dict(dictionary)
 
         boolean_reg_uid = "TEST_BOOLEAN"
         bool_register = EthernetRegister(
@@ -216,7 +200,6 @@ def test_register_mapped_address(subnode, address, mapped_address_eth, mapped_ad
         (True, True),
     ],
 )
-@pytest.mark.usefixtures("stop_virtual_drive")
 @pytest.mark.no_connection
 def test_bit_register(connect_virtual_drive_with_bool_register, write_value, expected_read_value):
     dictionary = os.path.join("virtual_drive/resources/", "virtual_drive.xdf")
@@ -232,7 +215,6 @@ def test_bit_register(connect_virtual_drive_with_bool_register, write_value, exp
     [2, "one"],
 )
 @pytest.mark.no_connection
-@pytest.mark.usefixtures("stop_virtual_drive")
 def test_bit_register_write_invalid_value(connect_virtual_drive_with_bool_register, write_value):
     dictionary = os.path.join("virtual_drive/resources/", "virtual_drive.xdf")
     servo, _ = connect_virtual_drive_with_bool_register(dictionary)

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -20,11 +20,7 @@ from ingenialink.exceptions import (
 )
 from ingenialink.register import REG_ADDRESS_TYPE
 from ingenialink.servo import SERVO_STATE
-from tests.virtual.test_virtual_network import (
-    RESOURCES_FOLDER,
-    connect_virtual_drive,  # noqa: F401
-    stop_virtual_drive,  # noqa: F401
-)
+from tests.virtual.test_virtual_network import RESOURCES_FOLDER
 
 MONITORING_CH_DATA_SIZE = 4
 MONITORING_NUM_SAMPLES = 100
@@ -252,10 +248,9 @@ def test_load_configuration(connect_to_slave):
 
 
 @pytest.mark.no_connection
-@pytest.mark.usefixtures("stop_virtual_drive")
-def test_load_configuration_strict(mocker, connect_virtual_drive):  # noqa: F811
+def test_load_configuration_strict(mocker, virtual_drive_custom_dict):  # noqa: F811
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
-    servo, net = connect_virtual_drive(dictionary)
+    server, net, servo = virtual_drive_custom_dict(dictionary)
     test_file = "./tests/resources/test_config_file.xcf"
     mocker.patch("ingenialink.servo.Servo.write", side_effect=ILError("Error writing"))
     with pytest.raises(ILError) as exc_info:
@@ -640,12 +635,12 @@ def test_disturbance_overflow(connect_to_slave, pytestconfig):
 
 
 @pytest.mark.no_connection
-def test_subscribe_register_updates(connect_virtual_drive):  # noqa: F811
+def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
     user_over_voltage_uid = "DRV_PROT_USER_OVER_VOLT"
     register_update_callback = RegisterUpdateTest()
 
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
-    servo, _ = connect_virtual_drive(dictionary)
+    server, net, servo = virtual_drive_custom_dict(dictionary)
     servo.register_update_subscribe(register_update_callback.register_update_test)
 
     previous_reg_value = servo.read(user_over_voltage_uid, subnode=1)

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -8,9 +8,7 @@ from ingenialink.network import NET_STATE
 from virtual_drive.core import VirtualDrive
 
 RESOURCES_FOLDER = "virtual_drive/resources/"
-TEST_PORT = 82
 
-server = VirtualDrive(TEST_PORT)
 
 
 @pytest.mark.no_connection

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -5,7 +5,6 @@ import pytest
 
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
 from ingenialink.network import NET_STATE
-from ingenialink.virtual.network import VirtualNetwork
 from virtual_drive.core import VirtualDrive
 
 RESOURCES_FOLDER = "virtual_drive/resources/"
@@ -14,31 +13,10 @@ TEST_PORT = 82
 server = VirtualDrive(TEST_PORT)
 
 
-@pytest.fixture(autouse=True, scope="function")
-def stop_virtual_drive():
-    yield
-    server.stop()
-
-
-@pytest.fixture
-def connect_virtual_drive():
-    def connect(dictionary):
-        global server
-        server.stop()
-        server = VirtualDrive(TEST_PORT, dictionary)
-        server.start()
-        net = VirtualNetwork()
-        servo = net.connect_to_slave(dictionary, TEST_PORT)
-        return servo, net
-
-    return connect
-
-
 @pytest.mark.no_connection
-def test_connect_to_virtual_drive(connect_virtual_drive):
+def test_connect_to_virtual_drive(virtual_drive_custom_dict):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
-    connect = connect_virtual_drive
-    servo, net = connect(dictionary)
+    server, net, servo = virtual_drive_custom_dict(dictionary)
     assert servo is not None and net is not None
     assert len(net.servos) == 1
     fw_version = servo.read("DRV_ID_SOFTWARE_VERSION")
@@ -46,9 +24,9 @@ def test_connect_to_virtual_drive(connect_virtual_drive):
 
 
 @pytest.mark.no_connection
-def test_virtual_drive_disconnection(connect_virtual_drive):
+def test_virtual_drive_disconnection(virtual_drive_custom_dict):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
-    servo, net = connect_virtual_drive(dictionary)
+    server, net, servo = virtual_drive_custom_dict(dictionary)
     net.disconnect_from_slave(servo)
     assert net.get_servo_state(VirtualDrive.IP_ADDRESS) == NET_STATE.DISCONNECTED
     assert len(net.servos) == 0
@@ -56,13 +34,13 @@ def test_virtual_drive_disconnection(connect_virtual_drive):
 
 
 @pytest.mark.no_connection
-def test_connect_virtual_custom_dictionaries(connect_virtual_drive, read_config):
+def test_connect_virtual_custom_dictionaries(virtual_drive_custom_dict, read_config):
     config = read_config
     for protocol in ["ethernet", "canopen"]:
         dictionary = config[protocol]["dictionary"]
         if not os.path.exists(dictionary):
             continue
-        servo, net = connect_virtual_drive(dictionary)
+        server, net, servo = virtual_drive_custom_dict(dictionary)
         assert servo is not None and net is not None
         assert len(net.servos) == 1
         fw_version = servo.read("DRV_ID_SOFTWARE_VERSION")

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -10,7 +10,6 @@ from virtual_drive.core import VirtualDrive
 RESOURCES_FOLDER = "virtual_drive/resources/"
 
 
-
 @pytest.mark.no_connection
 def test_connect_to_virtual_drive(virtual_drive_custom_dict):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")


### PR DESCRIPTION
I had problems on running some unrelated tests on the CI for this PR: https://github.com/ingeniamc/ingenialink-python/pull/497
The tests failing did not have anything to do with the ones introduced, just that they used virtual drive.
Apparently some tests had a virtual drive global variable and a weird autouse stop fixture that was explicitly used in some cases. 
The pattern is flawed and I think that some tests left the server open, so depending on the set or order that you run the tests you get a timeout error or not. The first fixture is the responsible to cleanup what has created.

I have created a new fixture that allows to create N virtual drives with the dictionary that you want and adapted the tests that had this use case