### PR TITLE
INGK-1007 add function to quickly read product code and revision number from dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Method to subscribe to register value updates.
 - Add is_node_id_dependent property to CanopenRegister
 - Methods to get/set the MAC Address of Ethernet drives.
+- Add get_dictionary_description in DictionaryFactory
 
 ### Fixed
 - Restore CoE communication after a power cycle.

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -661,7 +661,7 @@ class DictionaryV3(Dictionary):
         else:
             device_element = root.find(self.__DEVICE_ELEMENT[self.interface])
         if device_element is None:
-            raise ILDictionaryParseError("Dictionary can not be used for the chose communication")
+            raise ILDictionaryParseError("Dictionary cannot be used for the chosen communication")
         self.__read_device_attributes(device_element)
         if self.interface == Interface.ETH:
             self.__read_device_eth(device_element)
@@ -1098,6 +1098,13 @@ class DictionaryV2(Dictionary):
         },
     }
 
+    _INTERFACE_STR = {
+        Interface.CAN: "CAN",
+        Interface.ECAT: "ETH",
+        Interface.EoE: "ETH",
+        Interface.ETH: "ETH",
+    }
+
     @classmethod
     def get_description(cls, dictionary_path: str, interface: Interface) -> DictionaryDescriptor:
         try:
@@ -1111,6 +1118,9 @@ class DictionaryV2(Dictionary):
             raise ILDictionaryParseError(
                 f"Could not load the dictionary {dictionary_path}. Device information is missing"
             )
+        dict_interface = device.attrib.get("Interface")
+        if cls._INTERFACE_STR[interface] != dict_interface and dict_interface is not None:
+            raise ILDictionaryParseError("Dictionary cannot be used for the chosen communication")
         firmware_version = device.attrib.get("firmwareVersion")
         product_code = device.attrib.get("ProductCode")
         if product_code is not None and product_code.isdecimal():

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -538,8 +538,10 @@ class DictionaryV3(Dictionary):
         try:
             with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
                 tree = ET.parse(xdf_file)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"There is not any xdf file in the path: {dictionary_path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"There is not any xdf file in the path: {dictionary_path}"
+            ) from e
         root = tree.getroot()
         device_path = (
             f"{cls.__BODY_ELEMENT}/{cls.__DEVICES_ELEMENT}/{cls.__DEVICE_ELEMENT[interface]}"
@@ -575,8 +577,8 @@ class DictionaryV3(Dictionary):
         try:
             with open(self.path, "r", encoding="utf-8") as xdf_file:
                 tree = ET.parse(xdf_file)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}") from e
         root = tree.getroot()
         drive_image_element = self.__find_and_check(root, self.__DRIVE_IMAGE_ELEMENT)
         self.__read_drive_image(drive_image_element)
@@ -1110,8 +1112,10 @@ class DictionaryV2(Dictionary):
         try:
             with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
                 tree = ET.parse(xdf_file)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"There is not any xdf file in the path: {dictionary_path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"There is not any xdf file in the path: {dictionary_path}"
+            ) from e
         root = tree.getroot()
         device = root.find(cls.__DICT_ROOT_DEVICE)
         if device is None:
@@ -1139,8 +1143,8 @@ class DictionaryV2(Dictionary):
         try:
             with open(self.path, "r", encoding="utf-8") as xdf_file:
                 tree = ET.parse(xdf_file)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}")
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}") from e
         root = tree.getroot()
 
         device = root.find(self.__DICT_ROOT_DEVICE)

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -546,7 +546,9 @@ class DictionaryV3(Dictionary):
         device_path = (
             f"{cls.__BODY_ELEMENT}/{cls.__DEVICES_ELEMENT}/{cls.__DEVICE_ELEMENT[interface]}"
         )
-        device = cls.__find_and_check(root, device_path)
+        device = root.find(device_path)
+        if device is None:
+            raise ILDictionaryParseError("Dictionary cannot be used for the chosen communication")
         firmware_version = device.attrib[cls.__DEVICE_FW_VERSION_ATTR]
         product_code = int(device.attrib[cls.__DEVICE_PRODUCT_CODE_ATTR])
         part_number = device.attrib[cls.__DEVICE_PART_NUMBER_ATTR]

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -19,7 +19,15 @@ from ingenialink.constants import (
     PASSWORD_STORE_ALL,
     PASSWORD_STORE_RESTORE_SUB_0,
 )
-from ingenialink.dictionary import Dictionary, DictionaryError, DictionaryV3, Interface, SubnodeType
+from ingenialink.dictionary import (
+    Dictionary,
+    DictionaryDescriptor,
+    DictionaryError,
+    DictionaryV2,
+    DictionaryV3,
+    Interface,
+    SubnodeType,
+)
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
 from ingenialink.enums.servo import SERVO_STATE
@@ -86,6 +94,31 @@ class DictionaryFactory:
                 return EthernetDictionaryV2(dictionary_path)
             if interface == Interface.VIRTUAL:
                 return VirtualDictionary(dictionary_path)
