### PR TITLE
INGK-1008 Raise exception if DictionaryV2 does not match interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed
 - CiA 301 PDO related registers are not saved to the configuration file. 
 - Remove an unnecessary argument for a servo status listener callback.
+- DictionaryV2 raises an exception if the interface does not match.
 
 ## [7.3.5] - 2025-08-23
 

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -38,8 +38,7 @@ class CanopenDictionaryV2(DictionaryV2):
         ),
     ]
 
-    def __init__(self, dictionary_path: str):
-        super().__init__(dictionary_path, Interface.CAN)
+    interface = Interface.CAN
 
     def _read_xdf_register(self, register: ET.Element) -> Optional[CanopenRegister]:
         current_read_register = super()._read_xdf_register(register)

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1185,7 +1185,9 @@ class DictionaryV2(Dictionary):
         revision_number = device.attrib.get("RevisionNumber")
         if revision_number is not None and revision_number.isdecimal():
             self.revision_number = int(revision_number)
-        self.dict_interface = device.attrib.get("Interface")
+        dict_interface = device.attrib.get("Interface")
+        if self._INTERFACE_STR[self.interface] != dict_interface and dict_interface is not None:
+            raise ILDictionaryParseError("Dictionary cannot be used for the chosen communication")
 
         if root.findall(self.__DICT_ROOT_AXES):
             # For each axis

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1107,6 +1107,9 @@ class DictionaryV2(Dictionary):
         Interface.ETH: "ETH",
     }
 
+    def __init__(self, dictionary_path: str) -> None:
+        super().__init__(dictionary_path, self.interface)
+
     @classmethod
     def get_description(cls, dictionary_path: str, interface: Interface) -> DictionaryDescriptor:
         try:
@@ -1185,8 +1188,12 @@ class DictionaryV2(Dictionary):
         revision_number = device.attrib.get("RevisionNumber")
         if revision_number is not None and revision_number.isdecimal():
             self.revision_number = int(revision_number)
-        dict_interface = device.attrib.get("Interface")
-        if self._INTERFACE_STR[self.interface] != dict_interface and dict_interface is not None:
+        self.dict_interface = device.attrib.get("Interface")
+        if (
+            self.interface != Interface.VIRTUAL
+            and self._INTERFACE_STR[self.interface] != self.dict_interface
+            and self.dict_interface is not None
+        ):
             raise ILDictionaryParseError("Dictionary cannot be used for the chosen communication")
 
         if root.findall(self.__DICT_ROOT_AXES):

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -129,8 +129,7 @@ class EthercatDictionaryV2(DictionaryV2):
         ),
     ]
 
-    def __init__(self, dictionary_path: str):
-        super().__init__(dictionary_path, Interface.ECAT)
+    interface = Interface.ECAT
 
     @staticmethod
     def __get_cia_offset(subnode: int) -> int:

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -38,8 +38,7 @@ class EthernetDictionaryV2(DictionaryV2):
         ),
     ]
 
-    def __init__(self, dictionary_path: str) -> None:
-        super().__init__(dictionary_path, Interface.ETH)
+    interface = Interface.ETH
 
     def _read_xdf_register(self, register: ET.Element) -> Optional[EthernetRegister]:
         current_read_register = super()._read_xdf_register(register)

--- a/ingenialink/virtual/dictionary.py
+++ b/ingenialink/virtual/dictionary.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import ingenialogger
 
+from ingenialink.dictionary import Interface
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
 from ingenialink.ethernet.register import EthernetRegister
 
@@ -18,6 +19,8 @@ class VirtualDictionary(EthernetDictionaryV2):
         dictionary_path: Path to the Ingenia dictionary.
 
     """
+
+    interface = Interface.VIRTUAL
 
     def _transform_canopen_index_to_mcb_address(self, index: int, subnode: int) -> int:
         """CANopen index is an uint16 but MCB address only has 12 bits, so,

--- a/tests/resources/canopen/test_dict_can.xdf
+++ b/tests/resources/canopen/test_dict_can.xdf
@@ -99,5 +99,6 @@
     </Errors>
   </Body>
   <DriveImage encoding="xs:base64Binary">
+    test_image
   </DriveImage>
 </IngeniaDictionary>

--- a/tests/resources/ethernet/test_dict_eth.xdf
+++ b/tests/resources/ethernet/test_dict_eth.xdf
@@ -95,5 +95,6 @@
     </Errors>
   </Body>
   <DriveImage encoding="xs:base64Binary">
