### PR TITLE
INGK-1030 Catch ftp exception

### DIFF
--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -126,9 +126,8 @@ class EthernetNetwork(Network):
             try:
                 with open(fw_file, "rb") as file:
                     ftp_output = ftp.storbinary(f"STOR {os.path.basename(file.name)}", file)
-            except ftplib.error_temp:
-                logger.exception("An error occurred while transferring the firmware file.")
-                raise ILFirmwareLoadError("Unable to load the FW file through FTP.")
+            except ftplib.error_temp as e:
+                raise ILFirmwareLoadError("Unable to load the FW file through FTP.") from e
             logger.info(ftp_output)
             if FTP_FILE_TRANSFER_OK_CODE not in ftp_output:
                 raise ILFirmwareLoadError("Unable to load the FW file through FTP")

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -123,8 +123,12 @@ class EthernetNetwork(Network):
             # Load file through FTP.
             logger.info("Uploading firmware file...")
             ftp.set_pasv(False)
-            with open(fw_file, "rb") as file:
-                ftp_output = ftp.storbinary(f"STOR {os.path.basename(file.name)}", file)
+            try:
+                with open(fw_file, "rb") as file:
+                    ftp_output = ftp.storbinary(f"STOR {os.path.basename(file.name)}", file)
+            except ftplib.error_temp:
+                logger.exception("An error occurred while transferring the firmware file.")
+                raise ILFirmwareLoadError("Unable to load the FW file through FTP.")
             logger.info(ftp_output)
             if FTP_FILE_TRANSFER_OK_CODE not in ftp_output:
                 raise ILFirmwareLoadError("Unable to load the FW file through FTP")


### PR DESCRIPTION
### Description

An ftplib.error_temp exception is raised if the firewall is enabled.

Fixes # INGK-1030

### Type of change

- Catch exception.

### Tests
- Load firmware with the firewall enabled.
- Check that the exception is caught.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