+        raise NotImplementedError(f"Dictionary version {major_version} is not supported")
+
+    @classmethod
+    def get_dictionary_description(
+        cls, dictionary_path: str, interface: Interface
+    ) -> DictionaryDescriptor:
+        """Quick function to get target dictionary description
+
+        Args:
+            dictionary_path: target dictionary path
+            interface: device interface
+
+        Returns:
+            Target dictionary description
+
+        Raises:
+            FileNotFoundError: dictionary path does not exist.
+            ILDictionaryParseError: xdf is not well-formed.
+            NotImplementedError: Dictionary version is not supported.
+        """
+        major_version, minor_version = cls.__get_dictionary_version(dictionary_path)
+        if major_version == 3:
+            return DictionaryV3.get_description(dictionary_path, interface)
+        if major_version == 2:
+            return DictionaryV2.get_description(dictionary_path, interface)
         raise NotImplementedError(f"Dictionary version {major_version} is not supported")
 
     @classmethod

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -161,7 +161,7 @@ def test_safety_pdo_not_implemented():
 @pytest.mark.no_connection
 def test_wrong_dictionary():
     with pytest.raises(
-        ILDictionaryParseError, match="Dictionary can not be used for the chose communication"
+        ILDictionaryParseError, match="Dictionary cannot be used for the chosen communication"
     ):
         DictionaryV3("./tests/resources/test_dict_ecat_eoe_v3.0.xdf", Interface.CAN)
 

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -195,7 +195,7 @@ def test_safety_tpdo_not_exist():
 @pytest.mark.no_connection
 def test_wrong_dictionary():
     with pytest.raises(
-        ILDictionaryParseError, match="Dictionary can not be used for the chose communication"
+        ILDictionaryParseError, match="Dictionary cannot be used for the chosen communication"
     ):
         DictionaryV3("./tests/resources/canopen/test_dict_can_v3.0.xdf", Interface.ECAT)
 

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -76,7 +76,9 @@ def test_dictionary_description(
     "dict_path, interface, raises",
     [
         (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
-        (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}canopen/test_dict_can.xdf", Interface.ECAT, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}test_dict_ecat_eoe_v3.0.xdf", Interface.CAN, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}ethercat/test_dict_ethercat.xdf", Interface.CAN, ILDictionaryParseError),
         (f"{PATH_RESOURCE}test_no_dict.xdf", Interface.ECAT, FileNotFoundError),
     ],
 )

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -8,7 +8,13 @@ from xml.dom import minidom
 import pytest
 
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
-from ingenialink.dictionary import DictionaryDescriptor, DictionaryV2, DictionaryV3, Interface, ILDictionaryParseError
+from ingenialink.dictionary import (
+    DictionaryDescriptor,
+    DictionaryV2,
+    DictionaryV3,
+    ILDictionaryParseError,
+    Interface,
+)
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
 from ingenialink.servo import DictionaryFactory
@@ -51,7 +57,7 @@ PATH_TO_DICTIONARY = "./virtual_drive/resources/virtual_drive.xdf"
             57745409,
             "CAP-NET-E",
             196635,
-        )
+        ),
     ],
 )
 def test_dictionary_description(
@@ -65,17 +71,16 @@ def test_dictionary_description(
         revision_number=revision_number,
     )
 
+
 @pytest.mark.parametrize(
     "dict_path, interface, raises",
     [
         (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
         (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
         (f"{PATH_RESOURCE}test_no_dict.xdf", Interface.ECAT, FileNotFoundError),
-    ]
+    ],
 )
-def test_dictionary_description_fail(
-    dict_path, interface, raises
-):
+def test_dictionary_description_fail(dict_path, interface, raises):
     with pytest.raises(raises):
         DictionaryFactory.get_dictionary_description(dict_path, interface)
 

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -8,13 +8,76 @@ from xml.dom import minidom
 import pytest
 
 from ingenialink.canopen.dictionary import CanopenDictionaryV2
-from ingenialink.dictionary import DictionaryV2, DictionaryV3, Interface
+from ingenialink.dictionary import DictionaryDescriptor, DictionaryV2, DictionaryV3, Interface, ILDictionaryParseError
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
 from ingenialink.servo import DictionaryFactory
 
 PATH_RESOURCE = "./tests/resources/"
 PATH_TO_DICTIONARY = "./virtual_drive/resources/virtual_drive.xdf"
+
+
+@pytest.mark.parametrize(
+    "dict_path, interface, fw_version, product_code, part_number, revision_number",
+    [
+        (
+            f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf",
+            Interface.CAN,
+            "2.4.1",
+            61939713,
+            "EVS-NET-C",
+            196617,
+        ),
+        (
+            f"{PATH_RESOURCE}comkit/com-kit.xdf",
+            Interface.ETH,
+            "1.4.7",
+            123456789,
+            None,
+            12345,
+        ),
+        (
+            f"{PATH_RESOURCE}ethercat/test_dict_ethercat.xdf",
+            Interface.ECAT,
+            "2.0.1",
+            57745409,
+            "CAP-NET-E",
+            196635,
+        ),
+        (
+            f"{PATH_RESOURCE}ethercat/test_dict_ethercat.xdf",
+            Interface.ETH,
+            "2.0.1",
+            57745409,
+            "CAP-NET-E",
+            196635,
+        )
+    ],
+)
+def test_dictionary_description(
+    dict_path, interface, fw_version, product_code, part_number, revision_number
+):
+    dict_description = DictionaryFactory.get_dictionary_description(dict_path, interface)
+    assert dict_description == DictionaryDescriptor(
+        firmware_version=fw_version,
+        product_code=product_code,
+        part_number=part_number,
+        revision_number=revision_number,
+    )
+
+@pytest.mark.parametrize(
+    "dict_path, interface, raises",
+    [
+        (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}test_no_dict.xdf", Interface.ECAT, FileNotFoundError),
+    ]
+)
+def test_dictionary_description_fail(
+    dict_path, interface, raises
+):
+    with pytest.raises(raises):
+        DictionaryFactory.get_dictionary_description(dict_path, interface)
 
 
 @pytest.mark.parametrize("dictionary_class", [CanopenDictionaryV2, EthernetDictionaryV2])


### PR DESCRIPTION
Add function to read product code and revision number from dictionary quickly

Fixes # INGK-1007

### Type of change

- [x] Add get_dictionary_description in DictionaryFactory

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
