### PR TITLE
INGK-1001 Include formatting and linting on virtual drive

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,8 +32,8 @@ Please update the documentation.
 
 ### Code formatting and linting
 
-- [ ] Use the ruff package to format the code: `ruff format ingenialink tests`.
-- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests`.
+- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
+- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.
 
 ### Others
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,8 @@ skip_install = true
 deps =
     ruff==0.2.2
 commands =
-    ruff format --check {posargs:ingenialink tests}
-    ruff check {posargs:ingenialink tests}
+    ruff format --check {posargs:ingenialink tests virtual_drive}
+    ruff check {posargs:ingenialink tests virtual_drive}
 
 [testenv:type]
 description = run type checks

--- a/virtual_drive/__init__.py
+++ b/virtual_drive/__init__.py
@@ -1,1 +1,1 @@
-from .core import VirtualDrive
+

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1316,7 +1316,7 @@ class VirtualDrive(Thread):
         while not self.__stop:
             try:
                 frame, add = self.socket.recvfrom(ETH_BUF_SIZE)
-            except:
+            except Exception:
                 continue
             reg_add, subnode, cmd, data = MCB.read_mcb_frame(frame)
             self.__log(add, frame, MSG_TYPE.RECEIVED)


### PR DESCRIPTION
### Type of change

- Fix linting errors.
- Update the tox environment to include the virtual_drive folder.
- Update the PR template.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
