### PR TITLE
INGK-1010 Avoid mapping a PDO map twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Avoid mapping a PDO map twice.
+
 ## [7.4.0] - 2025-12-3
 ### Added
 - Method to subscribe to emergency messages.

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -298,8 +298,12 @@ class EthercatServo(PDOServo):
             callback(emergency_message)
 
     def set_pdo_map_to_slave(self, rpdo_maps: List[RPDOMap], tpdo_maps: List[TPDOMap]) -> None:
-        self._rpdo_maps.extend(rpdo_maps)
-        self._tpdo_maps.extend(tpdo_maps)
+        for rpdo_map in rpdo_maps:
+            if rpdo_map not in self._rpdo_maps:
+                self._rpdo_maps.append(rpdo_map)
+        for tpdo_map in tpdo_maps:
+            if tpdo_map not in self._tpdo_maps:
+                self._tpdo_maps.append(tpdo_map)
         self.slave.config_func = self.map_pdos
 
     def process_pdo_inputs(self) -> None:

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -388,6 +388,16 @@ def test_set_pdo_map_to_slave(connect_to_slave, create_pdo_map):
     assert len(servo._tpdo_maps) == 2
     assert servo._tpdo_maps[1] == new_tpdo_map
 
+    # Add same maps again
+    servo.set_pdo_map_to_slave([new_rdpo_map, rpdo_map], [new_tpdo_map, tpdo_map])
+    # Check that nothing changes
+    assert len(servo._rpdo_maps) == 2
+    assert servo._rpdo_maps[0] == rpdo_map
+    assert servo._rpdo_maps[1] == new_rdpo_map
+    assert len(servo._tpdo_maps) == 2
+    assert servo._tpdo_maps[0] == tpdo_map
+    assert servo._tpdo_maps[1] == new_tpdo_map
+
 
 @pytest.mark.no_connection
 def test_pdo_item_bool():


### PR DESCRIPTION
### Description

Avoid mapping a PDO map twice.

Fixes # INGK-1010

### Type of change

- [x] Check if a map was added before adding it


### Tests
- [x] Add new unit tests if it applies.
- [ ] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
