### PR TITLE
Fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,7 @@
 ingenialink-python
 ==================
 
-.. |tests| |pypi| |python_versions| #TODO INGK-969: Include test badge once master branch jobs are passing.
-|pypi| |python_versions|
+|tests| |pypi| |python_versions|
 
 |license|
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     },
     description="IngeniaLink Communications Library",
     long_description=open("README.rst").read(),
+    long_description_content_type="text/x-rst",
     author="Novanta",
     author_email="support@ingeniamc.com",
     url="https://www.ingeniamc.com",

--- a/tox.ini
+++ b/tox.ini
@@ -55,8 +55,10 @@ commands =
 description = build wheels
 deps =
     wheel==0.42.0
+    twine==6.0.1
 commands =
     python setup.py {posargs:build sdist bdist_wheel}
+    twine check dist/*
 
 [run]
 relative_files=True


### PR DESCRIPTION
It was not possible to upload wheels to pypi on master:
![image](https://github.com/user-attachments/assets/17869c68-ecfc-40c4-b4eb-6d97fa7166e7)

It was because the readme was not properly formatted. Fixed on master directly, and adding here a check that verifies that is always ready to be published

Running the command before fixing the readme:
![image](https://github.com/user-attachments/assets/e701d34f-ad06-40de-a71f-9dfb01d8f68e)