+    test_image
   </DriveImage>
 </IngeniaDictionary>

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -130,6 +130,7 @@ def test_dictionary_factory(dict_path, interface, dict_class):
     test_dict = DictionaryFactory.create_dictionary(dict_path, interface)
     assert isinstance(test_dict, dict_class)
 
+
 @pytest.mark.no_connection
 @pytest.mark.parametrize(
     "dict_path, interface, raises",

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -87,17 +87,29 @@ def test_dictionary_description_fail(dict_path, interface, raises):
         DictionaryFactory.get_dictionary_description(dict_path, interface)
 
 
-@pytest.mark.parametrize("dictionary_class", [CanopenDictionaryV2, EthernetDictionaryV2])
+@pytest.mark.parametrize(
+    "dictionary_class, dictionary_path",
+    [
+        (CanopenDictionaryV2, f"{PATH_RESOURCE}canopen/test_dict_can.xdf"),
+        (EthernetDictionaryV2, f"{PATH_RESOURCE}ethernet/test_dict_eth.xdf"),
+    ],
+)
 @pytest.mark.no_connection
-def test_dictionary_v2_image(dictionary_class):
-    dictionary = dictionary_class(PATH_TO_DICTIONARY)
+def test_dictionary_v2_image(dictionary_class, dictionary_path):
+    dictionary = dictionary_class(dictionary_path)
     assert isinstance(dictionary.image, str)
 
 
-@pytest.mark.parametrize("dictionary_class", [CanopenDictionaryV2, EthernetDictionaryV2])
+@pytest.mark.parametrize(
+    "dictionary_class, dictionary_path",
+    [
+        (CanopenDictionaryV2, f"{PATH_RESOURCE}canopen/test_dict_can.xdf"),
+        (EthernetDictionaryV2, f"{PATH_RESOURCE}ethernet/test_dict_eth.xdf"),
+    ],
+)
 @pytest.mark.no_connection
-def test_dictionary_v2_image_none(dictionary_class):
-    with open(PATH_TO_DICTIONARY, "r", encoding="utf-8") as xdf_file:
+def test_dictionary_v2_image_none(dictionary_class, dictionary_path):
+    with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
         tree = ET.parse(xdf_file)
     root = tree.getroot()
     root.remove(root.find(DictionaryV2._DictionaryV2__DICT_IMAGE))

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -156,7 +156,7 @@ def test_dictionary_factory(dict_path, interface, dict_class):
         (f"{PATH_RESOURCE}test_dict_ecat_eoe_v3.0.xdf", Interface.CAN, ILDictionaryParseError),
     ],
 )
-def test_dictionary_factory_fail(dict_path, interface, raises):
+def test_dictionary_interface_mismatch(dict_path, interface, raises):
     with pytest.raises(raises):
         DictionaryFactory.create_dictionary(dict_path, interface)
 

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -130,6 +130,23 @@ def test_dictionary_factory(dict_path, interface, dict_class):
     test_dict = DictionaryFactory.create_dictionary(dict_path, interface)
     assert isinstance(test_dict, dict_class)
 
+@pytest.mark.no_connection
+@pytest.mark.parametrize(
+    "dict_path, interface, raises",
+    [
+        (f"{PATH_RESOURCE}canopen/test_dict_can.xdf", Interface.ETH, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}canopen/test_dict_can_v3.0.xdf", Interface.ECAT, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}ethercat/test_dict_ethercat.xdf", Interface.CAN, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}ethernet/test_dict_eth.xdf", Interface.CAN, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}ethercat/test_dict_ethercat.xdf", Interface.CAN, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}test_dict_ecat_eoe_v3.0.xdf", Interface.ETH, ILDictionaryParseError),
+        (f"{PATH_RESOURCE}test_dict_ecat_eoe_v3.0.xdf", Interface.CAN, ILDictionaryParseError),
+    ],
+)
+def test_dictionary_factory_fail(dict_path, interface, raises):
+    with pytest.raises(raises):
+        DictionaryFactory.create_dictionary(dict_path, interface)
+
 
 @pytest.mark.no_connection
 def test_merge_dictionaries_registers():


### PR DESCRIPTION
Raise exception if DictionaryV2 does not match interface

Fixes # (INGK-1008)

### Type of change

- [x] Raise exception if DictionaryV2 does not match interface

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink`.

### Others

- [x] Set fix version field in the Jira issue.
