### PR TITLE
INGK-1022: follow CapWords convention (Enums)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ Pipfile.lock
 pyproject.toml
 venv
 
+# Test files
+pytest_reports/
+
 # Documentation
 _docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,7 +92,7 @@
 
 ### Add
 - Dictionary V3 support
-- ILWrongWorkingCount exception raised when the working count in PDO is not the expected one.
+- ILWrongWorkingCountError exception raised when the working count in PDO is not the expected one.
 - Register type for monitoring/disturbance data.
 - Support for merging dictionary instances. (It can only be used for merging COM-KIT and CORE dictionaries.)
 - Support to socketcan so the canopen communication can be used in Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Avoid mapping a PDO map twice.
 - Recover from a disconnection while PDOs were active.
+- Changed `Enums` names to follow CapWords convention. Old names are still supported, but will soon be deprecated.
 
 ## [7.4.0] - 2025-12-3
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## [Unreleased]
+### Deprecated
+- Changed `Enums` names to follow CapWords convention. Old names are still supported, but will soon be deprecated.
+
 ## [7.4.1] - 2025-01-28
 ### Fixed
 - Avoid mapping a PDO map twice.
 - Recover from a disconnection while PDOs were active.
-- Changed `Enums` names to follow CapWords convention. Old names are still supported, but will soon be deprecated.
 
 ### Changed
 - Virtual monitoring and disturbance disabled for old disturbance. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@
 
 ### Add
 - Dictionary V3 support
-- ILWrongWorkingCountError exception raised when the working count in PDO is not the expected one.
+- ILWrongWorkingCount exception raised when the working count in PDO is not the expected one.
 - Register type for monitoring/disturbance data.
 - Support for merging dictionary instances. (It can only be used for merging COM-KIT and CORE dictionaries.)
 - Support to socketcan so the canopen communication can be used in Linux.

--- a/docs/api/protocols/canopen/network.rst
+++ b/docs/api/protocols/canopen/network.rst
@@ -5,7 +5,7 @@ Network
 .. autoclass:: ingenialink.canopen.network.CAN_BAUDRATE
     :members:
 
-.. autoclass:: ingenialink.canopen.network.CAN_DEVICE
+.. autoclass:: ingenialink.canopen.network.CanDevice
     :members:
 
 .. autoclass:: ingenialink.canopen.network.CanopenNetwork

--- a/docs/api/protocols/canopen/network.rst
+++ b/docs/api/protocols/canopen/network.rst
@@ -2,7 +2,7 @@
 Network
 =======
 
-.. autoclass:: ingenialink.canopen.network.CAN_BAUDRATE
+.. autoclass:: ingenialink.canopen.network.CanBaudrate
     :members:
 
 .. autoclass:: ingenialink.canopen.network.CanDevice

--- a/examples/canopen/can_connection.py
+++ b/examples/canopen/can_connection.py
@@ -1,13 +1,13 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 
 
 def connection_example(args: argparse.Namespace) -> None:
     """Scans for nodes in a network, connects to the first found node, reads
     a register and disconnects the found servo from the network."""
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()
     print(nodes)

--- a/examples/canopen/can_connection.py
+++ b/examples/canopen/can_connection.py
@@ -1,12 +1,12 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 
 
 def connection_example(args: argparse.Namespace) -> None:
     """Scans for nodes in a network, connects to the first found node, reads
     a register and disconnects the found servo from the network."""
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()

--- a/examples/canopen/can_connection_linux.py
+++ b/examples/canopen/can_connection_linux.py
@@ -1,6 +1,6 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 
 
 def connection_example(args: argparse.Namespace) -> None:
@@ -11,7 +11,7 @@ def connection_example(args: argparse.Namespace) -> None:
         dict_path: Path to the dictionary
     """
     can_baudrate = CAN_BAUDRATE(args.baudrate)
-    net = CanopenNetwork(device=CAN_DEVICE.SOCKETCAN, channel=args.channel, baudrate=can_baudrate)
+    net = CanopenNetwork(device=CanDevice.SOCKETCAN, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()
     print(nodes)
 

--- a/examples/canopen/can_connection_linux.py
+++ b/examples/canopen/can_connection_linux.py
@@ -1,6 +1,6 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 
 
 def connection_example(args: argparse.Namespace) -> None:
@@ -10,7 +10,7 @@ def connection_example(args: argparse.Namespace) -> None:
     Args:
         dict_path: Path to the dictionary
     """
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=CanDevice.SOCKETCAN, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()
     print(nodes)

--- a/examples/canopen/can_disturbance.py
+++ b/examples/canopen/can_disturbance.py
@@ -2,7 +2,7 @@ import argparse
 import math
 from typing import List, Union, cast
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from ingenialink.exceptions import ILRegisterNotFoundError
 from ingenialink.register import RegDtype
 
@@ -12,7 +12,8 @@ def disturbance_example(args: argparse.Namespace) -> None:
     divider = 100
     # Calculate time between disturbance samples
     sample_period = divider / 20000
-    # The disturbance signal will be a simple harmonic motion (SHM) with frequency 0.5Hz and 2000 counts of amplitude
+    # The disturbance signal will be a simple harmonic motion (SHM)
+    # with frequency 0.5Hz and 2000 counts of amplitude
     signal_frequency = 0.5
     signal_amplitude = 1
     # Calculate number of samples to load a complete oscillation
@@ -61,7 +62,7 @@ def disturbance_example(args: argparse.Namespace) -> None:
     )
 
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     servo = net.connect_to_slave(target=args.node_id, dictionary=args.dictionary_path)
 

--- a/examples/canopen/can_disturbance.py
+++ b/examples/canopen/can_disturbance.py
@@ -2,7 +2,7 @@ import argparse
 import math
 from typing import List, Union, cast
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from ingenialink.exceptions import ILRegisterNotFoundError
 from ingenialink.register import RegDtype
 
@@ -60,7 +60,7 @@ def disturbance_example(args: argparse.Namespace) -> None:
         ],
     )
 
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     servo = net.connect_to_slave(target=args.node_id, dictionary=args.dictionary_path)

--- a/examples/canopen/can_disturbance.py
+++ b/examples/canopen/can_disturbance.py
@@ -4,7 +4,7 @@ from typing import List, Union, cast
 
 from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
 from ingenialink.exceptions import ILRegisterNotFoundError
-from ingenialink.register import REG_DTYPE
+from ingenialink.register import RegDtype
 
 
 def disturbance_example(args: argparse.Namespace) -> None:
@@ -71,15 +71,15 @@ def disturbance_example(args: argparse.Namespace) -> None:
         print("Disturbance is not available for this drive")
     else:
         servo.disturbance_remove_all_mapped_registers()
-        servo.disturbance_set_mapped_register(0, 0x2021, 1, REG_DTYPE.FLOAT.value, 4)
-        servo.disturbance_set_mapped_register(1, 0x2020, 1, REG_DTYPE.S32.value, 4)
-        servo.disturbance_set_mapped_register(2, 0x201A, 1, REG_DTYPE.FLOAT.value, 4)
-        servo.disturbance_set_mapped_register(3, 0x201B, 1, REG_DTYPE.FLOAT.value, 4)
-        servo.disturbance_set_mapped_register(4, 0x2024, 1, REG_DTYPE.U16.value, 2)
+        servo.disturbance_set_mapped_register(0, 0x2021, 1, RegDtype.FLOAT.value, 4)
+        servo.disturbance_set_mapped_register(1, 0x2020, 1, RegDtype.S32.value, 4)
+        servo.disturbance_set_mapped_register(2, 0x201A, 1, RegDtype.FLOAT.value, 4)
+        servo.disturbance_set_mapped_register(3, 0x201B, 1, RegDtype.FLOAT.value, 4)
+        servo.disturbance_set_mapped_register(4, 0x2024, 1, RegDtype.U16.value, 2)
 
         servo.disturbance_write_data(
             [0, 1, 2, 3, 4],
-            [REG_DTYPE.FLOAT, REG_DTYPE.S32, REG_DTYPE.FLOAT, REG_DTYPE.FLOAT, REG_DTYPE.U16],
+            [RegDtype.FLOAT, RegDtype.S32, RegDtype.FLOAT, RegDtype.FLOAT, RegDtype.U16],
             [data_vel, data_pos, data_curr_q, data_curr_d, data_positioning_opt],
         )
         servo.disturbance_enable()

--- a/examples/canopen/can_load_firmware.py
+++ b/examples/canopen/can_load_firmware.py
@@ -1,6 +1,6 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 
 
 def print_status_message(msg: str) -> None:
@@ -26,7 +26,7 @@ def print_errors_enabled(value: int) -> None:
 def load_firmware_example(args: argparse.Namespace) -> None:
     """Loads a firmware to an already connected drive."""
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
 
     nodes = net.scan_slaves()
@@ -56,7 +56,7 @@ def load_firmware_example(args: argparse.Namespace) -> None:
 
 def load_firmware_example_disconnected() -> None:
     """Loads a firmware to a disconnected drive."""
-    net = CanopenNetwork(device=CanDevice.IXXAT, channel=0, baudrate=CAN_BAUDRATE.Baudrate_1M)
+    net = CanopenNetwork(device=CanDevice.IXXAT, channel=0, baudrate=CanBaudrate.Baudrate_1M)
     net.load_firmware(
         32,
         "../../resources/firmware/eve-net-c_1.8.1.sfu",

--- a/examples/canopen/can_load_firmware.py
+++ b/examples/canopen/can_load_firmware.py
@@ -1,6 +1,6 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 
 
 def print_status_message(msg: str) -> None:
@@ -25,7 +25,7 @@ def print_errors_enabled(value: int) -> None:
 
 def load_firmware_example(args: argparse.Namespace) -> None:
     """Loads a firmware to an already connected drive."""
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
 
@@ -56,7 +56,7 @@ def load_firmware_example(args: argparse.Namespace) -> None:
 
 def load_firmware_example_disconnected() -> None:
     """Loads a firmware to a disconnected drive."""
-    net = CanopenNetwork(device=CAN_DEVICE.IXXAT, channel=0, baudrate=CAN_BAUDRATE.Baudrate_1M)
+    net = CanopenNetwork(device=CanDevice.IXXAT, channel=0, baudrate=CAN_BAUDRATE.Baudrate_1M)
     net.load_firmware(
         32,
         "../../resources/firmware/eve-net-c_1.8.1.sfu",

--- a/examples/canopen/can_load_save_config.py
+++ b/examples/canopen/can_load_save_config.py
@@ -1,12 +1,12 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 
 
 def connect_slave(args: argparse.Namespace) -> tuple[CanopenServo, CanopenNetwork]:
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
 
     servo = net.connect_to_slave(target=args.node_id, dictionary=args.dictionary_path)

--- a/examples/canopen/can_load_save_config.py
+++ b/examples/canopen/can_load_save_config.py
@@ -1,11 +1,11 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from ingenialink.canopen.servo import CanopenServo
 
 
 def connect_slave(args: argparse.Namespace) -> tuple[CanopenServo, CanopenNetwork]:
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
 

--- a/examples/canopen/can_monitoring.py
+++ b/examples/canopen/can_monitoring.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 from numpy.typing import NDArray
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.exceptions import ILRegisterNotFoundError
 
@@ -15,7 +15,7 @@ def monitoring_example(args: argparse.Namespace) -> List[NDArray[np.float_]]:
     ]
 
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     servo = net.connect_to_slave(target=args.node_id, dictionary=args.dictionary_path)
     # Monitoring

--- a/examples/canopen/can_monitoring.py
+++ b/examples/canopen/can_monitoring.py
@@ -4,7 +4,7 @@ from typing import List
 import numpy as np
 from numpy.typing import NDArray
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.exceptions import ILRegisterNotFoundError
 
@@ -14,7 +14,7 @@ def monitoring_example(args: argparse.Namespace) -> List[NDArray[np.float_]]:
         "DRV_PROT_TEMP_VALUE",
     ]
 
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     servo = net.connect_to_slave(target=args.node_id, dictionary=args.dictionary_path)

--- a/examples/canopen/can_store_restore.py
+++ b/examples/canopen/can_store_restore.py
@@ -1,12 +1,12 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 
 
 def store_restore_example(args: argparse.Namespace) -> None:
     """Connects to the first scanned drive and store and restores the
     current configuration."""
-    can_device = CAN_DEVICE(args.transceiver)
+    can_device = CanDevice(args.transceiver)
     can_baudrate = CAN_BAUDRATE(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()
@@ -22,21 +22,21 @@ def store_restore_example(args: argparse.Namespace) -> None:
         try:
             servo.store_parameters()
             print("Stored all parameters successfully")
-        except Exception as e:
+        except Exception:
             print("Error storing all parameters")
 
         # Store axis 1
         try:
             servo.store_parameters(subnode=1)
             print("Stored axis 1 parameters successfully")
-        except Exception as e:
+        except Exception:
             print("Error storing parameters axis 1")
 
         # Restore all
         try:
             servo.restore_parameters()
             print("Restored all parameters successfully")
-        except Exception as e:
+        except Exception:
             print("Error restoring all parameters")
 
         net.disconnect_from_slave(servo)

--- a/examples/canopen/can_store_restore.py
+++ b/examples/canopen/can_store_restore.py
@@ -1,13 +1,13 @@
 import argparse
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 
 
 def store_restore_example(args: argparse.Namespace) -> None:
     """Connects to the first scanned drive and store and restores the
     current configuration."""
     can_device = CanDevice(args.transceiver)
-    can_baudrate = CAN_BAUDRATE(args.baudrate)
+    can_baudrate = CanBaudrate(args.baudrate)
     net = CanopenNetwork(device=can_device, channel=args.channel, baudrate=can_baudrate)
     nodes = net.scan_slaves()
     print(nodes)

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
-    ServoFlags,
     ServoMode,
     ServoState,
     ServoUnitsAcc,
@@ -28,7 +27,6 @@ __all__ = [
     "NetDevEvt",
     "NetState",
     "ServoState",
-    "ServoFlags",
     "ServoMode",
     "ServoUnitsTorque",
     "ServoUnitsPos",
@@ -57,13 +55,10 @@ _DEPRECATED = {
     "NET_PROT": "NetProt",
     "NET_STATE": "NetState",
     "NET_DEV_EVT": "NetDevEvt",
-    "EEPROM_FILE_FORMAT": "EepromFileFormat",
-    "NET_TRANS_PROT": "NetTransProt",
     "REG_DTYPE": "RegDtype",
     "REG_ACCESS": "RegAccess",
     "REG_PHY": "RegPhy",
     "SERVO_STATE": "ServoState",
-    "SERVO_FLAGS": "ServoFlags",
     "SERVO_MODE": "ServoMode",
     "SERVO_UNITS_TORQUE": "ServoUnitsTorque",
     "SERVO_UNITS_POS": "ServoUnitsPos",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -2,11 +2,11 @@ from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
     SERVO_FLAGS,
     SERVO_MODE,
-    SERVO_STATE,
     SERVO_UNITS_ACC,
     SERVO_UNITS_POS,
     SERVO_UNITS_TORQUE,
     SERVO_UNITS_VEL,
+    ServoState,
 )
 from ingenialink.poller import Poller
 from ingenialink.servo import Servo
@@ -29,6 +29,7 @@ NET_TRANS_PROT = NetTransProt
 REG_DTYPE = RegDtype
 REG_ACCESS = RegAccess
 REG_PHY = RegPhy
+SERVO_STATE = ServoState
 
 __all__ = [
     "EEPROM_FILE_FORMAT",  # WARNING: deprecated
@@ -41,7 +42,8 @@ __all__ = [
     "NetState",
     "NET_TRANS_PROT",  # WARNING: deprecated
     "NetTransProt",
-    "SERVO_STATE",
+    "SERVO_STATE",  # WARNING: deprecated
+    "ServoState",
     "SERVO_FLAGS",
     "SERVO_MODE",
     "SERVO_UNITS_TORQUE",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -18,14 +18,31 @@ from .canopen.servo import CanopenServo
 from .ethercat.network import EthercatNetwork
 from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
-from .network import EEPROM_FILE_FORMAT, NET_DEV_EVT, NET_PROT, NET_STATE, NET_TRANS_PROT, Network
+from .network import (
+    EEPROM_FILE_FORMAT,
+    NET_DEV_EVT,
+    NET_PROT,
+    NET_STATE,
+    NET_TRANS_PROT,
+    EepromFileFormat,
+    NetDevEvt,
+    NetProt,
+    NetState,
+    NetTransProt,
+    Network,
+)
 
 __all__ = [
-    "EEPROM_FILE_FORMAT",
-    "NET_PROT",
-    "NET_DEV_EVT",
-    "NET_STATE",
-    "NET_TRANS_PROT",
+    "EEPROM_FILE_FORMAT",  # WARNING: deprecated
+    "EepromFileFormat",
+    "NET_PROT",  # WARNING: deprecated
+    "NetProt",
+    "NET_DEV_EVT",  # WARNING: deprecated
+    "NetDevEvt",
+    "NET_STATE",  # WARNING: deprecated
+    "NetState",
+    "NET_TRANS_PROT",  # WARNING: deprecated
+    "NetTransProt",
     "SERVO_STATE",
     "SERVO_FLAGS",
     "SERVO_MODE",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,4 +1,4 @@
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegAccess, RegDtype
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
     SERVO_FLAGS,
     SERVO_MODE,
@@ -54,9 +54,10 @@ __all__ = [
     "Servo",
     "REG_DTYPE",  # WARNING: deprecated
     "RegDtype",
-    "REG_ACCESS",
-    "RegAccess",  # WARNING: deprecated
-    "REG_PHY",
+    "REG_ACCESS",  # WARNING: deprecated
+    "RegAccess",
+    "REG_PHY",  # WARNING: deprecated
+    "RegPhy",
     "EthercatNetwork",
     "EthernetServo",
     "EthernetNetwork",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Any
 
 from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
@@ -75,7 +76,7 @@ _DEPRECATED = {
 }
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     if name in _DEPRECATED:
         warnings.warn(
             f"{name} is deprecated, use {_DEPRECATED[name]} instead",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,4 +1,4 @@
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegAccess, RegDtype, RegPhy
+from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
     SERVO_FLAGS,
     SERVO_MODE,
@@ -18,19 +18,17 @@ from .canopen.servo import CanopenServo
 from .ethercat.network import EthercatNetwork
 from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
-from .network import (
-    EEPROM_FILE_FORMAT,
-    NET_DEV_EVT,
-    NET_PROT,
-    NET_STATE,
-    NET_TRANS_PROT,
-    EepromFileFormat,
-    NetDevEvt,
-    NetProt,
-    NetState,
-    NetTransProt,
-    Network,
-)
+from .network import EepromFileFormat, NetDevEvt, NetProt, NetState, NetTransProt, Network
+
+# WARNING: Deprecated aliases
+NET_PROT = NetProt
+NET_STATE = NetState
+NET_DEV_EVT = NetDevEvt
+EEPROM_FILE_FORMAT = EepromFileFormat
+NET_TRANS_PROT = NetTransProt
+REG_DTYPE = RegDtype
+REG_ACCESS = RegAccess
+REG_PHY = RegPhy
 
 __all__ = [
     "EEPROM_FILE_FORMAT",  # WARNING: deprecated

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,4 +1,4 @@
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegDtype
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegAccess, RegDtype
 from ingenialink.enums.servo import (
     SERVO_FLAGS,
     SERVO_MODE,
@@ -55,6 +55,7 @@ __all__ = [
     "REG_DTYPE",  # WARNING: deprecated
     "RegDtype",
     "REG_ACCESS",
+    "RegAccess",  # WARNING: deprecated
     "REG_PHY",
     "EthercatNetwork",
     "EthernetServo",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,3 +1,5 @@
+import warnings
+
 from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
     ServoFlags,
@@ -20,70 +22,68 @@ from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
 from .network import EepromFileFormat, NetDevEvt, NetProt, NetState, NetTransProt, Network
 
-# WARNING: Deprecated aliases
-NET_PROT = NetProt
-NET_STATE = NetState
-NET_DEV_EVT = NetDevEvt
-EEPROM_FILE_FORMAT = EepromFileFormat
-NET_TRANS_PROT = NetTransProt
-REG_DTYPE = RegDtype
-REG_ACCESS = RegAccess
-REG_PHY = RegPhy
-SERVO_STATE = ServoState
-SERVO_FLAGS = ServoFlags
-SERVO_MODE = ServoMode
-SERVO_UNITS_TORQUE = ServoUnitsTorque
-SERVO_UNITS_POS = ServoUnitsPos
-SERVO_UNITS_VEL = ServoUnitsVel
-SERVO_UNITS_ACC = ServoUnitsAcc
-CAN_DEVICE = CanDevice
-CAN_BAUDRATE = CanBaudrate
-
 __all__ = [
-    "EEPROM_FILE_FORMAT",  # WARNING: deprecated
     "EepromFileFormat",
-    "NET_PROT",  # WARNING: deprecated
     "NetProt",
-    "NET_DEV_EVT",  # WARNING: deprecated
     "NetDevEvt",
-    "NET_STATE",  # WARNING: deprecated
     "NetState",
-    "NET_TRANS_PROT",  # WARNING: deprecated
     "NetTransProt",
-    "SERVO_STATE",  # WARNING: deprecated
     "ServoState",
-    "SERVO_FLAGS",  # WARNING: deprecated
     "ServoFlags",
-    "SERVO_MODE",  # WARNING: deprecated
     "ServoMode",
-    "SERVO_UNITS_TORQUE",  # WARNING: deprecated
     "ServoUnitsTorque",
-    "SERVO_UNITS_POS",  # WARNING: deprecated
     "ServoUnitsPos",
-    "SERVO_UNITS_VEL",  # WARNING: deprecated
     "ServoUnitsVel",
-    "SERVO_UNITS_ACC",  # WARNING: deprecated
     "ServoUnitsAcc",
     "Network",
     "Servo",
-    "REG_DTYPE",  # WARNING: deprecated
     "RegDtype",
-    "REG_ACCESS",  # WARNING: deprecated
     "RegAccess",
-    "REG_PHY",  # WARNING: deprecated
     "RegPhy",
     "EthercatNetwork",
     "EthernetServo",
     "EthernetNetwork",
     "CanopenNetwork",
-    "CAN_DEVICE",  # WARNING: deprecated
     "CanDevice",
-    "CAN_BAUDRATE",  # WARNING: deprecated
     "CanBaudrate",
     "CanopenServo",
     "CanopenRegister",
     "Poller",
     "CanopenDictionaryV2",
 ]
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "NET_PROT": "NetProt",
+    "NET_STATE": "NetState",
+    "NET_DEV_EVT": "NetDevEvt",
+    "EEPROM_FILE_FORMAT": "EepromFileFormat",
+    "NET_TRANS_PROT": "NetTransProt",
+    "REG_DTYPE": "RegDtype",
+    "REG_ACCESS": "RegAccess",
+    "REG_PHY": "RegPhy",
+    "SERVO_STATE": "ServoState",
+    "SERVO_FLAGS": "ServoFlags",
+    "SERVO_MODE": "ServoMode",
+    "SERVO_UNITS_TORQUE": "ServoUnitsTorque",
+    "SERVO_UNITS_POS": "ServoUnitsPos",
+    "SERVO_UNITS_VEL": "ServoUnitsVel",
+    "SERVO_UNITS_ACC": "ServoUnitsAcc",
+    "CAN_DEVICE": "CanDevice",
+    "CAN_BAUDRATE": "CanBaudrate",
+}
+
+
+def __getattr__(name):
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 __version__ = "7.4.0"

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -80,34 +80,4 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
-# WARNING: Deprecated aliases
-_DEPRECATED = {
-    "NET_PROT": "NetProt",
-    "NET_STATE": "NetState",
-    "NET_DEV_EVT": "NetDevEvt",
-    "REG_DTYPE": "RegDtype",
-    "REG_ACCESS": "RegAccess",
-    "REG_PHY": "RegPhy",
-    "SERVO_STATE": "ServoState",
-    "SERVO_MODE": "ServoMode",
-    "SERVO_UNITS_TORQUE": "ServoUnitsTorque",
-    "SERVO_UNITS_POS": "ServoUnitsPos",
-    "SERVO_UNITS_VEL": "ServoUnitsVel",
-    "SERVO_UNITS_ACC": "ServoUnitsAcc",
-    "CAN_DEVICE": "CanDevice",
-    "CAN_BAUDRATE": "CanBaudrate",
-}
-
-
-def __getattr__(name: str) -> Any:
-    if name in _DEPRECATED:
-        warnings.warn(
-            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return globals()[_DEPRECATED[name]]
-    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
 __version__ = "7.4.1"

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -12,7 +12,7 @@ from ingenialink.poller import Poller
 from ingenialink.servo import Servo
 
 from .canopen.dictionary import CanopenDictionaryV2
-from .canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from .canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from .canopen.register import CanopenRegister
 from .canopen.servo import CanopenServo
 from .ethercat.network import EthercatNetwork
@@ -36,6 +36,7 @@ SERVO_UNITS_TORQUE = ServoUnitsTorque
 SERVO_UNITS_POS = ServoUnitsPos
 SERVO_UNITS_VEL = ServoUnitsVel
 SERVO_UNITS_ACC = ServoUnitsAcc
+CAN_DEVICE = CanDevice
 
 __all__ = [
     "EEPROM_FILE_FORMAT",  # WARNING: deprecated
@@ -74,7 +75,8 @@ __all__ = [
     "EthernetServo",
     "EthernetNetwork",
     "CanopenNetwork",
-    "CAN_DEVICE",
+    "CAN_DEVICE",  # WARNING: deprecated
+    "CanDevice",
     "CAN_BAUDRATE",
     "CanopenServo",
     "CanopenRegister",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,4 +1,4 @@
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY
+from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, REG_PHY, RegDtype
 from ingenialink.enums.servo import (
     SERVO_FLAGS,
     SERVO_MODE,
@@ -35,7 +35,8 @@ __all__ = [
     "SERVO_UNITS_ACC",
     "Network",
     "Servo",
-    "REG_DTYPE",
+    "REG_DTYPE",  # WARNING: deprecated
+    "RegDtype",
     "REG_ACCESS",
     "REG_PHY",
     "EthercatNetwork",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -12,7 +12,7 @@ from ingenialink.poller import Poller
 from ingenialink.servo import Servo
 
 from .canopen.dictionary import CanopenDictionaryV2
-from .canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from .canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from .canopen.register import CanopenRegister
 from .canopen.servo import CanopenServo
 from .ethercat.network import EthercatNetwork
@@ -37,6 +37,7 @@ SERVO_UNITS_POS = ServoUnitsPos
 SERVO_UNITS_VEL = ServoUnitsVel
 SERVO_UNITS_ACC = ServoUnitsAcc
 CAN_DEVICE = CanDevice
+CAN_BAUDRATE = CanBaudrate
 
 __all__ = [
     "EEPROM_FILE_FORMAT",  # WARNING: deprecated
@@ -77,7 +78,8 @@ __all__ = [
     "CanopenNetwork",
     "CAN_DEVICE",  # WARNING: deprecated
     "CanDevice",
-    "CAN_BAUDRATE",
+    "CAN_BAUDRATE",  # WARNING: deprecated
+    "CanBaudrate",
     "CanopenServo",
     "CanopenRegister",
     "Poller",

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -1,12 +1,12 @@
 from ingenialink.enums.register import RegAccess, RegDtype, RegPhy
 from ingenialink.enums.servo import (
-    SERVO_FLAGS,
-    SERVO_MODE,
-    SERVO_UNITS_ACC,
-    SERVO_UNITS_POS,
-    SERVO_UNITS_TORQUE,
-    SERVO_UNITS_VEL,
+    ServoFlags,
+    ServoMode,
     ServoState,
+    ServoUnitsAcc,
+    ServoUnitsPos,
+    ServoUnitsTorque,
+    ServoUnitsVel,
 )
 from ingenialink.poller import Poller
 from ingenialink.servo import Servo
@@ -30,6 +30,12 @@ REG_DTYPE = RegDtype
 REG_ACCESS = RegAccess
 REG_PHY = RegPhy
 SERVO_STATE = ServoState
+SERVO_FLAGS = ServoFlags
+SERVO_MODE = ServoMode
+SERVO_UNITS_TORQUE = ServoUnitsTorque
+SERVO_UNITS_POS = ServoUnitsPos
+SERVO_UNITS_VEL = ServoUnitsVel
+SERVO_UNITS_ACC = ServoUnitsAcc
 
 __all__ = [
     "EEPROM_FILE_FORMAT",  # WARNING: deprecated
@@ -44,12 +50,18 @@ __all__ = [
     "NetTransProt",
     "SERVO_STATE",  # WARNING: deprecated
     "ServoState",
-    "SERVO_FLAGS",
-    "SERVO_MODE",
-    "SERVO_UNITS_TORQUE",
-    "SERVO_UNITS_POS",
-    "SERVO_UNITS_VEL",
-    "SERVO_UNITS_ACC",
+    "SERVO_FLAGS",  # WARNING: deprecated
+    "ServoFlags",
+    "SERVO_MODE",  # WARNING: deprecated
+    "ServoMode",
+    "SERVO_UNITS_TORQUE",  # WARNING: deprecated
+    "ServoUnitsTorque",
+    "SERVO_UNITS_POS",  # WARNING: deprecated
+    "ServoUnitsPos",
+    "SERVO_UNITS_VEL",  # WARNING: deprecated
+    "ServoUnitsVel",
+    "SERVO_UNITS_ACC",  # WARNING: deprecated
+    "ServoUnitsAcc",
     "Network",
     "Servo",
     "REG_DTYPE",  # WARNING: deprecated

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -5,7 +5,7 @@ import ingenialogger
 
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.enums.register import RegCyclicType
+from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -1,5 +1,5 @@
-import xml.etree.ElementTree as ET
 from typing import List, Optional
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -40,7 +40,7 @@ class CanopenDictionaryV2(DictionaryV2):
 
     interface = Interface.CAN
 
-    def _read_xdf_register(self, register: ET.Element) -> Optional[CanopenRegister]:
+    def _read_xdf_register(self, register: ElementTree.Element) -> Optional[CanopenRegister]:
         current_read_register = super()._read_xdf_register(register)
         if current_read_register is None:
             return None

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import ingenialogger
 
-from ingenialink.canopen.register import REG_ACCESS, REG_DTYPE, CanopenRegister, RegCyclicType
+from ingenialink.canopen.register import REG_ACCESS, CanopenRegister, RegCyclicType, RegDtype
 from ingenialink.dictionary import DictionaryV2, Interface
 
 logger = ingenialogger.get_logger(__name__)
@@ -23,7 +23,7 @@ class CanopenDictionaryV2(DictionaryV2):
             idx=0x58B2,
             subidx=0x00,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
             subnode=0,
         ),
@@ -32,7 +32,7 @@ class CanopenDictionaryV2(DictionaryV2):
             idx=0x58B4,
             subidx=0x00,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
             subnode=0,
         ),

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 import ingenialogger
 
-from ingenialink.canopen.register import REG_ACCESS, CanopenRegister, RegCyclicType, RegDtype
+from ingenialink.canopen.register import CanopenRegister, RegAccess, RegCyclicType, RegDtype
 from ingenialink.dictionary import DictionaryV2, Interface
 
 logger = ingenialogger.get_logger(__name__)
@@ -24,7 +24,7 @@ class CanopenDictionaryV2(DictionaryV2):
             subidx=0x00,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.RO,
+            access=RegAccess.RO,
             subnode=0,
         ),
         CanopenRegister(
@@ -33,7 +33,7 @@ class CanopenDictionaryV2(DictionaryV2):
             subidx=0x00,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.WO,
+            access=RegAccess.WO,
             subnode=0,
         ),
     ]

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -22,7 +22,7 @@ from ingenialink.canopen.servo import CANOPEN_SDO_RESPONSE_TIMEOUT, CanopenServo
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
-from ingenialink.register import REG_ACCESS, REG_DTYPE
+from ingenialink.register import REG_ACCESS, RegDtype
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
 
@@ -49,7 +49,7 @@ PROG_STAT_1 = CanopenRegister(
     idx=0x1F51,
     subidx=0x01,
     cyclic=RegCyclicType.CONFIG,
-    dtype=REG_DTYPE.U8,
+    dtype=RegDtype.U8,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_CONTROL_1",
     subnode=0,
@@ -58,7 +58,7 @@ PROG_DL_1 = CanopenRegister(
     idx=0x1F50,
     subidx=0x01,
     cyclic=RegCyclicType.CONFIG,
-    dtype=REG_DTYPE.BYTE_ARRAY_512,
+    dtype=RegDtype.BYTE_ARRAY_512,
     access=REG_ACCESS.RW,
     identifier="CIA302_BL_PROGRAM_DATA",
     subnode=0,
@@ -67,7 +67,7 @@ FORCE_BOOT = CanopenRegister(
     idx=0x5EDE,
     subidx=0x00,
     cyclic=RegCyclicType.CONFIG,
-    dtype=REG_DTYPE.U32,
+    dtype=RegDtype.U32,
     access=REG_ACCESS.WO,
     identifier="DRV_BOOT_COCO_FORCE",
     subnode=0,
@@ -77,7 +77,7 @@ CIA301_DRV_ID_DEVICE_TYPE = CanopenRegister(
     idx=0x1000,
     subidx=0x00,
     cyclic=RegCyclicType.CONFIG,
-    dtype=REG_DTYPE.U32,
+    dtype=RegDtype.U32,
     access=REG_ACCESS.RO,
     identifier="",
     subnode=0,
@@ -317,11 +317,11 @@ class CanopenNetwork(Network):
                 node = connected_slaves[slave_id]
             try:
                 product_code = convert_bytes_to_dtype(
-                    node.sdo.upload(self.DRIVE_INFO_INDEX, self.PRODUCT_CODE_SUB_IX), REG_DTYPE.U32
+                    node.sdo.upload(self.DRIVE_INFO_INDEX, self.PRODUCT_CODE_SUB_IX), RegDtype.U32
                 )
                 revision_number = convert_bytes_to_dtype(
                     node.sdo.upload(self.DRIVE_INFO_INDEX, self.REVISION_NUMBER_SUB_IX),
-                    REG_DTYPE.U32,
+                    RegDtype.U32,
                 )
             except canopen.sdo.exceptions.SdoError as e:
                 logger.warning(

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -22,7 +22,7 @@ from ingenialink.canopen.servo import CANOPEN_SDO_RESPONSE_TIMEOUT, CanopenServo
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
-from ingenialink.register import REG_ACCESS, RegDtype
+from ingenialink.register import RegAccess, RegDtype
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
 
@@ -50,7 +50,7 @@ PROG_STAT_1 = CanopenRegister(
     subidx=0x01,
     cyclic=RegCyclicType.CONFIG,
     dtype=RegDtype.U8,
-    access=REG_ACCESS.RW,
+    access=RegAccess.RW,
     identifier="CIA302_BL_PROGRAM_CONTROL_1",
     subnode=0,
 )
@@ -59,7 +59,7 @@ PROG_DL_1 = CanopenRegister(
     subidx=0x01,
     cyclic=RegCyclicType.CONFIG,
     dtype=RegDtype.BYTE_ARRAY_512,
-    access=REG_ACCESS.RW,
+    access=RegAccess.RW,
     identifier="CIA302_BL_PROGRAM_DATA",
     subnode=0,
 )
@@ -68,7 +68,7 @@ FORCE_BOOT = CanopenRegister(
     subidx=0x00,
     cyclic=RegCyclicType.CONFIG,
     dtype=RegDtype.U32,
-    access=REG_ACCESS.WO,
+    access=RegAccess.WO,
     identifier="DRV_BOOT_COCO_FORCE",
     subnode=0,
 )
@@ -78,7 +78,7 @@ CIA301_DRV_ID_DEVICE_TYPE = CanopenRegister(
     subidx=0x00,
     cyclic=RegCyclicType.CONFIG,
     dtype=RegDtype.U32,
-    access=REG_ACCESS.RO,
+    access=RegAccess.RO,
     identifier="",
     subnode=0,
 )

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -1112,7 +1112,7 @@ class CanopenNetwork(Network):
     @staticmethod
     def _reload_kvaser_lib() -> None:
         """Reload the Kvaser library to refresh the connected transceivers."""
-        canUnLoadLibrary = get_canlib_function("canUnloadLibrary")
-        canInitializeLibrary = get_canlib_function("canInitializeLibrary")
-        canUnLoadLibrary()
-        canInitializeLibrary()
+        can_unload_library = get_canlib_function("canUnloadLibrary")
+        can_initialize_library = get_canlib_function("canInitializeLibrary")
+        can_unload_library()
+        can_initialize_library()

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -21,7 +21,7 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.canopen.servo import CANOPEN_SDO_RESPONSE_TIMEOUT, CanopenServo
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NET_DEV_EVT, NET_STATE, NetProt, Network, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, NetProt, NetState, Network, SlaveInfo
 from ingenialink.register import REG_ACCESS, REG_DTYPE
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
@@ -187,15 +187,15 @@ class NetStatusListener(Thread):
                 is_alive = current_timestamp != timestamps[node_id]
                 servo_state = self.__network.get_servo_state(node_id)
                 if is_alive:
-                    if servo_state != NET_STATE.CONNECTED:
+                    if servo_state != NetState.CONNECTED:
                         self.__network._notify_status(node_id, NET_DEV_EVT.ADDED)
-                        self.__network._set_servo_state(node_id, NET_STATE.CONNECTED)
+                        self.__network._set_servo_state(node_id, NetState.CONNECTED)
                     timestamps[node_id] = node.nmt.timestamp
-                elif servo_state == NET_STATE.DISCONNECTED:
+                elif servo_state == NetState.DISCONNECTED:
                     self.__network._reset_connection()
                 else:
                     self.__network._notify_status(node_id, NET_DEV_EVT.REMOVED)
-                    self.__network._set_servo_state(node_id, NET_STATE.DISCONNECTED)
+                    self.__network._set_servo_state(node_id, NetState.DISCONNECTED)
 
     def stop(self) -> None:
         self.__stop = True
@@ -373,7 +373,7 @@ class CanopenNetwork(Network):
                     target, node, dictionary, servo_status_listener=servo_status_listener
                 )
                 self.servos.append(servo)
-                self._set_servo_state(target, NET_STATE.CONNECTED)
+                self._set_servo_state(target, NetState.CONNECTED)
                 if net_status_listener:
                     self.start_status_listener()
                 return servo
@@ -1050,7 +1050,7 @@ class CanopenNetwork(Network):
         """Obtain network protocol."""
         return NetProt.CAN
 
-    def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
+    def get_servo_state(self, servo_id: Union[int, str]) -> NetState:
         """Get the state of a servo that's a part of network.
         The state indicates if the servo is connected or disconnected.
 
@@ -1065,7 +1065,7 @@ class CanopenNetwork(Network):
             raise ValueError("The servo ID must be an int.")
         return self._servos_state[servo_id]
 
-    def _set_servo_state(self, servo_id: Union[int, str], state: NET_STATE) -> None:
+    def _set_servo_state(self, servo_id: Union[int, str], state: NetState) -> None:
         """Set the state of a servo that's a part of network.
 
         Args:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -19,7 +19,7 @@ from can.interfaces.pcan.pcan import PcanCanOperationError
 
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.canopen.servo import CANOPEN_SDO_RESPONSE_TIMEOUT, CanopenServo
-from ingenialink.enums.register import RegCyclicType
+from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
@@ -29,7 +29,7 @@ if platform.system() == "Windows":
     with DisableLogger():
         from can.interfaces.ixxat.exceptions import VCIError
 else:
-    VCIError = None  # type: ignore
+    VCIError = None  # noqa: PGH003
 from canopen import Network as NetworkLib
 
 KVASER_DRIVER_INSTALLED = True

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -29,7 +29,7 @@ if platform.system() == "Windows":
     with DisableLogger():
         from can.interfaces.ixxat.exceptions import VCIError
 else:
-    VCIError = None  # noqa: PGH003
+    VCIError = None  # type: ignore  # noqa: PGH003
 from canopen import Network as NetworkLib
 
 KVASER_DRIVER_INSTALLED = True

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -105,8 +105,7 @@ CAN_CHANNELS: Dict[str, Union[Tuple[int, int], Tuple[str, str]]] = {
 }
 
 
-# FIXME: INGK-1022
-class CAN_DEVICE(Enum):
+class CanDevice(Enum):
     """CAN Device."""
 
     KVASER = "kvaser"
@@ -218,7 +217,7 @@ class CanopenNetwork(Network):
 
     def __init__(
         self,
-        device: CAN_DEVICE,
+        device: CanDevice,
         channel: int = 0,
         baudrate: CAN_BAUDRATE = CAN_BAUDRATE.Baudrate_1M,
     ):
@@ -236,7 +235,7 @@ class CanopenNetwork(Network):
             "channel": self.__channel,
             "bitrate": self.__baudrate,
         }
-        if self.__device == CAN_DEVICE.PCAN.value:
+        if self.__device == CanDevice.PCAN.value:
             self.__connection_args["auto_reset"] = True
 
     def scan_slaves(self) -> List[int]:
@@ -406,7 +405,7 @@ class CanopenNetwork(Network):
         """
         if self._connection is None:
             self._connection = canopen.Network()
-            if self.__device in [CAN_DEVICE.IXXAT.value, CAN_DEVICE.KVASER.value]:
+            if self.__device in [CanDevice.IXXAT.value, CanDevice.KVASER.value]:
                 self._connection.listeners.append(CustomListener())
             try:
                 self._connection.connect(**self.__connection_args)
@@ -463,7 +462,7 @@ class CanopenNetwork(Network):
                 logger.info("Bus flushed")
         except Exception as e:
             logger.error(f"Could not stop guarding. Exception: {e}")
-        if self.__device in [CAN_DEVICE.IXXAT.value, CAN_DEVICE.KVASER.value]:
+        if self.__device in [CanDevice.IXXAT.value, CanDevice.KVASER.value]:
             self._connection.listeners.append(CustomListener())
         try:
             self._connection.connect(**self.__connection_args)
@@ -1079,14 +1078,14 @@ class CanopenNetwork(Network):
         Returns:
             List of tuples with device name and channel
         """
-        unavailable_devices = [CAN_DEVICE.KVASER, CAN_DEVICE.VIRTUAL]
+        unavailable_devices = [CanDevice.KVASER, CanDevice.VIRTUAL]
         if platform.system() == "Windows":
-            unavailable_devices.append(CAN_DEVICE.SOCKETCAN)
+            unavailable_devices.append(CanDevice.SOCKETCAN)
         return [
             (available_device["interface"], available_device["channel"])
             for available_device in (
                 can.detect_available_configs(
-                    [device.value for device in CAN_DEVICE if device not in unavailable_devices]
+                    [device.value for device in CanDevice if device not in unavailable_devices]
                 )
                 + self._get_available_kvaser_devices()
             )
@@ -1100,7 +1099,7 @@ class CanopenNetwork(Network):
         """
         if not KVASER_DRIVER_INSTALLED:
             return []
-        if self.__device == CAN_DEVICE.KVASER.value and not self.servos:
+        if self.__device == CanDevice.KVASER.value and not self.servos:
             self._reload_kvaser_lib()
         num_channels = ctypes.c_int(0)
         with contextlib.suppress(CANLIBError, NameError):

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -21,7 +21,7 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.canopen.servo import CANOPEN_SDO_RESPONSE_TIMEOUT, CanopenServo
 from ingenialink.enums.register import RegCyclicType
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, NET_STATE, NetProt, Network, SlaveInfo
 from ingenialink.register import REG_ACCESS, REG_DTYPE
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
@@ -105,6 +105,7 @@ CAN_CHANNELS: Dict[str, Union[Tuple[int, int], Tuple[str, str]]] = {
 }
 
 
+# FIXME: INGK-1022
 class CAN_DEVICE(Enum):
     """CAN Device."""
 
@@ -115,6 +116,7 @@ class CAN_DEVICE(Enum):
     SOCKETCAN = "socketcan"
 
 
+# FIXME: INGK-1022
 class CAN_BAUDRATE(Enum):
     """Baudrates."""
 
@@ -1044,9 +1046,9 @@ class CanopenNetwork(Network):
         return self._connection
 
     @property
-    def protocol(self) -> NET_PROT:
+    def protocol(self) -> NetProt:
         """Obtain network protocol."""
-        return NET_PROT.CAN
+        return NetProt.CAN
 
     def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
         """Get the state of a servo that's a part of network.

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -115,8 +115,7 @@ class CanDevice(Enum):
     SOCKETCAN = "socketcan"
 
 
-# FIXME: INGK-1022
-class CAN_BAUDRATE(Enum):
+class CanBaudrate(Enum):
     """Baudrates."""
 
     Baudrate_1M = 1000000
@@ -134,12 +133,12 @@ class CAN_BAUDRATE(Enum):
 
 
 CAN_BIT_TIMMING = {
-    CAN_BAUDRATE.Baudrate_1M: 0,
-    CAN_BAUDRATE.Baudrate_500K: 2,
-    CAN_BAUDRATE.Baudrate_250K: 3,
-    CAN_BAUDRATE.Baudrate_125K: 4,
-    CAN_BAUDRATE.Baudrate_100K: 5,
-    CAN_BAUDRATE.Baudrate_50K: 6,
+    CanBaudrate.Baudrate_1M: 0,
+    CanBaudrate.Baudrate_500K: 2,
+    CanBaudrate.Baudrate_250K: 3,
+    CanBaudrate.Baudrate_125K: 4,
+    CanBaudrate.Baudrate_100K: 5,
+    CanBaudrate.Baudrate_50K: 6,
 }
 
 
@@ -219,7 +218,7 @@ class CanopenNetwork(Network):
         self,
         device: CanDevice,
         channel: int = 0,
-        baudrate: CAN_BAUDRATE = CAN_BAUDRATE.Baudrate_1M,
+        baudrate: CanBaudrate = CanBaudrate.Baudrate_1M,
     ):
         super(CanopenNetwork, self).__init__()
         self.servos: List[CanopenServo] = []
@@ -836,7 +835,7 @@ class CanopenNetwork(Network):
     def change_baudrate(
         self,
         target_node: int,
-        new_target_baudrate: CAN_BAUDRATE,
+        new_target_baudrate: CanBaudrate,
         vendor_id: int,
         product_code: int,
         rev_number: int,

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import tempfile
+import warnings
 from collections import OrderedDict, defaultdict
 from enum import Enum
 from threading import Thread
@@ -1126,3 +1127,21 @@ class CanopenNetwork(Network):
         can_initialize_library = get_canlib_function("canInitializeLibrary")  # type: ignore[no-untyped-call]
         can_unload_library()
         can_initialize_library()
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "CAN_DEVICE": "CanDevice",
+    "CAN_BAUDRATE": "CanBaudrate",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ACCESS,
     REG_ADDRESS_TYPE,
     REG_PHY,
+    RegAccess,
     RegCyclicType,
     RegDtype,
 )
@@ -48,7 +48,7 @@ class CanopenRegister(Register):
         idx: int,
         subidx: int,
         dtype: RegDtype,
-        access: REG_ACCESS,
+        access: RegAccess,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Optional, Tuple, Union
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
-    REG_PHY,
     RegAccess,
     RegCyclicType,
     RegDtype,
+    RegPhy,
 )
 from ingenialink.register import Register
 
@@ -52,7 +52,7 @@ class CanopenRegister(Register):
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,
-        phy: REG_PHY = REG_PHY.NONE,
+        phy: RegPhy = RegPhy.NONE,
         subnode: int = 1,
         storage: Any = None,
         reg_range: Union[

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -4,9 +4,9 @@ from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ACCESS,
     REG_ADDRESS_TYPE,
-    REG_DTYPE,
     REG_PHY,
     RegCyclicType,
+    RegDtype,
 )
 from ingenialink.register import Register
 
@@ -47,7 +47,7 @@ class CanopenRegister(Register):
         self,
         idx: int,
         subidx: int,
-        dtype: REG_DTYPE,
+        dtype: RegDtype,
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ADDRESS_TYPE,
     RegAccess,
+    RegAddressType,
     RegCyclicType,
     RegDtype,
     RegPhy,
@@ -63,7 +63,7 @@ class CanopenRegister(Register):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[REG_ADDRESS_TYPE] = None,
+        address_type: Optional[RegAddressType] = None,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[Dict[str, BitField]] = None,

--- a/ingenialink/constants.py
+++ b/ingenialink/constants.py
@@ -1,4 +1,4 @@
-from ingenialink.register import REG_DTYPE
+from ingenialink.register import RegDtype
 
 DIST_FRAME_SIZE_BYTES = 128
 DIST_FRAME_SIZE = 512
@@ -25,15 +25,15 @@ CAN_MONITORING_MAPPED_REGISTERS_START_ADD = 0x58D000
 MONITORING_BUFFER_SIZE = 512
 
 data_type_size = {
-    REG_DTYPE.U8: 1,
-    REG_DTYPE.S8: 1,
-    REG_DTYPE.U16: 2,
-    REG_DTYPE.S16: 2,
-    REG_DTYPE.U32: 4,
-    REG_DTYPE.S32: 4,
-    REG_DTYPE.U64: 8,
-    REG_DTYPE.S64: 8,
-    REG_DTYPE.FLOAT: 4,
+    RegDtype.U8: 1,
+    RegDtype.S8: 1,
+    RegDtype.U16: 2,
+    RegDtype.S16: 2,
+    RegDtype.U32: 4,
+    RegDtype.S32: 4,
+    RegDtype.U64: 8,
+    RegDtype.S64: 8,
+    RegDtype.FLOAT: 4,
 }
 
 CAN_MAX_WRITE_SIZE = 512

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -14,7 +14,7 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILDictionaryParseError
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, RegCyclicType, RegDtype, Register
+from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegCyclicType, RegDtype, Register
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -175,7 +175,7 @@ class Dictionary(ABC):
         "byteArray512": RegDtype.BYTE_ARRAY_512,
     }
 
-    access_xdf_options = {"r": REG_ACCESS.RO, "w": REG_ACCESS.WO, "rw": REG_ACCESS.RW}
+    access_xdf_options = {"r": RegAccess.RO, "w": RegAccess.WO, "rw": RegAccess.RW}
 
     address_type_xdf_options = {
         "NVM": REG_ADDRESS_TYPE.NVM,

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 
 from ingenialink.bitfield import BitField
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import RegCyclicType
+from ingenialink.enums.register import RegAccess, RegAddressType, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILDictionaryParseError

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -14,7 +14,7 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILDictionaryParseError
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, RegCyclicType, Register
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, RegCyclicType, RegDtype, Register
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -161,18 +161,18 @@ class Dictionary(ABC):
     """
 
     dtype_xdf_options = {
-        "float": REG_DTYPE.FLOAT,
-        "s8": REG_DTYPE.S8,
-        "u8": REG_DTYPE.U8,
-        "s16": REG_DTYPE.S16,
-        "u16": REG_DTYPE.U16,
-        "s32": REG_DTYPE.S32,
-        "u32": REG_DTYPE.U32,
-        "s64": REG_DTYPE.S64,
-        "u64": REG_DTYPE.U64,
-        "str": REG_DTYPE.STR,
-        "bool": REG_DTYPE.BOOL,
-        "byteArray512": REG_DTYPE.BYTE_ARRAY_512,
+        "float": RegDtype.FLOAT,
+        "s8": RegDtype.S8,
+        "u8": RegDtype.U8,
+        "s16": RegDtype.S16,
+        "u16": RegDtype.U16,
+        "s32": RegDtype.S32,
+        "u32": RegDtype.U32,
+        "s64": RegDtype.S64,
+        "u64": RegDtype.U64,
+        "str": RegDtype.STR,
+        "bool": RegDtype.BOOL,
+        "byteArray512": RegDtype.BYTE_ARRAY_512,
     }
 
     access_xdf_options = {"r": REG_ACCESS.RO, "w": REG_ACCESS.WO, "rw": REG_ACCESS.RW}
@@ -769,9 +769,9 @@ class DictionaryV3(Dictionary):
         for subnode in subnode_list:
             if subnode.text is None:
                 raise ILDictionaryParseError("Subnode element text is None")
-            self.subnodes[
-                int(subnode.attrib[self.__SUBNODE_INDEX_ATTR])
-            ] = self.subnode_xdf_options[subnode.text.strip()]
+            self.subnodes[int(subnode.attrib[self.__SUBNODE_INDEX_ATTR])] = (
+                self.subnode_xdf_options[subnode.text.strip()]
+            )
 
     def __read_labels(self, root: ET.Element) -> Dict[str, str]:
         """Process Labels element

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1,11 +1,11 @@
 import copy
 import enum
-import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple, Union
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -76,7 +76,7 @@ class DictionaryCategories:
 
     """
 
-    def __init__(self, list_xdf_categories: List[ET.Element]) -> None:
+    def __init__(self, list_xdf_categories: List[ElementTree.Element]) -> None:
         self._list_xdf_categories = list_xdf_categories
         self._cat_ids: List[str] = []
         self._categories: Dict[str, Dict[str, str]] = {}
@@ -401,7 +401,7 @@ class Dictionary(ABC):
         else:
             self.coco_product_code = other_dict.product_code
 
-    def _read_errors(self, root: ET.Element, path: str) -> None:
+    def _read_errors(self, root: ElementTree.Element, path: str) -> None:
         """Process Errors element and set errors
 
         Args:
@@ -412,7 +412,7 @@ class Dictionary(ABC):
         self._load_errors(error_list)
 
     @staticmethod
-    def _findall_and_check(root: ET.Element, path: str) -> List[ET.Element]:
+    def _findall_and_check(root: ElementTree.Element, path: str) -> List[ElementTree.Element]:
         """Return list of elements in the target root element if exist, else, raises an exception.
 
         Args:
@@ -431,7 +431,7 @@ class Dictionary(ABC):
             raise ILDictionaryParseError(f"{path} element is not found")
         return element
 
-    def _load_errors(self, error_list: List[ET.Element]) -> None:
+    def _load_errors(self, error_list: List[ElementTree.Element]) -> None:
         """Parse and load the errors into the errors dictionary"""
         self.errors = {}
         for element in error_list:
@@ -543,7 +543,7 @@ class DictionaryV3(Dictionary):
     def get_description(cls, dictionary_path: str, interface: Interface) -> DictionaryDescriptor:
         try:
             with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
-                tree = ET.parse(xdf_file)
+                tree = ElementTree.parse(xdf_file)
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 f"There is not any xdf file in the path: {dictionary_path}"
@@ -562,7 +562,7 @@ class DictionaryV3(Dictionary):
         return DictionaryDescriptor(firmware_version, product_code, part_number, revision_number)
 
     @staticmethod
-    def __find_and_check(root: ET.Element, path: str) -> ET.Element:
+    def __find_and_check(root: ElementTree.Element, path: str) -> ElementTree.Element:
         """Return the path element in the target root element if exists, else, raises an exception.
 
         Args:
@@ -584,7 +584,7 @@ class DictionaryV3(Dictionary):
     def read_dictionary(self) -> None:
         try:
             with open(self.path, "r", encoding="utf-8") as xdf_file:
-                tree = ET.parse(xdf_file)
+                tree = ElementTree.parse(xdf_file)
         except FileNotFoundError as e:
             raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}") from e
         root = tree.getroot()
@@ -595,7 +595,7 @@ class DictionaryV3(Dictionary):
         body_element = self.__find_and_check(root, self.__BODY_ELEMENT)
         self.__read_body(body_element)
 
-    def __read_drive_image(self, drive_image: ET.Element) -> None:
+    def __read_drive_image(self, drive_image: ElementTree.Element) -> None:
         """Process DriveImage element and set image
 
         Args:
@@ -607,7 +607,7 @@ class DictionaryV3(Dictionary):
         else:
             self.image = None
 
-    def __read_header(self, root: ET.Element) -> None:
+    def __read_header(self, root: ElementTree.Element) -> None:
         """Process Header element
 
         Args:
@@ -618,7 +618,7 @@ class DictionaryV3(Dictionary):
         self.__read_version(version_element)
         # Dictionary localization not implemented
 
-    def __read_version(self, root: ET.Element) -> None:
+    def __read_version(self, root: ElementTree.Element) -> None:
         """Process Version element and set version
 
         Args:
@@ -632,7 +632,7 @@ class DictionaryV3(Dictionary):
             raise ILDictionaryParseError("Version is empty")
         self.version = root.text.strip()
 
-    def __read_body(self, root: ET.Element) -> None:
+    def __read_body(self, root: ElementTree.Element) -> None:
         """Process Body element
 
         Args:
@@ -644,7 +644,7 @@ class DictionaryV3(Dictionary):
         devices_element = self.__find_and_check(root, self.__DEVICES_ELEMENT)
         self.__read_devices(devices_element)
 
-    def __read_categories(self, root: ET.Element) -> None:
+    def __read_categories(self, root: ElementTree.Element) -> None:
         """Process Categories element and set categories
 
         Args:
@@ -654,7 +654,7 @@ class DictionaryV3(Dictionary):
         category_list = self._findall_and_check(root, self.__CATEGORY_ELEMENT)
         self.categories = DictionaryCategories(category_list)
 
-    def __read_devices(self, root: ET.Element) -> None:
+    def __read_devices(self, root: ElementTree.Element) -> None:
         """Process Devices element
 
         Args:
@@ -682,13 +682,13 @@ class DictionaryV3(Dictionary):
         if self.interface == Interface.EoE:
             self.__read_device_eoe(device_element)
 
-    def __read_device_attributes(self, device: ET.Element) -> None:
+    def __read_device_attributes(self, device: ElementTree.Element) -> None:
         self.firmware_version = device.attrib[self.__DEVICE_FW_VERSION_ATTR]
         self.product_code = int(device.attrib[self.__DEVICE_PRODUCT_CODE_ATTR])
         self.part_number = device.attrib[self.__DEVICE_PART_NUMBER_ATTR]
         self.revision_number = int(device.attrib[self.DEVICE_REVISION_NUMBER_ATTR])
 
-    def __read_device_eoe(self, root: ET.Element) -> None:
+    def __read_device_eoe(self, root: ElementTree.Element) -> None:
         """Process EoEDevice element
 
         Args:
@@ -698,7 +698,7 @@ class DictionaryV3(Dictionary):
         # Device element is identical
         self.__read_device_eth(root)
 
-    def __read_device_eth(self, root: ET.Element) -> None:
+    def __read_device_eth(self, root: ElementTree.Element) -> None:
         """Process ETHDevice element
 
         Args:
@@ -716,7 +716,7 @@ class DictionaryV3(Dictionary):
         errors_element = self.__find_and_check(root, self.__ERRORS_ELEMENT)
         self._read_errors(errors_element, self.__ERROR_ELEMENT)
 
-    def __read_device_ecat(self, root: ET.Element) -> None:
+    def __read_device_ecat(self, root: ElementTree.Element) -> None:
         """Process ECATDevice element
 
         Args:
@@ -737,7 +737,7 @@ class DictionaryV3(Dictionary):
         if safety_pdos_element is not None:
             self.__read_safety_pdos(safety_pdos_element)
 
-    def __read_device_can(self, root: ET.Element) -> None:
+    def __read_device_can(self, root: ElementTree.Element) -> None:
         """Process CANDevice element
 
         Args:
@@ -755,7 +755,7 @@ class DictionaryV3(Dictionary):
         errors_element = self.__find_and_check(root, self.__ERRORS_ELEMENT)
         self._read_errors(errors_element, self.__ERROR_ELEMENT)
 
-    def __read_subnodes(self, root: ET.Element) -> None:
+    def __read_subnodes(self, root: ElementTree.Element) -> None:
         """Process Subnodes element and fill subnodes
 
         Args:
@@ -769,11 +769,11 @@ class DictionaryV3(Dictionary):
         for subnode in subnode_list:
             if subnode.text is None:
                 raise ILDictionaryParseError("Subnode element text is None")
-            self.subnodes[int(subnode.attrib[self.__SUBNODE_INDEX_ATTR])] = (
-                self.subnode_xdf_options[subnode.text.strip()]
-            )
+            self.subnodes[
+                int(subnode.attrib[self.__SUBNODE_INDEX_ATTR])
+            ] = self.subnode_xdf_options[subnode.text.strip()]
 
-    def __read_labels(self, root: ET.Element) -> Dict[str, str]:
+    def __read_labels(self, root: ElementTree.Element) -> Dict[str, str]:
         """Process Labels element
 
         Args:
@@ -790,7 +790,7 @@ class DictionaryV3(Dictionary):
             labels[key] = value
         return labels
 
-    def __read_label(self, label: ET.Element) -> Tuple[str, str]:
+    def __read_label(self, label: ElementTree.Element) -> Tuple[str, str]:
         """Process Label element
 
         Args:
@@ -808,7 +808,7 @@ class DictionaryV3(Dictionary):
         return label.attrib[self.__LABEL_LANG_ATTR], label.text.strip()
 
     def __read_range(
-        self, range_elem: Optional[ET.Element]
+        self, range_elem: Optional[ElementTree.Element]
     ) -> Union[Tuple[None, None], Tuple[str, str]]:
         """Process Range element
 
@@ -826,7 +826,7 @@ class DictionaryV3(Dictionary):
         return None, None
 
     def __read_enumeration(
-        self, enumerations_element: Optional[ET.Element]
+        self, enumerations_element: Optional[ElementTree.Element]
     ) -> Optional[Dict[str, int]]:
         """Process Enumerations possible element
 
@@ -847,7 +847,7 @@ class DictionaryV3(Dictionary):
         return None
 
     def __read_bitfields(
-        self, bitfields_element: Optional[ET.Element]
+        self, bitfields_element: Optional[ElementTree.Element]
     ) -> Optional[Dict[str, BitField]]:
         """Process Bitfields possible element
 
@@ -870,7 +870,7 @@ class DictionaryV3(Dictionary):
 
         return None
 
-    def __read_mcb_register(self, register: ET.Element) -> None:
+    def __read_mcb_register(self, register: ElementTree.Element) -> None:
         """Process MCBRegister element and add it to _registers
 
         Args:
@@ -922,7 +922,7 @@ class DictionaryV3(Dictionary):
             self._registers[subnode] = {}
         self._registers[subnode][identifier] = ethernet_register
 
-    def __read_canopen_object(self, root: ET.Element) -> None:
+    def __read_canopen_object(self, root: ElementTree.Element) -> None:
         """Process CANopenObject element and add it to registers_group if has UID
 
         Args:
@@ -944,7 +944,7 @@ class DictionaryV3(Dictionary):
             self.registers_group[subnode][object_uid] = list(register_list)
 
     def __read_canopen_subitem(
-        self, subitem: ET.Element, reg_index: int, subnode: int
+        self, subitem: ElementTree.Element, reg_index: int, subnode: int
     ) -> CanopenRegister:
         """Process Subitem element and add it to _registers
 
@@ -1008,7 +1008,7 @@ class DictionaryV3(Dictionary):
         self._registers[subnode][identifier] = canopen_register
         return canopen_register
 
-    def __read_safety_pdos(self, root: ET.Element) -> None:
+    def __read_safety_pdos(self, root: ElementTree.Element) -> None:
         """Process SafetyPDOs element
 
         Args:
@@ -1025,7 +1025,7 @@ class DictionaryV3(Dictionary):
             uid, safety_tpdo = self.__read_pdo(tpdo_element)
             self.safety_tpdos[uid] = safety_tpdo
 
-    def __read_pdo(self, pdo: ET.Element) -> Tuple[str, DictionarySafetyPDO]:
+    def __read_pdo(self, pdo: ElementTree.Element) -> Tuple[str, DictionarySafetyPDO]:
         """Process RPDO and TPDO elements
 
         Args:
@@ -1152,7 +1152,7 @@ class DictionaryV2(Dictionary):
     def get_description(cls, dictionary_path: str, interface: Interface) -> DictionaryDescriptor:
         try:
             with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
-                tree = ET.parse(xdf_file)
+                tree = ElementTree.parse(xdf_file)
         except FileNotFoundError as e:
             raise FileNotFoundError(
                 f"There is not any xdf file in the path: {dictionary_path}"
@@ -1183,7 +1183,7 @@ class DictionaryV2(Dictionary):
     def read_dictionary(self) -> None:
         try:
             with open(self.path, "r", encoding="utf-8") as xdf_file:
-                tree = ET.parse(xdf_file)
+                tree = ElementTree.parse(xdf_file)
         except FileNotFoundError as e:
             raise FileNotFoundError(f"There is not any xdf file in the path: {self.path}") from e
         root = tree.getroot()
@@ -1256,7 +1256,7 @@ class DictionaryV2(Dictionary):
         xdf_file.close()
         self._append_missing_registers()
 
-    def _read_xdf_register(self, register: ET.Element) -> Optional[Register]:
+    def _read_xdf_register(self, register: ElementTree.Element) -> Optional[Register]:
         """Reads a register from the dictionary and creates a Register instance.
 
         Args:

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -14,7 +14,7 @@ from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILDictionaryParseError
-from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegCyclicType, RegDtype, Register
+from ingenialink.register import RegAccess, RegAddressType, RegCyclicType, RegDtype, Register
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -178,11 +178,11 @@ class Dictionary(ABC):
     access_xdf_options = {"r": RegAccess.RO, "w": RegAccess.WO, "rw": RegAccess.RW}
 
     address_type_xdf_options = {
-        "NVM": REG_ADDRESS_TYPE.NVM,
-        "NVM_NONE": REG_ADDRESS_TYPE.NVM_NONE,
-        "NVM_CFG": REG_ADDRESS_TYPE.NVM_CFG,
-        "NVM_LOCK": REG_ADDRESS_TYPE.NVM_LOCK,
-        "NVM_HW": REG_ADDRESS_TYPE.NVM_HW,
+        "NVM": RegAddressType.NVM,
+        "NVM_NONE": RegAddressType.NVM_NONE,
+        "NVM_CFG": RegAddressType.NVM_CFG,
+        "NVM_LOCK": RegAddressType.NVM_LOCK,
+        "NVM_HW": RegAddressType.NVM_HW,
     }
 
     subnode_xdf_options = {

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -77,9 +77,3 @@ class RegCyclicType(Enum):
     TX = "CYCLIC_TX"
     TXRX = "CYCLIC_TXRX"
     CONFIG = "CONFIG"
-
-
-# WARNING: Deprecated aliases
-REG_DTYPE = RegDtype
-REG_ACCESS = RegAccess
-REG_PHY = RegPhy

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class REG_DTYPE(Enum):
+class RegDtype(Enum):
     """Data Type."""
 
     U8 = 0
@@ -30,6 +30,7 @@ class REG_DTYPE(Enum):
     """Boolean."""
 
 
+# FIXME: INGK-1022
 class REG_ACCESS(Enum):
     """Access Type."""
 
@@ -41,6 +42,7 @@ class REG_ACCESS(Enum):
     """Write-only."""
 
 
+# FIXME: INGK-1022
 class REG_PHY(Enum):
     """Physical Units."""
 
@@ -60,6 +62,7 @@ class REG_PHY(Enum):
     """Radians."""
 
 
+# FIXME: INGK-1022
 class REG_ADDRESS_TYPE(Enum):
     """Address Type."""
 
@@ -77,3 +80,7 @@ class RegCyclicType(Enum):
     TX = "CYCLIC_TX"
     TXRX = "CYCLIC_TXRX"
     CONFIG = "CONFIG"
+
+
+# WARNING: Deprecated aliases
+REG_DTYPE = RegDtype

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -41,8 +41,7 @@ class RegAccess(Enum):
     """Write-only."""
 
 
-# FIXME: INGK-1022
-class REG_PHY(Enum):
+class RegPhy(Enum):
     """Physical Units."""
 
     NONE = 0
@@ -84,3 +83,4 @@ class RegCyclicType(Enum):
 # WARNING: Deprecated aliases
 REG_DTYPE = RegDtype
 REG_ACCESS = RegAccess
+REG_PHY = RegPhy

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -60,8 +60,7 @@ class RegPhy(Enum):
     """Radians."""
 
 
-# FIXME: INGK-1022
-class REG_ADDRESS_TYPE(Enum):
+class RegAddressType(Enum):
     """Address Type."""
 
     NVM = 0

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -30,8 +30,7 @@ class RegDtype(Enum):
     """Boolean."""
 
 
-# FIXME: INGK-1022
-class REG_ACCESS(Enum):
+class RegAccess(Enum):
     """Access Type."""
 
     RW = 0
@@ -84,3 +83,4 @@ class RegCyclicType(Enum):
 
 # WARNING: Deprecated aliases
 REG_DTYPE = RegDtype
+REG_ACCESS = RegAccess

--- a/ingenialink/enums/register.py
+++ b/ingenialink/enums/register.py
@@ -1,4 +1,6 @@
+import warnings
 from enum import Enum
+from typing import Any
 
 
 class RegDtype(Enum):
@@ -77,3 +79,21 @@ class RegCyclicType(Enum):
     TX = "CYCLIC_TX"
     TXRX = "CYCLIC_TXRX"
     CONFIG = "CONFIG"
+
+
+_DEPRECATED = {
+    "REG_DTYPE": "RegDtype",
+    "REG_ACCESS": "RegAccess",
+    "REG_PHY": "RegPhy",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingenialink/enums/servo.py
+++ b/ingenialink/enums/servo.py
@@ -22,8 +22,7 @@ class ServoState(Enum):
     """Fault."""
 
 
-# FIXME: INGK-1022
-class SERVO_FLAGS(Enum):
+class ServoFlags(Enum):
     """Status Flags."""
 
     TGT_REACHED = 0x01
@@ -48,8 +47,7 @@ class SERVO_FLAGS(Enum):
     """Initial angle determination finished."""
 
 
-# FIXME: INGK-1022
-class SERVO_MODE(Enum):
+class ServoMode(Enum):
     """Operation Mode."""
 
     OLV = 0
@@ -76,8 +74,7 @@ class SERVO_MODE(Enum):
     """Cyclic sync torque mode."""
 
 
-# FIXME: INGK-1022
-class SERVO_UNITS_TORQUE(Enum):
+class ServoUnitsTorque(Enum):
     """Torque Units."""
 
     NATIVE = 0
@@ -88,8 +85,7 @@ class SERVO_UNITS_TORQUE(Enum):
     """Newtons*meter."""
 
 
-# FIXME: INGK-1022
-class SERVO_UNITS_POS(Enum):
+class ServoUnitsPos(Enum):
     """Position Units."""
 
     NATIVE = 0
@@ -108,8 +104,7 @@ class SERVO_UNITS_POS(Enum):
     """Meters."""
 
 
-# FIXME: INGK-1022
-class SERVO_UNITS_VEL(Enum):
+class ServoUnitsVel(Enum):
     """Velocity Units."""
 
     NATIVE = 0
@@ -130,8 +125,7 @@ class SERVO_UNITS_VEL(Enum):
     """Meters/second."""
 
 
-# FIXME: INGK-1022
-class SERVO_UNITS_ACC(Enum):
+class ServoUnitsAcc(Enum):
     """Acceleration Units."""
 
     NATIVE = 0

--- a/ingenialink/enums/servo.py
+++ b/ingenialink/enums/servo.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class SERVO_STATE(Enum):
+class ServoState(Enum):
     """Servo states."""
 
     NRDY = 0
@@ -22,6 +22,7 @@ class SERVO_STATE(Enum):
     """Fault."""
 
 
+# FIXME: INGK-1022
 class SERVO_FLAGS(Enum):
     """Status Flags."""
 
@@ -47,6 +48,7 @@ class SERVO_FLAGS(Enum):
     """Initial angle determination finished."""
 
 
+# FIXME: INGK-1022
 class SERVO_MODE(Enum):
     """Operation Mode."""
 
@@ -74,6 +76,7 @@ class SERVO_MODE(Enum):
     """Cyclic sync torque mode."""
 
 
+# FIXME: INGK-1022
 class SERVO_UNITS_TORQUE(Enum):
     """Torque Units."""
 
@@ -85,6 +88,7 @@ class SERVO_UNITS_TORQUE(Enum):
     """Newtons*meter."""
 
 
+# FIXME: INGK-1022
 class SERVO_UNITS_POS(Enum):
     """Position Units."""
 
@@ -104,6 +108,7 @@ class SERVO_UNITS_POS(Enum):
     """Meters."""
 
 
+# FIXME: INGK-1022
 class SERVO_UNITS_VEL(Enum):
     """Velocity Units."""
 
@@ -125,6 +130,7 @@ class SERVO_UNITS_VEL(Enum):
     """Meters/second."""
 
 
+# FIXME: INGK-1022
 class SERVO_UNITS_ACC(Enum):
     """Acceleration Units."""
 

--- a/ingenialink/enums/servo.py
+++ b/ingenialink/enums/servo.py
@@ -1,4 +1,6 @@
+import warnings
 from enum import Enum
+from typing import Any
 
 
 class ServoState(Enum):
@@ -117,3 +119,25 @@ class ServoUnitsAcc(Enum):
     """Millimeters/second^2."""
     M_S2 = 6
     """Meters/second^2."""
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "SERVO_STATE": "ServoState",
+    "SERVO_MODE": "ServoMode",
+    "SERVO_UNITS_TORQUE": "ServoUnitsTorque",
+    "SERVO_UNITS_POS": "ServoUnitsPos",
+    "SERVO_UNITS_VEL": "ServoUnitsVel",
+    "SERVO_UNITS_ACC": "ServoUnitsAcc",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingenialink/eoe/network.py
+++ b/ingenialink/eoe/network.py
@@ -13,7 +13,7 @@ from ingenialink import constants
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.ethernet.servo import EthernetServo
 from ingenialink.exceptions import ILError, ILIOError, ILTimeoutError
-from ingenialink.network import NET_DEV_EVT, SlaveInfo
+from ingenialink.network import NetDevEvt, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -399,14 +399,14 @@ class EoENetwork(EthernetNetwork):
     def load_firmware(self) -> None:  # type: ignore [override]
         raise NotImplementedError
 
-    def _recover_from_power_cycle(self, status: NET_DEV_EVT) -> None:
+    def _recover_from_power_cycle(self, status: NetDevEvt) -> None:
         """Recover the connection after a power cycle.
 
         Args:
             status: The network status.
 
         """
-        if status == NET_DEV_EVT.REMOVED:
+        if status == NetDevEvt.REMOVED:
             connection_recovery_thread = Thread(target=self._connection_recovery)
             connection_recovery_thread.start()
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -10,7 +10,7 @@ from ingenialink.constants import (
 )
 from ingenialink.dictionary import DictionaryV2, Interface
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegCyclicType, RegDtype
+from ingenialink.register import RegAccess, RegAddressType, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -55,7 +55,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_ASSIGN_REGISTER_SUB_IDX_1",
@@ -65,7 +65,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_MAP_REGISTER_SUB_IDX_0",
@@ -75,7 +75,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="RPDO_MAP_REGISTER_SUB_IDX_1",
@@ -85,7 +85,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=RegDtype.STR,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_ASSIGN_REGISTER_SUB_IDX_0",
@@ -95,7 +95,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_ASSIGN_REGISTER_SUB_IDX_1",
@@ -105,7 +105,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_MAP_REGISTER_SUB_IDX_0",
@@ -115,7 +115,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x00,
             dtype=RegDtype.S32,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
         EthercatRegister(
             identifier="TPDO_MAP_REGISTER_SUB_IDX_1",
@@ -125,7 +125,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             dtype=RegDtype.STR,
             access=RegAccess.RW,
-            address_type=REG_ADDRESS_TYPE.NVM_NONE,
+            address_type=RegAddressType.NVM_NONE,
         ),
     ]
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -10,7 +10,7 @@ from ingenialink.constants import (
 )
 from ingenialink.dictionary import DictionaryV2, Interface
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, RegCyclicType
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -31,7 +31,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x58B2,
             subidx=0x01,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
         EthercatRegister(
@@ -41,7 +41,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x58B4,
             subidx=0x01,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),
     ]
@@ -53,7 +53,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1C12,
             subidx=0x00,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -63,7 +63,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1C12,
             subidx=0x01,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -73,7 +73,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1600,
             subidx=0x00,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -83,7 +83,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1600,
             subidx=0x01,
-            dtype=REG_DTYPE.STR,
+            dtype=RegDtype.STR,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -93,7 +93,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1C13,
             subidx=0x00,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -103,7 +103,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1C13,
             subidx=0x01,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -113,7 +113,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1A00,
             subidx=0x00,
-            dtype=REG_DTYPE.S32,
+            dtype=RegDtype.S32,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
@@ -123,7 +123,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subnode=0,
             idx=0x1A00,
             subidx=0x01,
-            dtype=REG_DTYPE.STR,
+            dtype=RegDtype.STR,
             access=REG_ACCESS.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -1,5 +1,5 @@
-import xml.etree.ElementTree as ET
 from typing import List, Optional
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -148,7 +148,7 @@ class EthercatDictionaryV2(DictionaryV2):
             else CANOPEN_ADDRESS_OFFSET + MAP_ADDRESS_OFFSET * (subnode - 1)
         )
 
-    def _read_xdf_register(self, register: ET.Element) -> Optional[EthercatRegister]:
+    def _read_xdf_register(self, register: ElementTree.Element) -> Optional[EthercatRegister]:
         current_read_register = super()._read_xdf_register(register)
         if current_read_register is None:
             return None

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -10,7 +10,7 @@ from ingenialink.constants import (
 )
 from ingenialink.dictionary import DictionaryV2, Interface
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, RegCyclicType, RegDtype
+from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -32,7 +32,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.RO,
+            access=RegAccess.RO,
         ),
         EthercatRegister(
             identifier="DIST_DATA_VALUE",
@@ -42,7 +42,7 @@ class EthercatDictionaryV2(DictionaryV2):
             subidx=0x01,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.WO,
+            access=RegAccess.WO,
         ),
     ]
 
@@ -54,7 +54,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1C12,
             subidx=0x00,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -64,7 +64,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1C12,
             subidx=0x01,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -74,7 +74,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1600,
             subidx=0x00,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -84,7 +84,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1600,
             subidx=0x01,
             dtype=RegDtype.STR,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -94,7 +94,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1C13,
             subidx=0x00,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -104,7 +104,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1C13,
             subidx=0x01,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -114,7 +114,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1A00,
             subidx=0x00,
             dtype=RegDtype.S32,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
         EthercatRegister(
@@ -124,7 +124,7 @@ class EthercatDictionaryV2(DictionaryV2):
             idx=0x1A00,
             subidx=0x01,
             dtype=RegDtype.STR,
-            access=REG_ACCESS.RW,
+            access=RegAccess.RW,
             address_type=REG_ADDRESS_TYPE.NVM_NONE,
         ),
     ]

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -19,7 +19,12 @@ except ImportError as ex:
 
 from ingenialink import bin as bin_module
 from ingenialink.ethercat.servo import EthercatServo
-from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILStateError, ILWrongWorkingCount
+from ingenialink.exceptions import (
+    ILError,
+    ILFirmwareLoadError,
+    ILStateError,
+    ILWrongWorkingCountError,
+)
 from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
@@ -308,7 +313,7 @@ class EthercatNetwork(Network):
             timeout: receive processdata timeout in seconds, 0.1 seconds by default.
 
         Raises:
-            ILWrongWorkingCount: If processdata working count is wrong
+            ILWrongWorkingCountError: If processdata working count is wrong
 
         """
         for servo in self.servos:
@@ -330,7 +335,7 @@ class EthercatNetwork(Network):
                     servos_state_msg += f", AL status {al_status}."
                 else:
                     servos_state_msg += ". "
-            raise ILWrongWorkingCount(
+            raise ILWrongWorkingCountError(
                 f"Processdata working count is wrong, expected: {self._ecat_master.expected_wkc},"
                 f" real: {processdata_wkc}. {servos_state_msg}"
             )

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -20,7 +20,7 @@ except ImportError as ex:
 from ingenialink import bin as bin_module
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILStateError, ILWrongWorkingCount
-from ingenialink.network import NET_DEV_EVT, NetProt, NetState, Network, SlaveInfo
+from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -59,14 +59,14 @@ class NetStatusListener(Thread):
                 servo_state = self.__network.get_servo_state(slave_id)
                 is_servo_alive = not servo.slave.state == pysoem.NONE_STATE
                 if not is_servo_alive and servo_state == NetState.CONNECTED:
-                    self.__network._notify_status(slave_id, NET_DEV_EVT.REMOVED)
+                    self.__network._notify_status(slave_id, NetDevEvt.REMOVED)
                     self.__network._set_servo_state(slave_id, NetState.DISCONNECTED)
                 if (
                     is_servo_alive
                     and servo_state == NetState.DISCONNECTED
                     and self.__network._recover_from_disconnection()
                 ):
-                    self.__network._notify_status(slave_id, NET_DEV_EVT.ADDED)
+                    self.__network._notify_status(slave_id, NetDevEvt.ADDED)
                     self.__network._set_servo_state(slave_id, NetState.CONNECTED)
                 time.sleep(self.__refresh_time)
 
@@ -376,7 +376,7 @@ class EthercatNetwork(Network):
         )
 
     def subscribe_to_status(  # type: ignore [override]
-        self, slave_id: int, callback: Callable[[NET_DEV_EVT], None]
+        self, slave_id: int, callback: Callable[[NetDevEvt], None]
     ) -> None:
         """Subscribe to network state changes.
 
@@ -391,7 +391,7 @@ class EthercatNetwork(Network):
         self.__observers_net_state[slave_id].append(callback)
 
     def unsubscribe_from_status(  # type: ignore [override]
-        self, slave_id: int, callback: Callable[[str, NET_DEV_EVT], None]
+        self, slave_id: int, callback: Callable[[str, NetDevEvt], None]
     ) -> None:
         """Unsubscribe from network state changes.
 
@@ -533,7 +533,7 @@ class EthercatNetwork(Network):
         """
         self._servos_state[servo_id] = state
 
-    def _notify_status(self, slave_id: int, status: NET_DEV_EVT) -> None:
+    def _notify_status(self, slave_id: int, status: NetDevEvt) -> None:
         """Notify subscribers of a network state change."""
         for callback in self.__observers_net_state[slave_id]:
             callback(status)

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -20,7 +20,7 @@ except ImportError as ex:
 from ingenialink import bin as bin_module
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILStateError, ILWrongWorkingCount
-from ingenialink.network import NET_DEV_EVT, NET_PROT, NET_STATE, Network, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, NET_STATE, NetProt, Network, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -504,9 +504,9 @@ class EthercatNetwork(Network):
         self.__is_master_running = True
 
     @property
-    def protocol(self) -> NET_PROT:
-        """NET_PROT: Obtain network protocol."""
-        return NET_PROT.ECAT
+    def protocol(self) -> NetProt:
+        """NetProt: Obtain network protocol."""
+        return NetProt.ECAT
 
     def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
         """Get the state of a servo that's a part of network.

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -20,7 +20,7 @@ except ImportError as ex:
 from ingenialink import bin as bin_module
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError, ILFirmwareLoadError, ILStateError, ILWrongWorkingCount
-from ingenialink.network import NET_DEV_EVT, NET_STATE, NetProt, Network, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, NetProt, NetState, Network, SlaveInfo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -58,16 +58,16 @@ class NetStatusListener(Thread):
                 slave_id = servo.slave_id
                 servo_state = self.__network.get_servo_state(slave_id)
                 is_servo_alive = not servo.slave.state == pysoem.NONE_STATE
-                if not is_servo_alive and servo_state == NET_STATE.CONNECTED:
+                if not is_servo_alive and servo_state == NetState.CONNECTED:
                     self.__network._notify_status(slave_id, NET_DEV_EVT.REMOVED)
-                    self.__network._set_servo_state(slave_id, NET_STATE.DISCONNECTED)
+                    self.__network._set_servo_state(slave_id, NetState.DISCONNECTED)
                 if (
                     is_servo_alive
-                    and servo_state == NET_STATE.DISCONNECTED
+                    and servo_state == NetState.DISCONNECTED
                     and self.__network._recover_from_disconnection()
                 ):
                     self.__network._notify_status(slave_id, NET_DEV_EVT.ADDED)
-                    self.__network._set_servo_state(slave_id, NET_STATE.CONNECTED)
+                    self.__network._set_servo_state(slave_id, NetState.CONNECTED)
                 time.sleep(self.__refresh_time)
 
     def stop(self) -> None:
@@ -221,7 +221,7 @@ class EthercatNetwork(Network):
             raise ILStateError("Slave can not reach PreOp state")
         servo.reset_pdo_mapping()
         self.servos.append(servo)
-        self._set_servo_state(slave_id, NET_STATE.CONNECTED)
+        self._set_servo_state(slave_id, NetState.CONNECTED)
         if net_status_listener:
             self.start_status_listener()
         return servo
@@ -508,7 +508,7 @@ class EthercatNetwork(Network):
         """NetProt: Obtain network protocol."""
         return NetProt.ECAT
 
-    def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
+    def get_servo_state(self, servo_id: Union[int, str]) -> NetState:
         """Get the state of a servo that's a part of network.
         The state indicates if the servo is connected or disconnected.
 
@@ -523,7 +523,7 @@ class EthercatNetwork(Network):
             raise ValueError("The servo ID must be an int.")
         return self._servos_state[servo_id]
 
-    def _set_servo_state(self, servo_id: Union[int, str], state: NET_STATE) -> None:
+    def _set_servo_state(self, servo_id: Union[int, str], state: NetState) -> None:
         """Set the state of a servo that's a part of network.
 
         Args:

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -25,7 +25,7 @@ from ingenialink.pdo import PDOServo, RPDOMap, TPDOMap
 logger = ingenialogger.get_logger(__name__)
 
 
-class SDO_OPERATION_MSG(Enum):
+class SdoOperationMsg(Enum):
     """Message for exceptions depending on the operation type."""
 
     READ = "reading"
@@ -158,7 +158,7 @@ class EthercatServo(PDOServo):
             pysoem.WkcError,
             ILIOError,
         ) as e:
-            self._handle_sdo_exception(reg, SDO_OPERATION_MSG.READ, e)
+            self._handle_sdo_exception(reg, SdoOperationMsg.READ, e)
         finally:
             self._lock.release()
         return value
@@ -181,12 +181,12 @@ class EthercatServo(PDOServo):
             pysoem.WkcError,
             ILIOError,
         ) as e:
-            self._handle_sdo_exception(reg, SDO_OPERATION_MSG.WRITE, e)
+            self._handle_sdo_exception(reg, SdoOperationMsg.WRITE, e)
         finally:
             self._lock.release()
 
     def _handle_sdo_exception(
-        self, reg: EthercatRegister, operation_msg: SDO_OPERATION_MSG, exception: Exception
+        self, reg: EthercatRegister, operation_msg: SdoOperationMsg, exception: Exception
     ) -> None:
         """
         Handle the exceptions that occur when reading or writing SDOs.

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -1,5 +1,5 @@
-import xml.etree.ElementTree as ET
 from typing import List, Optional
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -40,7 +40,7 @@ class EthernetDictionaryV2(DictionaryV2):
 
     interface = Interface.ETH
 
-    def _read_xdf_register(self, register: ET.Element) -> Optional[EthernetRegister]:
+    def _read_xdf_register(self, register: ElementTree.Element) -> Optional[EthernetRegister]:
         current_read_register = super()._read_xdf_register(register)
         if current_read_register is None:
             return None

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import REG_ACCESS, REG_DTYPE, EthernetRegister, RegCyclicType
+from ingenialink.ethernet.register import REG_ACCESS, EthernetRegister, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -24,7 +24,7 @@ class EthernetDictionaryV2(DictionaryV2):
             subnode=0,
             address=0x00B2,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.RO,
         ),
         EthernetRegister(
@@ -33,7 +33,7 @@ class EthernetDictionaryV2(DictionaryV2):
             subnode=0,
             address=0x00B4,
             cyclic=RegCyclicType.CONFIG,
-            dtype=REG_DTYPE.BYTE_ARRAY_512,
+            dtype=RegDtype.BYTE_ARRAY_512,
             access=REG_ACCESS.WO,
         ),
     ]

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 import ingenialogger
 
 from ingenialink.dictionary import DictionaryV2, Interface
-from ingenialink.ethernet.register import REG_ACCESS, EthernetRegister, RegCyclicType, RegDtype
+from ingenialink.ethernet.register import EthernetRegister, RegAccess, RegCyclicType, RegDtype
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -25,7 +25,7 @@ class EthernetDictionaryV2(DictionaryV2):
             address=0x00B2,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.RO,
+            access=RegAccess.RO,
         ),
         EthernetRegister(
             identifier="DIST_DATA_VALUE",
@@ -34,7 +34,7 @@ class EthernetDictionaryV2(DictionaryV2):
             address=0x00B4,
             cyclic=RegCyclicType.CONFIG,
             dtype=RegDtype.BYTE_ARRAY_512,
-            access=REG_ACCESS.WO,
+            access=RegAccess.WO,
         ),
     ]
 

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -15,7 +15,7 @@ from ingenialink.exceptions import ILError, ILFirmwareLoadError
 from ingenialink.network import NET_DEV_EVT, NET_STATE, Network, SlaveInfo
 from ingenialink.utils.udp import UDP
 
-from ..network import NET_PROT
+from ..network import NetProt
 from .servo import EthernetServo
 
 logger = ingenialogger.get_logger(__name__)
@@ -328,6 +328,6 @@ class EthernetNetwork(Network):
         self._servos_state[servo_id] = state
 
     @property
-    def protocol(self) -> NET_PROT:
+    def protocol(self) -> NetProt:
         """Obtain network protocol."""
-        return NET_PROT.ETH
+        return NetProt.ETH

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -13,7 +13,7 @@ from typing_extensions import override
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NetDevEvt, NetState, Network, SlaveInfo, NetProt
+from ingenialink.network import NetDevEvt, NetProt, NetState, Network, SlaveInfo
 from ingenialink.utils.udp import UDP
 
 from .servo import EthernetServo

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -12,7 +12,7 @@ import ingenialogger
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NET_DEV_EVT, NetState, Network, SlaveInfo
+from ingenialink.network import NetDevEvt, NetState, Network, SlaveInfo
 from ingenialink.utils.udp import UDP
 
 from ..network import NetProt
@@ -59,10 +59,10 @@ class NetStatusListener(Thread):
                         break
                 ping_response = unsuccessful_pings != self.__max_unsuccessful_pings
                 if servo_state == NetState.CONNECTED and not ping_response:
-                    self.__network._notify_status(servo_ip, NET_DEV_EVT.REMOVED)
+                    self.__network._notify_status(servo_ip, NetDevEvt.REMOVED)
                     self.__network._set_servo_state(servo_ip, NetState.DISCONNECTED)
                 if servo_state == NetState.DISCONNECTED and ping_response:
-                    self.__network._notify_status(servo_ip, NET_DEV_EVT.ADDED)
+                    self.__network._notify_status(servo_ip, NetDevEvt.ADDED)
                     self.__network._set_servo_state(servo_ip, NetState.CONNECTED)
             time.sleep(self.__refresh_time)
 
@@ -76,9 +76,7 @@ class EthernetNetwork(Network):
     def __init__(self) -> None:
         super(EthernetNetwork, self).__init__()
         self.__listener_net_status: Optional[NetStatusListener] = None
-        self.__observers_net_state: Dict[str, List[Callable[[NET_DEV_EVT], Any]]] = defaultdict(
-            list
-        )
+        self.__observers_net_state: Dict[str, List[Callable[[NetDevEvt], Any]]] = defaultdict(list)
 
     @staticmethod
     def load_firmware(
@@ -271,12 +269,12 @@ class EthernetNetwork(Network):
             self.__listener_net_status.join()
         self.__listener_net_status = None
 
-    def _notify_status(self, ip: str, status: NET_DEV_EVT) -> None:
+    def _notify_status(self, ip: str, status: NetDevEvt) -> None:
         """Notify subscribers of a network state change."""
         for callback in self.__observers_net_state[ip]:
             callback(status)
 
-    def subscribe_to_status(self, ip: str, callback: Callable[[NET_DEV_EVT], Any]) -> None:  # type: ignore [override]
+    def subscribe_to_status(self, ip: str, callback: Callable[[NetDevEvt], Any]) -> None:  # type: ignore [override]
         """Subscribe to network state changes.
 
         Args:
@@ -289,7 +287,7 @@ class EthernetNetwork(Network):
             return
         self.__observers_net_state[ip].append(callback)
 
-    def unsubscribe_from_status(self, ip: str, callback: Callable[[NET_DEV_EVT], Any]) -> None:  # type: ignore [override]
+    def unsubscribe_from_status(self, ip: str, callback: Callable[[NetDevEvt], Any]) -> None:  # type: ignore [override]
         """Unsubscribe from network state changes.
 
         Args:

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -12,7 +12,7 @@ import ingenialogger
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NET_DEV_EVT, NET_STATE, Network, SlaveInfo
+from ingenialink.network import NET_DEV_EVT, NetState, Network, SlaveInfo
 from ingenialink.utils.udp import UDP
 
 from ..network import NetProt
@@ -58,12 +58,12 @@ class NetStatusListener(Thread):
                     else:
                         break
                 ping_response = unsuccessful_pings != self.__max_unsuccessful_pings
-                if servo_state == NET_STATE.CONNECTED and not ping_response:
+                if servo_state == NetState.CONNECTED and not ping_response:
                     self.__network._notify_status(servo_ip, NET_DEV_EVT.REMOVED)
-                    self.__network._set_servo_state(servo_ip, NET_STATE.DISCONNECTED)
-                if servo_state == NET_STATE.DISCONNECTED and ping_response:
+                    self.__network._set_servo_state(servo_ip, NetState.DISCONNECTED)
+                if servo_state == NetState.DISCONNECTED and ping_response:
                     self.__network._notify_status(servo_ip, NET_DEV_EVT.ADDED)
-                    self.__network._set_servo_state(servo_ip, NET_STATE.CONNECTED)
+                    self.__network._set_servo_state(servo_ip, NetState.CONNECTED)
             time.sleep(self.__refresh_time)
 
     def stop(self) -> None:
@@ -228,7 +228,7 @@ class EthernetNetwork(Network):
             servo.stop_status_listener()
             raise ILError(f"Drive not found in IP {target}.") from e
         self.servos.append(servo)
-        self._set_servo_state(target, NET_STATE.CONNECTED)
+        self._set_servo_state(target, NetState.CONNECTED)
 
         if net_status_listener:
             self.start_status_listener()
@@ -247,7 +247,7 @@ class EthernetNetwork(Network):
         self.servos.remove(servo)
         servo.stop_status_listener()
         self.close_socket(servo.socket)
-        self._set_servo_state(servo.ip_address, NET_STATE.DISCONNECTED)
+        self._set_servo_state(servo.ip_address, NetState.DISCONNECTED)
         if len(self.servos) == 0:
             self.stop_status_listener()
 
@@ -302,7 +302,7 @@ class EthernetNetwork(Network):
             return
         self.__observers_net_state[ip].remove(callback)
 
-    def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
+    def get_servo_state(self, servo_id: Union[int, str]) -> NetState:
         """Get the state of a servo that's a part of network.
         The state indicates if the servo is connected or disconnected.
 
@@ -317,7 +317,7 @@ class EthernetNetwork(Network):
             raise ValueError("The servo ID must be a string.")
         return self._servos_state[servo_id]
 
-    def _set_servo_state(self, servo_id: Union[int, str], state: NET_STATE) -> None:
+    def _set_servo_state(self, servo_id: Union[int, str], state: NetState) -> None:
         """Set the state of a servo that's a part of network.
 
         Args:

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -2,8 +2,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ADDRESS_TYPE,
     RegAccess,
+    RegAddressType,
     RegCyclicType,
     RegDtype,
     RegPhy,
@@ -63,7 +63,7 @@ class EthernetRegister(Register):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[REG_ADDRESS_TYPE] = None,
+        address_type: Optional[RegAddressType] = None,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[Dict[str, BitField]] = None,

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -4,9 +4,9 @@ from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ACCESS,
     REG_ADDRESS_TYPE,
-    REG_DTYPE,
     REG_PHY,
     RegCyclicType,
+    RegDtype,
 )
 from ingenialink.register import Register
 
@@ -47,7 +47,7 @@ class EthernetRegister(Register):
     def __init__(
         self,
         address: int,
-        dtype: REG_DTYPE,
+        dtype: RegDtype,
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Optional, Tuple, Union
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
-    REG_PHY,
     RegAccess,
     RegCyclicType,
     RegDtype,
+    RegPhy,
 )
 from ingenialink.register import Register
 
@@ -52,7 +52,7 @@ class EthernetRegister(Register):
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,
-        phy: REG_PHY = REG_PHY.NONE,
+        phy: RegPhy = RegPhy.NONE,
         subnode: int = 1,
         storage: Any = None,
         reg_range: Union[

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ACCESS,
     REG_ADDRESS_TYPE,
     REG_PHY,
+    RegAccess,
     RegCyclicType,
     RegDtype,
 )
@@ -48,7 +48,7 @@ class EthernetRegister(Register):
         self,
         address: int,
         dtype: RegDtype,
-        access: REG_ACCESS,
+        access: RegAccess,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,

--- a/ingenialink/exceptions.py
+++ b/ingenialink/exceptions.py
@@ -6,7 +6,6 @@ class ILConfigurationError(ILError):
     """IngeniaLink configuration error."""
 
 
-
 class ILUDPError(ILError):
     """Ingenialink exception on UDP action."""
 
@@ -57,7 +56,6 @@ class ILNACKError(ILError):
 
 class ILDictionaryParseError(ILError):
     """IngeniaLink dictionary parse error."""
-
 
 
 class ILWrongWorkingCountError(ILError):

--- a/ingenialink/exceptions.py
+++ b/ingenialink/exceptions.py
@@ -10,7 +10,7 @@ class ILConfigurationError(ILError):
     pass
 
 
-class ILUDPException(ILError):
+class ILUDPError(ILError):
     """Ingenialink exception on UDP action."""
 
     pass
@@ -84,7 +84,7 @@ class ILDictionaryParseError(ILError):
     pass
 
 
-class ILWrongWorkingCount(ILError):
+class ILWrongWorkingCountError(ILError):
     """PDOs process data working count expected and received differ."""
 
     pass

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -11,7 +11,6 @@ from ingenialink.servo import Servo
 logger = ingenialogger.get_logger(__name__)
 
 
-# FIXME: INGK-1022
 class NetProt(Enum):
     """Network Protocol."""
 
@@ -22,7 +21,6 @@ class NetProt(Enum):
     CAN = 5
 
 
-# FIXME: INGK-1022
 class NetState(Enum):
     """Network State."""
 
@@ -31,17 +29,17 @@ class NetState(Enum):
     FAULTY = 2
 
 
-# WARNING: Deprecated aliases
-NET_PROT = NetProt
-NET_STATE = NetState
-
-
-# FIXME: INGK-1022
-class NET_DEV_EVT(Enum):
+class NetDevEvt(Enum):
     """Device Event."""
 
     ADDED = 0
     REMOVED = 1
+
+
+# WARNING: Deprecated aliases
+NET_PROT = NetProt
+NET_STATE = NetState
+NET_DEV_EVT = NetDevEvt
 
 
 # FIXME: INGK-1022
@@ -98,13 +96,13 @@ class Network(ABC):
 
     @abstractmethod
     def subscribe_to_status(
-        self, target: Union[int, str], callback: Callable[[NET_DEV_EVT], Any]
+        self, target: Union[int, str], callback: Callable[[NetDevEvt], Any]
     ) -> None:
         raise NotImplementedError
 
     @abstractmethod
     def unsubscribe_from_status(
-        self, target: Union[int, str], callback: Callable[[NET_DEV_EVT], Any]
+        self, target: Union[int, str], callback: Callable[[NetDevEvt], Any]
     ) -> None:
         raise NotImplementedError
 

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -11,7 +11,8 @@ from ingenialink.servo import Servo
 logger = ingenialogger.get_logger(__name__)
 
 
-class NET_PROT(Enum):
+# FIXME: INGK-1022
+class NetProt(Enum):
     """Network Protocol."""
 
     EUSB = 0
@@ -21,6 +22,11 @@ class NET_PROT(Enum):
     CAN = 5
 
 
+# WARNING: Deprecated aliases
+NET_PROT = NetProt
+
+
+# FIXME: INGK-1022
 class NET_STATE(Enum):
     """Network State."""
 
@@ -29,6 +35,7 @@ class NET_STATE(Enum):
     FAULTY = 2
 
 
+# FIXME: INGK-1022
 class NET_DEV_EVT(Enum):
     """Device Event."""
 
@@ -36,6 +43,7 @@ class NET_DEV_EVT(Enum):
     REMOVED = 1
 
 
+# FIXME: INGK-1022
 class EEPROM_FILE_FORMAT(Enum):
     """EEPROM file format"""
 
@@ -43,6 +51,7 @@ class EEPROM_FILE_FORMAT(Enum):
     INTEL = 1
 
 
+# FIXME: INGK-1022
 class NET_TRANS_PROT(Enum):
     """Transmission protocol."""
 
@@ -115,5 +124,5 @@ class Network(ABC):
         self._servos_state[servo_id] = state
 
     @property
-    def protocol(self) -> NET_PROT:
+    def protocol(self) -> NetProt:
         raise NotImplementedError

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -50,14 +50,6 @@ class NetTransProt(Enum):
     UDP = 2
 
 
-# WARNING: Deprecated aliases
-NET_PROT = NetProt
-NET_STATE = NetState
-NET_DEV_EVT = NetDevEvt
-EEPROM_FILE_FORMAT = EepromFileFormat
-NET_TRANS_PROT = NetTransProt
-
-
 @dataclass
 class SlaveInfo:
     product_code: Optional[int] = None

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -22,17 +22,18 @@ class NetProt(Enum):
     CAN = 5
 
 
-# WARNING: Deprecated aliases
-NET_PROT = NetProt
-
-
 # FIXME: INGK-1022
-class NET_STATE(Enum):
+class NetState(Enum):
     """Network State."""
 
     CONNECTED = 0
     DISCONNECTED = 1
     FAULTY = 2
+
+
+# WARNING: Deprecated aliases
+NET_PROT = NetProt
+NET_STATE = NetState
 
 
 # FIXME: INGK-1022
@@ -72,7 +73,7 @@ class Network(ABC):
         self.servos: List[Any] = []
         """List of the connected servos in the network."""
 
-        self._servos_state: Dict[Union[int, str], NET_STATE] = {}
+        self._servos_state: Dict[Union[int, str], NetState] = {}
         """Dictionary containing the state of the servos that are a part of the network."""
 
     @abstractmethod
@@ -116,11 +117,11 @@ class Network(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def get_servo_state(self, servo_id: Union[int, str]) -> NET_STATE:
+    def get_servo_state(self, servo_id: Union[int, str]) -> NetState:
         return self._servos_state[servo_id]
 
     @abstractmethod
-    def _set_servo_state(self, servo_id: Union[int, str], state: NET_STATE) -> None:
+    def _set_servo_state(self, servo_id: Union[int, str], state: NetState) -> None:
         self._servos_state[servo_id] = state
 
     @property

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -36,18 +36,18 @@ class NetDevEvt(Enum):
     REMOVED = 1
 
 
-# WARNING: Deprecated aliases
-NET_PROT = NetProt
-NET_STATE = NetState
-NET_DEV_EVT = NetDevEvt
-
-
-# FIXME: INGK-1022
-class EEPROM_FILE_FORMAT(Enum):
+class EepromFileFormat(Enum):
     """EEPROM file format"""
 
     BINARY = 0
     INTEL = 1
+
+
+# WARNING: Deprecated aliases
+NET_PROT = NetProt
+NET_STATE = NetState
+NET_DEV_EVT = NetDevEvt
+EEPROM_FILE_FORMAT = EepromFileFormat
 
 
 # FIXME: INGK-1022

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -43,19 +43,19 @@ class EepromFileFormat(Enum):
     INTEL = 1
 
 
+class NetTransProt(Enum):
+    """Transmission protocol."""
+
+    TCP = 1
+    UDP = 2
+
+
 # WARNING: Deprecated aliases
 NET_PROT = NetProt
 NET_STATE = NetState
 NET_DEV_EVT = NetDevEvt
 EEPROM_FILE_FORMAT = EepromFileFormat
-
-
-# FIXME: INGK-1022
-class NET_TRANS_PROT(Enum):
-    """Transmission protocol."""
-
-    TCP = 1
-    UDP = 2
+NET_TRANS_PROT = NetTransProt
 
 
 @dataclass

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -1,3 +1,4 @@
+import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -160,3 +161,22 @@ class Network(ABC):
     def protocol(self) -> NetProt:
         """NET_PROT: Obtain network protocol."""
         raise NotImplementedError
+
+
+# WARNING: Deprecated aliases
+_DEPRECATED = {
+    "NET_PROT": "NetProt",
+    "NET_STATE": "NetState",
+    "NET_DEV_EVT": "NetDevEvt",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED:
+        warnings.warn(
+            f"{name} is deprecated, use {_DEPRECATED[name]} instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return globals()[_DEPRECATED[name]]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import bitarray
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_ACCESS, RegCyclicType, RegDtype
+from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILError
 from ingenialink.servo import Servo
@@ -52,7 +52,7 @@ class PDOMapItem:
                 subidx=0x00,
                 cyclic=self.ACCEPTED_CYCLIC,
                 dtype=RegDtype.STR,
-                access=REG_ACCESS.RW,
+                access=RegAccess.RW,
             )
         self.register = register
         self.size_bits = size_bits or dtype_length_bits[register.dtype]

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -3,7 +3,7 @@ from typing import List, Optional, Union
 import bitarray
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, RegCyclicType
+from ingenialink.enums.register import REG_ACCESS, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILError
 from ingenialink.servo import Servo
@@ -51,7 +51,7 @@ class PDOMapItem:
                 idx=0x0000,
                 subidx=0x00,
                 cyclic=self.ACCEPTED_CYCLIC,
-                dtype=REG_DTYPE.STR,
+                dtype=RegDtype.STR,
                 access=REG_ACCESS.RW,
             )
         self.register = register
@@ -133,7 +133,7 @@ class PDOMapItem:
             raise NotImplementedError(
                 "The register value must be read by the raw_data_bytes attribute."
             )
-        if self.register.dtype == REG_DTYPE.BOOL:
+        if self.register.dtype == RegDtype.BOOL:
             value = self.raw_data_bits.any()
         else:
             value = convert_bytes_to_dtype(self.raw_data_bytes, self.register.dtype)

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -4,9 +4,9 @@ from typing import Any, Dict, Optional, Tuple, Union
 from ingenialink import exceptions as exc
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ACCESS,
     REG_ADDRESS_TYPE,
     REG_PHY,
+    RegAccess,
     RegCyclicType,
     RegDtype,
 )
@@ -58,7 +58,7 @@ class Register(ABC):
     def __init__(
         self,
         dtype: RegDtype,
-        access: REG_ACCESS,
+        access: RegAccess,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,
@@ -106,11 +106,11 @@ class Register(ABC):
         self.__bitfields = bitfields
         self.__config_range(reg_range)
 
-    def __type_errors(self, dtype: RegDtype, access: REG_ACCESS, phy: REG_PHY) -> None:
+    def __type_errors(self, dtype: RegDtype, access: RegAccess, phy: REG_PHY) -> None:
         if not isinstance(dtype, RegDtype):
             raise exc.ILValueError("Invalid data type")
 
-        if not isinstance(access, REG_ACCESS):
+        if not isinstance(access, RegAccess):
             raise exc.ILAccessError("Invalid access type")
 
         if not isinstance(phy, REG_PHY):
@@ -148,9 +148,9 @@ class Register(ABC):
         return RegDtype(self._dtype)
 
     @property
-    def access(self) -> REG_ACCESS:
+    def access(self) -> RegAccess:
         """Access type of the register."""
-        return REG_ACCESS(self._access)
+        return RegAccess(self._access)
 
     @property
     def identifier(self) -> Optional[str]:

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -6,22 +6,22 @@ from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ACCESS,
     REG_ADDRESS_TYPE,
-    REG_DTYPE,
     REG_PHY,
     RegCyclicType,
+    RegDtype,
 )
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
-dtypes_ranges: Dict[REG_DTYPE, Dict[str, Union[int, float]]] = {
-    REG_DTYPE.U8: {"max": 255, "min": 0},
-    REG_DTYPE.S8: {"max": 127, "min": -128},
-    REG_DTYPE.U16: {"max": 65535, "min": 0},
-    REG_DTYPE.S16: {"max": 32767, "min": -32767 - 1},
-    REG_DTYPE.U32: {"max": 4294967295, "min": 0},
-    REG_DTYPE.S32: {"max": 2147483647, "min": -2147483647 - 1},
-    REG_DTYPE.U64: {"max": 18446744073709551615, "min": 0},
-    REG_DTYPE.S64: {"max": 9223372036854775807, "min": 9223372036854775807 - 1},
-    REG_DTYPE.FLOAT: {"max": 3.4e38, "min": -3.4e38},
+dtypes_ranges: Dict[RegDtype, Dict[str, Union[int, float]]] = {
+    RegDtype.U8: {"max": 255, "min": 0},
+    RegDtype.S8: {"max": 127, "min": -128},
+    RegDtype.U16: {"max": 65535, "min": 0},
+    RegDtype.S16: {"max": 32767, "min": -32767 - 1},
+    RegDtype.U32: {"max": 4294967295, "min": 0},
+    RegDtype.S32: {"max": 2147483647, "min": -2147483647 - 1},
+    RegDtype.U64: {"max": 18446744073709551615, "min": 0},
+    RegDtype.S64: {"max": 9223372036854775807, "min": 9223372036854775807 - 1},
+    RegDtype.FLOAT: {"max": 3.4e38, "min": -3.4e38},
 }
 
 
@@ -57,7 +57,7 @@ class Register(ABC):
 
     def __init__(
         self,
-        dtype: REG_DTYPE,
+        dtype: RegDtype,
         access: REG_ACCESS,
         identifier: Optional[str] = None,
         units: Optional[str] = None,
@@ -106,8 +106,8 @@ class Register(ABC):
         self.__bitfields = bitfields
         self.__config_range(reg_range)
 
-    def __type_errors(self, dtype: REG_DTYPE, access: REG_ACCESS, phy: REG_PHY) -> None:
-        if not isinstance(dtype, REG_DTYPE):
+    def __type_errors(self, dtype: RegDtype, access: REG_ACCESS, phy: REG_PHY) -> None:
+        if not isinstance(dtype, RegDtype):
             raise exc.ILValueError("Invalid data type")
 
         if not isinstance(access, REG_ACCESS):
@@ -124,7 +124,7 @@ class Register(ABC):
         if self.dtype not in dtypes_ranges:
             self._storage_valid = False
             return
-        elif self.dtype == REG_DTYPE.FLOAT:
+        elif self.dtype == RegDtype.FLOAT:
             cast_type = float
         else:
             cast_type = int
@@ -143,9 +143,9 @@ class Register(ABC):
             self._storage = cast_type(self.storage)
 
     @property
-    def dtype(self) -> REG_DTYPE:
+    def dtype(self) -> RegDtype:
         """Data type of the register."""
-        return REG_DTYPE(self._dtype)
+        return RegDtype(self._dtype)
 
     @property
     def access(self) -> REG_ACCESS:
@@ -184,15 +184,15 @@ class Register(ABC):
             return None
 
         if self.dtype in [
-            REG_DTYPE.S8,
-            REG_DTYPE.U8,
-            REG_DTYPE.S16,
-            REG_DTYPE.U16,
-            REG_DTYPE.S32,
-            REG_DTYPE.U32,
-            REG_DTYPE.S64,
-            REG_DTYPE.U64,
-            REG_DTYPE.FLOAT,
+            RegDtype.S8,
+            RegDtype.U8,
+            RegDtype.S16,
+            RegDtype.U16,
+            RegDtype.S32,
+            RegDtype.U32,
+            RegDtype.S64,
+            RegDtype.U64,
+            RegDtype.FLOAT,
         ]:
             return self._storage
         else:

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Optional, Tuple, Union
 from ingenialink import exceptions as exc
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
-    REG_ADDRESS_TYPE,
     RegAccess,
+    RegAddressType,
     RegCyclicType,
     RegDtype,
     RegPhy,
@@ -73,7 +73,7 @@ class Register(ABC):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[REG_ADDRESS_TYPE] = None,
+        address_type: Optional[RegAddressType] = None,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[Dict[str, BitField]] = None,
@@ -253,9 +253,9 @@ class Register(ABC):
         return self._internal_use
 
     @property
-    def address_type(self) -> Optional[REG_ADDRESS_TYPE]:
+    def address_type(self) -> Optional[RegAddressType]:
         """Address type of the register."""
-        return REG_ADDRESS_TYPE(self._address_type)
+        return RegAddressType(self._address_type)
 
     @property
     def description(self) -> Optional[str]:

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -5,10 +5,10 @@ from ingenialink import exceptions as exc
 from ingenialink.bitfield import BitField
 from ingenialink.enums.register import (
     REG_ADDRESS_TYPE,
-    REG_PHY,
     RegAccess,
     RegCyclicType,
     RegDtype,
+    RegPhy,
 )
 from ingenialink.utils._utils import convert_bytes_to_dtype
 
@@ -62,7 +62,7 @@ class Register(ABC):
         identifier: Optional[str] = None,
         units: Optional[str] = None,
         cyclic: RegCyclicType = RegCyclicType.CONFIG,
-        phy: REG_PHY = REG_PHY.NONE,
+        phy: RegPhy = RegPhy.NONE,
         subnode: int = 1,
         storage: Any = None,
         reg_range: Union[
@@ -106,14 +106,14 @@ class Register(ABC):
         self.__bitfields = bitfields
         self.__config_range(reg_range)
 
-    def __type_errors(self, dtype: RegDtype, access: RegAccess, phy: REG_PHY) -> None:
+    def __type_errors(self, dtype: RegDtype, access: RegAccess, phy: RegPhy) -> None:
         if not isinstance(dtype, RegDtype):
             raise exc.ILValueError("Invalid data type")
 
         if not isinstance(access, RegAccess):
             raise exc.ILAccessError("Invalid access type")
 
-        if not isinstance(phy, REG_PHY):
+        if not isinstance(phy, RegPhy):
             raise exc.ILValueError("Invalid physical units type")
 
     def __config_range(
@@ -168,9 +168,9 @@ class Register(ABC):
         return self._cyclic
 
     @property
-    def phy(self) -> REG_PHY:
+    def phy(self) -> RegPhy:
         """Physical units of the register."""
-        return REG_PHY(self._phy)
+        return RegPhy(self._phy)
 
     @property
     def subnode(self) -> int:

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -2,10 +2,10 @@ import os
 import re
 import threading
 import time
-import xml.etree.ElementTree as ET
 from abc import abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from xml.dom import minidom
+from xml.etree import ElementTree
 
 import ingenialogger
 import numpy as np
@@ -140,8 +140,8 @@ class DictionaryFactory:
         try:
             with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
                 try:
-                    tree = ET.parse(xdf_file)
-                except ET.ParseError:
+                    tree = ElementTree.parse(xdf_file)
+                except ElementTree.ParseError:
                     raise ILDictionaryParseError(f"File is not a xdf: {dictionary_path}")
         except FileNotFoundError:
             raise FileNotFoundError(f"There is not any xdf file in the path: {dictionary_path}")
@@ -450,16 +450,16 @@ class Servo:
         rev_number = drive_info["revision_number"]
         firmware_version = drive_info["firmware_version"]
 
-        tree = ET.Element("IngeniaDictionary")
-        header = ET.SubElement(tree, "Header")
-        version = ET.SubElement(header, "Version")
+        tree = ElementTree.Element("IngeniaDictionary")
+        header = ElementTree.SubElement(tree, "Header")
+        version = ElementTree.SubElement(header, "Version")
         version.text = "2"
-        default_language = ET.SubElement(header, "DefaultLanguage")
+        default_language = ElementTree.SubElement(header, "DefaultLanguage")
         default_language.text = "en_US"
 
-        body = ET.SubElement(tree, "Body")
-        device = ET.SubElement(body, "Device")
-        registers = ET.SubElement(device, "Registers")
+        body = ElementTree.SubElement(tree, "Body")
+        device = ElementTree.SubElement(body, "Device")
+        registers = ElementTree.SubElement(device, "Registers")
         interface = (
             self.DICTIONARY_INTERFACE_ATTR_CAN
             if self.dictionary.interface == Interface.CAN
@@ -483,14 +483,14 @@ class Servo:
             for configuration_register in configuration_registers:
                 if configuration_register.identifier is None:
                     continue
-                register_xml = ET.SubElement(registers, "Register")
+                register_xml = ElementTree.SubElement(registers, "Register")
                 register_xml.set("access", access_ops[configuration_register.access])
                 register_xml.set("dtype", dtype_ops[configuration_register.dtype])
                 register_xml.set("id", configuration_register.identifier)
                 self.__update_register_dict(register_xml, node)
                 register_xml.set("subnode", str(node))
 
-        dom = minidom.parseString(ET.tostring(tree, encoding="utf-8"))
+        dom = minidom.parseString(ElementTree.tostring(tree, encoding="utf-8"))
         with open(config_file, "wb") as f:
             f.write(dom.toprettyxml(indent="\t").encode())
 
@@ -533,7 +533,9 @@ class Servo:
         return registers
 
     @staticmethod
-    def _read_configuration_file(config_file: str) -> Tuple[ET.Element, List[ET.Element]]:
+    def _read_configuration_file(
+        config_file: str,
+    ) -> Tuple[ElementTree.Element, List[ElementTree.Element]]:
         """Read a configuration file. Returns the device metadata and the registers list.
 
         Args:
@@ -550,7 +552,7 @@ class Servo:
         if not os.path.isfile(config_file):
             raise FileNotFoundError(f"Could not find {config_file}.")
         with open(config_file, "r", encoding="utf-8") as xml_file:
-            tree = ET.parse(xml_file)
+            tree = ElementTree.parse(xml_file)
         root = tree.getroot()
         device = root.find("Body/Device")
         axis = tree.findall("*/Device/Axes/Axis")
@@ -560,7 +562,7 @@ class Servo:
         else:
             # Single axis
             registers = root.findall("./Body/Device/Registers/Register")
-        if not isinstance(device, ET.Element):
+        if not isinstance(device, ElementTree.Element):
             raise ILIOError("Configuration file does not have device information")
         if not isinstance(registers, list):
             raise ILIOError("Configuration file does not have register list")
@@ -1123,7 +1125,7 @@ class Servo:
         else:
             raise TypeError("Invalid register")
 
-    def __update_register_dict(self, register: ET.Element, subnode: int) -> None:
+    def __update_register_dict(self, register: ElementTree.Element, subnode: int) -> None:
         """Updates the register from a dictionary with the
         storage parameters.
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -270,13 +270,13 @@ class Servo:
         self.full_name = f"{prod_name} {self.name} ({self.target})"
         """Obtains the servo full name."""
         self.units_torque = None
-        """SERVO_UNITS_TORQUE: Torque units."""
+        """ServoUnitsTorque: Torque units."""
         self.units_pos = None
-        """SERVO_UNITS_POS: Position units."""
+        """ServoUnitsPos: Position units."""
         self.units_vel = None
-        """SERVO_UNITS_VEL: Velocity units."""
+        """ServoUnitsVel: Velocity units."""
         self.units_acc = None
-        """SERVO_UNITS_ACC: Acceleration units."""
+        """ServoUnitsAcc: Acceleration units."""
         self._lock = threading.Lock()
         self.__observers_servo_state: List[Callable[[ServoState, int], Any]] = []
         self.__listener_servo_status: Optional[ServoStatusListener] = None

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -30,7 +30,7 @@ from ingenialink.dictionary import (
     SubnodeType,
 )
 from ingenialink.emcy import EmergencyMessage
-from ingenialink.enums.register import REG_ADDRESS_TYPE, RegAccess, RegDtype
+from ingenialink.enums.register import RegAccess, RegAddressType, RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
@@ -504,9 +504,7 @@ class Servo:
             True if the register can be used for the configuration file. False otherwise.
 
         """
-        if (register.access != RegAccess.RW) or (
-            register.address_type == REG_ADDRESS_TYPE.NVM_NONE
-        ):
+        if (register.access != RegAccess.RW) or (register.address_type == RegAddressType.NVM_NONE):
             return False
         return True
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -30,7 +30,7 @@ from ingenialink.dictionary import (
     SubnodeType,
 )
 from ingenialink.emcy import EmergencyMessage
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, RegDtype
+from ingenialink.enums.register import REG_ADDRESS_TYPE, RegAccess, RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
@@ -504,7 +504,7 @@ class Servo:
             True if the register can be used for the configuration file. False otherwise.
 
         """
-        if (register.access != REG_ACCESS.RW) or (
+        if (register.access != RegAccess.RW) or (
             register.address_type == REG_ADDRESS_TYPE.NVM_NONE
         ):
             return False
@@ -1325,7 +1325,7 @@ class Servo:
         """
         _reg = self._get_reg(reg, subnode)
 
-        if _reg.access == REG_ACCESS.RO:
+        if _reg.access == RegAccess.RO:
             raise ILAccessError("Register is Read-only")
         if isinstance(data, bytes):
             data_bytes = data
@@ -1354,7 +1354,7 @@ class Servo:
         """
         _reg = self._get_reg(reg, subnode)
         access = _reg.access
-        if access == REG_ACCESS.WO:
+        if access == RegAccess.WO:
             raise ILAccessError("Register is Write-only")
 
         raw_read = self._read_raw(_reg, **kwargs)

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -30,7 +30,7 @@ from ingenialink.dictionary import (
     SubnodeType,
 )
 from ingenialink.emcy import EmergencyMessage
-from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, REG_ADDRESS_TYPE, RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from ingenialink.ethercat.dictionary import EthercatDictionaryV2
 from ingenialink.ethernet.dictionary import EthernetDictionaryV2
@@ -282,7 +282,7 @@ class Servo:
         self.__listener_servo_status: Optional[ServoStatusListener] = None
         self.__monitoring_data: Dict[int, List[Union[int, float]]] = {}
         self.__monitoring_size: Dict[int, int] = {}
-        self.__monitoring_dtype: Dict[int, REG_DTYPE] = {}
+        self.__monitoring_dtype: Dict[int, RegDtype] = {}
         self.__disturbance_data = bytes()
         self.__disturbance_size: Dict[int, int] = {}
         self.__disturbance_dtype: Dict[int, str] = {}
@@ -911,7 +911,7 @@ class Servo:
 
         """
         self.__monitoring_data[channel] = []
-        self.__monitoring_dtype[channel] = REG_DTYPE(dtype)
+        self.__monitoring_dtype[channel] = RegDtype(dtype)
         self.__monitoring_size[channel] = size
         data = self._monitoring_disturbance_data_to_map_register(subnode, address, dtype, size)
         try:
@@ -977,7 +977,7 @@ class Servo:
         self.__monitoring_process_data(monitoring_data)
 
     def monitoring_channel_data(
-        self, channel: int, dtype: Optional[REG_DTYPE] = None
+        self, channel: int, dtype: Optional[RegDtype] = None
     ) -> List[float]:
         """Obtain processed monitoring data of a channel.
 
@@ -1023,7 +1023,7 @@ class Servo:
 
         """
         self.__disturbance_size[channel] = size
-        self.__disturbance_dtype[channel] = REG_DTYPE(dtype).name
+        self.__disturbance_dtype[channel] = RegDtype(dtype).name
         data = self._monitoring_disturbance_data_to_map_register(subnode, address, dtype, size)
         try:
             self.write(self.__disturbance_map_register(), data=data, subnode=0)
@@ -1268,7 +1268,7 @@ class Servo:
     def _disturbance_create_data_chunks(
         self,
         channels: Union[int, List[int]],
-        dtypes: Union[REG_DTYPE, List[REG_DTYPE]],
+        dtypes: Union[RegDtype, List[RegDtype]],
         data_arr: Union[List[Union[int, float]], List[List[Union[int, float]]]],
         max_size: int,
     ) -> Tuple[bytes, List[bytes]]:
@@ -1477,7 +1477,7 @@ class Servo:
     def disturbance_write_data(
         self,
         channels: Union[int, List[int]],
-        dtypes: Union[REG_DTYPE, List[REG_DTYPE]],
+        dtypes: Union[RegDtype, List[RegDtype]],
         data_arr: Union[List[Union[int, float]], List[List[Union[int, float]]]],
     ) -> None:
         """Write disturbance data.

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -173,8 +173,7 @@ def convert_int_to_ip(int_ip: int) -> str:
     return "{}.{}.{}.{}".format(drive_ip1, drive_ip2, drive_ip3, drive_ip4)
 
 
-# FIXME: INGK-1022
-class INT_SIZES(Enum):
+class IntSizes(Enum):
     """Integer sizes."""
 
     S8_MIN = -128

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -2,9 +2,9 @@ import functools
 import logging
 import struct
 import warnings
-import xml.etree.ElementTree as ET
 from enum import Enum
 from typing import Any, Callable, Dict, Optional, Tuple, Union
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -95,7 +95,7 @@ def to_ms(s: Union[int, float]) -> int:
     return int(s * 1e3)
 
 
-def remove_xml_subelement(element: ET.Element, subelement: ET.Element) -> None:
+def remove_xml_subelement(element: ElementTree.Element, subelement: ElementTree.Element) -> None:
     """Removes a subelement from the given element the element contains the subelement
 
     Args:
@@ -117,7 +117,7 @@ def pop_element(dictionary: Dict[str, Any], element: str) -> None:
         dictionary.pop(element)
 
 
-def cleanup_register(register: ET.Element) -> None:
+def cleanup_register(register: ElementTree.Element) -> None:
     """Cleans a ElementTree register to remove all
     unnecessary fields for a configuration file
 

--- a/ingenialink/utils/udp.py
+++ b/ingenialink/utils/udp.py
@@ -4,7 +4,7 @@ import struct
 
 import ingenialogger
 
-from ingenialink.exceptions import ILUDPException
+from ingenialink.exceptions import ILUDPError
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -85,7 +85,7 @@ class UDP:
         crc = binascii.crc_hqx(in_frame[0:12], 0)
         crcread = struct.unpack("<H", in_frame[12:14])[0]
         if crcread != crc:
-            raise ILUDPException("CRC error")
+            raise ILUDPError("CRC error")
 
         return int(cmd)
 

--- a/ingenialink/virtual/dictionary.py
+++ b/ingenialink/virtual/dictionary.py
@@ -1,5 +1,5 @@
-import xml.etree.ElementTree as ET
 from typing import Optional
+from xml.etree import ElementTree
 
 import ingenialogger
 
@@ -36,7 +36,7 @@ class VirtualDictionary(EthernetDictionaryV2):
         """
         return index - (0x2000 + (0x800 * (subnode - 1)))
 
-    def _read_xdf_register(self, register: ET.Element) -> Optional[EthernetRegister]:
+    def _read_xdf_register(self, register: ElementTree.Element) -> Optional[EthernetRegister]:
         current_read_register = super()._read_xdf_register(register)
 
         if current_read_register is None:

--- a/ingenialink/virtual/network.py
+++ b/ingenialink/virtual/network.py
@@ -5,6 +5,7 @@ import ingenialogger
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.ethernet.network import EthernetNetwork
 from ingenialink.exceptions import ILError
+from ingenialink.network import NetState
 from ingenialink.virtual.servo import VirtualServo
 from virtual_drive.core import VirtualDrive
 

--- a/ingenialink/virtual/network.py
+++ b/ingenialink/virtual/network.py
@@ -3,7 +3,7 @@ import socket
 import ingenialogger
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
-from ingenialink.ethernet.network import NET_STATE, EthernetNetwork
+from ingenialink.ethernet.network import EthernetNetwork, NetState
 from ingenialink.exceptions import ILError
 from ingenialink.virtual.servo import VirtualServo
 from virtual_drive.core import VirtualDrive
@@ -47,7 +47,7 @@ class VirtualNetwork(EthernetNetwork):
             servo.stop_status_listener()
             raise ILError(f"Drive not found in IP {VirtualDrive.IP_ADDRESS}.") from e
         self.servos.append(servo)
-        self._set_servo_state(VirtualDrive.IP_ADDRESS, NET_STATE.CONNECTED)
+        self._set_servo_state(VirtualDrive.IP_ADDRESS, NetState.CONNECTED)
 
         if net_status_listener:
             self.start_status_listener()

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,5 +7,6 @@ select = [
     "E", # pycodestyle
     "W", # pycodestyle
     "I", # isort
+    "N", # pep8-naming
 ]
 pydocstyle.convention = "google"

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,9 +2,6 @@ line-length = 100
 target-version = "py39"
 
 [lint]
-pydocstyle.convention = "google"
-flake8-unused-arguments.ignore-variadic-names = true
-
 select = [
     "F", # Pyflakes
     "E", # pycodestyle
@@ -38,6 +35,8 @@ select = [
     "RUF008", # Ruff dataclasses mutable defaults
     "RUF027", # Missing f-string syntax
 ]
+pydocstyle.convention = "google"
+flake8-unused-arguments.ignore-variadic-names = true
 
 ignore = [
     "C90", # mccabe complexity. Will be fixed in INGK-1020

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,9 @@ line-length = 100
 target-version = "py39"
 
 [lint]
+pydocstyle.convention = "google"
+flake8-unused-arguments.ignore-variadic-names = true
+
 select = [
     "F", # Pyflakes
     "E", # pycodestyle
@@ -35,8 +38,6 @@ select = [
     "RUF008", # Ruff dataclasses mutable defaults
     "RUF027", # Missing f-string syntax
 ]
-pydocstyle.convention = "google"
-flake8-unused-arguments.ignore-variadic-names = true
 
 ignore = [
     "C90", # mccabe complexity. Will be fixed in INGK-1020
@@ -47,9 +48,6 @@ ignore = [
 ]
 
 [lint.per-file-ignores]
-"ingenialink/enums/*" = [
-    "N801", # Invalid class name
-]
 "tests/*" = [
     "D", # Docstring rules
 ]

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -2,7 +2,7 @@ import platform
 
 import pytest
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from ingenialink.exceptions import ILError
 
 test_bus = "virtual"
@@ -13,7 +13,7 @@ test_channel = 0
 @pytest.fixture
 def virtual_network():
     net = CanopenNetwork(
-        device=CAN_DEVICE(test_bus), channel=test_channel, baudrate=CAN_BAUDRATE(test_baudrate)
+        device=CanDevice(test_bus), channel=test_channel, baudrate=CAN_BAUDRATE(test_baudrate)
     )
     return net
 
@@ -39,7 +39,7 @@ def test_connect_to_slave(connect_to_slave):
 def test_connect_to_slave_target_not_in_nodes(read_config):
     protocol_contents = read_config["canopen"]
     net = CanopenNetwork(
-        device=CAN_DEVICE(protocol_contents["device"]),
+        device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
         baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
     )
@@ -60,7 +60,7 @@ def test_connect_to_slave_none_nodes(virtual_network, read_config):
 @pytest.mark.canopen
 def test_scan_slaves(read_config):
     net = CanopenNetwork(
-        device=CAN_DEVICE(read_config["canopen"]["device"]),
+        device=CanDevice(read_config["canopen"]["device"]),
         channel=read_config["canopen"]["channel"],
         baudrate=CAN_BAUDRATE(read_config["canopen"]["baudrate"]),
     )
@@ -69,7 +69,7 @@ def test_scan_slaves(read_config):
 
 
 @pytest.mark.no_connection
-@pytest.mark.parametrize("can_device", [CAN_DEVICE.PCAN, CAN_DEVICE.KVASER, CAN_DEVICE.IXXAT])
+@pytest.mark.parametrize("can_device", [CanDevice.PCAN, CanDevice.KVASER, CanDevice.IXXAT])
 def test_scan_slaves_missing_drivers(can_device):
     net = CanopenNetwork(
         device=can_device,
@@ -88,7 +88,7 @@ def test_scan_slaves_missing_drivers(can_device):
 @pytest.mark.canopen
 def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     net = CanopenNetwork(
-        device=CAN_DEVICE(read_config["canopen"]["device"]),
+        device=CanDevice(read_config["canopen"]["device"]),
         channel=read_config["canopen"]["channel"],
         baudrate=CAN_BAUDRATE(read_config["canopen"]["baudrate"]),
     )
@@ -107,7 +107,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
 def test_disconnect_from_slave(read_config):
     protocol_contents = read_config["canopen"]
     net = CanopenNetwork(
-        device=CAN_DEVICE(protocol_contents["device"]),
+        device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
         baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
     )

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -2,7 +2,7 @@ import platform
 
 import pytest
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from ingenialink.exceptions import ILError
 
 test_bus = "virtual"
@@ -13,7 +13,7 @@ test_channel = 0
 @pytest.fixture
 def virtual_network():
     net = CanopenNetwork(
-        device=CanDevice(test_bus), channel=test_channel, baudrate=CAN_BAUDRATE(test_baudrate)
+        device=CanDevice(test_bus), channel=test_channel, baudrate=CanBaudrate(test_baudrate)
     )
     return net
 
@@ -41,7 +41,7 @@ def test_connect_to_slave_target_not_in_nodes(read_config):
     net = CanopenNetwork(
         device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
-        baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
+        baudrate=CanBaudrate(protocol_contents["baudrate"]),
     )
 
     with pytest.raises(ILError):
@@ -62,7 +62,7 @@ def test_scan_slaves(read_config):
     net = CanopenNetwork(
         device=CanDevice(read_config["canopen"]["device"]),
         channel=read_config["canopen"]["channel"],
-        baudrate=CAN_BAUDRATE(read_config["canopen"]["baudrate"]),
+        baudrate=CanBaudrate(read_config["canopen"]["baudrate"]),
     )
     slaves = net.scan_slaves()
     assert len(slaves) > 0
@@ -74,7 +74,7 @@ def test_scan_slaves_missing_drivers(can_device):
     net = CanopenNetwork(
         device=can_device,
         channel=0,
-        baudrate=CAN_BAUDRATE.Baudrate_1M,
+        baudrate=CanBaudrate.Baudrate_1M,
     )
     with pytest.raises(ILError) as exc_info:
         net.scan_slaves()
@@ -90,7 +90,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     net = CanopenNetwork(
         device=CanDevice(read_config["canopen"]["device"]),
         channel=read_config["canopen"]["channel"],
-        baudrate=CAN_BAUDRATE(read_config["canopen"]["baudrate"]),
+        baudrate=CanBaudrate(read_config["canopen"]["baudrate"]),
     )
     slaves_info = net.scan_slaves_info()
 
@@ -109,7 +109,7 @@ def test_disconnect_from_slave(read_config):
     net = CanopenNetwork(
         device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
-        baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
+        baudrate=CanBaudrate(protocol_contents["baudrate"]),
     )
 
     servo = net.connect_to_slave(

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -3,10 +3,10 @@ import pytest
 from ingenialink.canopen.register import (
     REG_ACCESS,
     REG_ADDRESS_TYPE,
-    REG_DTYPE,
     REG_PHY,
     CanopenRegister,
     RegCyclicType,
+    RegDtype,
 )
 from ingenialink.dictionary import Dictionary
 
@@ -15,7 +15,7 @@ from ingenialink.dictionary import Dictionary
 def test_getters_canopen_register():
     reg_idx = 0x58F0
     reg_subidx = 0x00
-    reg_dtype = REG_DTYPE.U32
+    reg_dtype = RegDtype.U32
     reg_access = REG_ACCESS.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
@@ -26,7 +26,7 @@ def test_getters_canopen_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
@@ -82,7 +82,7 @@ def test_canopen_connection_register(connect_to_slave):
     assert register.identifier == "DRV_OP_CMD"
     assert register.units == "-"
     assert register.cyclic == RegCyclicType.RX
-    assert register.dtype == REG_DTYPE.U16
+    assert register.dtype == RegDtype.U16
     assert register.access, REG_ACCESS.RW
     assert register.idx == 0x2014
     assert register.subidx == 0

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -1,10 +1,10 @@
 import pytest
 
 from ingenialink.canopen.register import (
-    REG_ACCESS,
     REG_ADDRESS_TYPE,
     REG_PHY,
     CanopenRegister,
+    RegAccess,
     RegCyclicType,
     RegDtype,
 )
@@ -16,7 +16,7 @@ def test_getters_canopen_register():
     reg_idx = 0x58F0
     reg_subidx = 0x00
     reg_dtype = RegDtype.U32
-    reg_access = REG_ACCESS.RW
+    reg_access = RegAccess.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
@@ -83,7 +83,7 @@ def test_canopen_connection_register(connect_to_slave):
     assert register.units == "-"
     assert register.cyclic == RegCyclicType.RX
     assert register.dtype == RegDtype.U16
-    assert register.access, REG_ACCESS.RW
+    assert register.access, RegAccess.RW
     assert register.idx == 0x2014
     assert register.subidx == 0
     assert register.phy == REG_PHY.NONE

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -26,7 +26,7 @@ def test_getters_canopen_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -2,11 +2,11 @@ import pytest
 
 from ingenialink.canopen.register import (
     REG_ADDRESS_TYPE,
-    REG_PHY,
     CanopenRegister,
     RegAccess,
     RegCyclicType,
     RegDtype,
+    RegPhy,
 )
 from ingenialink.dictionary import Dictionary
 
@@ -21,7 +21,7 @@ def test_getters_canopen_register():
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
         "cyclic": RegCyclicType.CONFIG,
-        "phy": REG_PHY.NONE,
+        "phy": RegPhy.NONE,
         "subnode": 0,
         "storage": 1,
         "reg_range": (-20, 20),
@@ -86,7 +86,7 @@ def test_canopen_connection_register(connect_to_slave):
     assert register.access, RegAccess.RW
     assert register.idx == 0x2014
     assert register.subidx == 0
-    assert register.phy == REG_PHY.NONE
+    assert register.phy == RegPhy.NONE
     assert register.subnode == 1
     assert register.storage is None
     assert not register.storage_valid

--- a/tests/canopen/test_canopen_register.py
+++ b/tests/canopen/test_canopen_register.py
@@ -1,9 +1,9 @@
 import pytest
 
 from ingenialink.canopen.register import (
-    REG_ADDRESS_TYPE,
     CanopenRegister,
     RegAccess,
+    RegAddressType,
     RegCyclicType,
     RegDtype,
     RegPhy,
@@ -30,7 +30,7 @@ def test_getters_canopen_register():
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
-        "address_type": REG_ADDRESS_TYPE.NVM,
+        "address_type": RegAddressType.NVM,
         "is_node_id_dependent": True,
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import json
 import pytest
 import rpyc
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CAN_DEVICE, CanopenNetwork
+from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -60,7 +60,7 @@ def pytest_collection_modifyitems(config, items):
 
 def connect_canopen(protocol_contents):
     net = CanopenNetwork(
-        device=CAN_DEVICE(protocol_contents["device"]),
+        device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
         baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ import json
 import pytest
 import rpyc
 
-from ingenialink.canopen.network import CAN_BAUDRATE, CanDevice, CanopenNetwork
+from ingenialink.canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from ingenialink.eoe.network import EoENetwork
 from ingenialink.ethercat.network import EthercatNetwork
 from ingenialink.ethernet.network import EthernetNetwork
@@ -62,7 +62,7 @@ def connect_canopen(protocol_contents):
     net = CanopenNetwork(
         device=CanDevice(protocol_contents["device"]),
         channel=protocol_contents["channel"],
-        baudrate=CAN_BAUDRATE(protocol_contents["baudrate"]),
+        baudrate=CanBaudrate(protocol_contents["baudrate"]),
     )
 
     servo = net.connect_to_slave(

--- a/tests/eoe/test_eoe_network.py
+++ b/tests/eoe/test_eoe_network.py
@@ -3,7 +3,7 @@ import socket
 import pytest
 
 from ingenialink.eoe.network import EoECommand, EoENetwork
-from ingenialink.ethernet.network import NET_PROT
+from ingenialink.ethernet.network import NetProt
 from ingenialink.ethernet.servo import EthernetServo
 
 
@@ -31,7 +31,7 @@ def test_eoe_connection(connect_to_slave, read_config):
     assert isinstance(servo, EthernetServo)
     assert net._eoe_service_init
     assert net._eoe_service_started
-    assert net.protocol == NET_PROT.ETH
+    assert net.protocol == NetProt.ETH
     assert net_socket.family == socket.AF_INET
     assert net_socket.type == socket.SOCK_DGRAM
     assert ip == eoe_service_ip

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -19,7 +19,7 @@ def test_getters_ethercat_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ADDRESS_TYPE, REG_PHY, RegAccess, RegDtype
+from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegDtype, RegPhy
 
 
 @pytest.mark.no_connection
@@ -14,7 +14,7 @@ def test_getters_ethercat_register():
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
         "cyclic": "CONFIG",
-        "phy": REG_PHY.NONE,
+        "phy": RegPhy.NONE,
         "subnode": 0,
         "storage": 1,
         "reg_range": (-20, 20),

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_PHY, RegDtype
+from ingenialink.register import REG_ADDRESS_TYPE, REG_PHY, RegAccess, RegDtype
 
 
 @pytest.mark.no_connection
@@ -9,7 +9,7 @@ def test_getters_ethercat_register():
     reg_idx = 0x58F0
     reg_subidx = 0x00
     reg_dtype = RegDtype.U32
-    reg_access = REG_ACCESS.RW
+    reg_access = RegAccess.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -1,14 +1,14 @@
 import pytest
 
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_PHY, RegDtype
 
 
 @pytest.mark.no_connection
 def test_getters_ethercat_register():
     reg_idx = 0x58F0
     reg_subidx = 0x00
-    reg_dtype = REG_DTYPE.U32
+    reg_dtype = RegDtype.U32
     reg_access = REG_ACCESS.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
@@ -19,7 +19,7 @@ def test_getters_ethercat_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethercat/test_ethercat_register.py
+++ b/tests/ethercat/test_ethercat_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegDtype, RegPhy
+from ingenialink.register import RegAccess, RegAddressType, RegDtype, RegPhy
 
 
 @pytest.mark.no_connection
@@ -23,7 +23,7 @@ def test_getters_ethercat_register():
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
-        "address_type": REG_ADDRESS_TYPE.NVM,
+        "address_type": RegAddressType.NVM,
     }
 
     register = EthercatRegister(

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -11,7 +11,7 @@ import pytest
 
 from ingenialink import EthercatNetwork
 from ingenialink.dictionary import Interface
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE, RegCyclicType
+from ingenialink.enums.register import REG_ACCESS, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError
@@ -401,7 +401,7 @@ def test_set_pdo_map_to_slave(connect_to_slave, create_pdo_map):
 
 @pytest.mark.no_connection
 def test_pdo_item_bool():
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
+    register = EthercatRegister(0, 1, RegDtype.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
     rpdo_item = RPDOMapItem(register)
 
     assert rpdo_item.register == register
@@ -460,7 +460,7 @@ def test_rpdo_padding():
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
     assert padding_register.subidx == 0x00
-    assert padding_register.dtype == REG_DTYPE.STR
+    assert padding_register.dtype == RegDtype.STR
     rpdo_item.raw_data_bytes = int.to_bytes(0, 1, "little")
     assert len(rpdo_item.raw_data_bits) == size_bits
 
@@ -475,7 +475,7 @@ def test_tpdo_padding():
     assert isinstance(padding_register, EthercatRegister)
     assert padding_register.idx == 0x0000
     assert padding_register.subidx == 0x00
-    assert padding_register.dtype == REG_DTYPE.STR
+    assert padding_register.dtype == RegDtype.STR
     tpdo_item.raw_data_bytes = int.to_bytes(0, 1, "little")
     assert len(tpdo_item.raw_data_bits) == size_bits
 
@@ -502,7 +502,7 @@ def test_map_pdo_with_bools(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[RPDO_REGISTERS[0]]
     item1 = RPDOMapItem(register)
     item2 = RPDOMapItem(register, size_bits=4)
-    register = EthercatRegister(0, 1, REG_DTYPE.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
+    register = EthercatRegister(0, 1, RegDtype.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
     item3 = RPDOMapItem(register)
     item4 = RPDOMapItem(register)
 

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -11,7 +11,7 @@ import pytest
 
 from ingenialink import EthercatNetwork
 from ingenialink.dictionary import Interface
-from ingenialink.enums.register import REG_ACCESS, RegCyclicType, RegDtype
+from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethercat.servo import EthercatServo
 from ingenialink.exceptions import ILError
@@ -401,7 +401,7 @@ def test_set_pdo_map_to_slave(connect_to_slave, create_pdo_map):
 
 @pytest.mark.no_connection
 def test_pdo_item_bool():
-    register = EthercatRegister(0, 1, RegDtype.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
+    register = EthercatRegister(0, 1, RegDtype.BOOL, RegAccess.RW, cyclic=RegCyclicType.RX)
     rpdo_item = RPDOMapItem(register)
 
     assert rpdo_item.register == register
@@ -502,7 +502,7 @@ def test_map_pdo_with_bools(open_dictionary):
     register = ethercat_dictionary.registers(SUBNODE)[RPDO_REGISTERS[0]]
     item1 = RPDOMapItem(register)
     item2 = RPDOMapItem(register, size_bits=4)
-    register = EthercatRegister(0, 1, RegDtype.BOOL, REG_ACCESS.RW, cyclic=RegCyclicType.RX)
+    register = EthercatRegister(0, 1, RegDtype.BOOL, RegAccess.RW, cyclic=RegCyclicType.RX)
     item3 = RPDOMapItem(register)
     item4 = RPDOMapItem(register)
 

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from ingenialink.ethernet.network import NET_DEV_EVT, NET_STATE, EthernetNetwork, NetProt
+from ingenialink.ethernet.network import NET_DEV_EVT, EthernetNetwork, NetProt, NetState
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 
@@ -50,7 +50,7 @@ def test_ethernet_connection(connect_to_slave, read_config):
     servo, net = connect_to_slave
     family = servo.socket.family
     ip, port = servo.socket.getpeername()
-    assert net.get_servo_state(read_config["ethernet"]["ip"]) == NET_STATE.CONNECTED
+    assert net.get_servo_state(read_config["ethernet"]["ip"]) == NetState.CONNECTED
     assert net.protocol == NetProt.ETH
     assert family == socket.AF_INET
     assert servo.socket.type == socket.SOCK_DGRAM
@@ -62,7 +62,7 @@ def test_ethernet_connection(connect_to_slave, read_config):
 def test_ethernet_disconnection(connect, read_config):
     servo, net = connect
     net.disconnect_from_slave(servo)
-    assert net.get_servo_state(read_config["ethernet"]["ip"]) == NET_STATE.DISCONNECTED
+    assert net.get_servo_state(read_config["ethernet"]["ip"]) == NetState.DISCONNECTED
     assert len(net.servos) == 0
     assert servo.socket._closed
 
@@ -109,7 +109,7 @@ def test_net_status_listener_connection(virtual_drive):
     status_list = []
     net.subscribe_to_status(server.ip, status_list.append)
     # Emulate a disconnection. TODO: disconnect from the virtual drive
-    net._set_servo_state(server.ip, NET_STATE.DISCONNECTED)
+    net._set_servo_state(server.ip, NetState.DISCONNECTED)
     net.start_status_listener()
     time.sleep(2)
     net.stop_status_listener()
@@ -138,7 +138,7 @@ def test_unsubscribe_from_status(virtual_drive):
     net.unsubscribe_from_status(server.ip, status_list.append)
 
     # Emulate a disconnection. TODO: disconnect from the virtual drive
-    net._set_servo_state(server.ip, NET_STATE.DISCONNECTED)
+    net._set_servo_state(server.ip, NetState.DISCONNECTED)
     net.start_status_listener()
     time.sleep(2)
     net.stop_status_listener()

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from ingenialink.ethernet.network import NET_DEV_EVT, EthernetNetwork, NetProt, NetState
+from ingenialink.ethernet.network import EthernetNetwork, NetDevEvt, NetProt, NetState
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 
@@ -115,7 +115,7 @@ def test_net_status_listener_connection(virtual_drive):
     net.stop_status_listener()
 
     assert len(status_list) == 1
-    assert status_list[0] == NET_DEV_EVT.ADDED
+    assert status_list[0] == NetDevEvt.ADDED
 
 
 @pytest.mark.skip

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from ingenialink.ethernet.network import NET_DEV_EVT, NET_PROT, NET_STATE, EthernetNetwork
+from ingenialink.ethernet.network import NET_DEV_EVT, NET_STATE, EthernetNetwork, NetProt
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
 
 
@@ -51,7 +51,7 @@ def test_ethernet_connection(connect_to_slave, read_config):
     family = servo.socket.family
     ip, port = servo.socket.getpeername()
     assert net.get_servo_state(read_config["ethernet"]["ip"]) == NET_STATE.CONNECTED
-    assert net.protocol == NET_PROT.ETH
+    assert net.protocol == NetProt.ETH
     assert family == socket.AF_INET
     assert servo.socket.type == socket.SOCK_DGRAM
     assert ip == read_config["ethernet"]["ip"]

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,13 +1,13 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_DTYPE, REG_PHY
+from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_PHY, RegDtype
 
 
 @pytest.mark.no_connection
 def test_getters_ethernet_register():
     reg_address = 0x58F0
-    reg_dtype = REG_DTYPE.U32
+    reg_dtype = RegDtype.U32
     reg_access = REG_ACCESS.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
@@ -18,7 +18,7 @@ def test_getters_ethernet_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegDtype, RegPhy
+from ingenialink.register import RegAccess, RegAddressType, RegDtype, RegPhy
 
 
 @pytest.mark.no_connection
@@ -22,7 +22,7 @@ def test_getters_ethernet_register():
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",
-        "address_type": REG_ADDRESS_TYPE.NVM,
+        "address_type": RegAddressType.NVM,
     }
 
     register = EthernetRegister(reg_address, reg_dtype, reg_access, **reg_kwargs)

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -18,7 +18,7 @@ def test_getters_ethernet_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": "No description (invent here)",

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_ADDRESS_TYPE, REG_PHY, RegAccess, RegDtype
+from ingenialink.register import REG_ADDRESS_TYPE, RegAccess, RegDtype, RegPhy
 
 
 @pytest.mark.no_connection
@@ -13,7 +13,7 @@ def test_getters_ethernet_register():
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
         "cyclic": "CONFIG",
-        "phy": REG_PHY.NONE,
+        "phy": RegPhy.NONE,
         "subnode": 0,
         "storage": 1,
         "reg_range": (-20, 20),

--- a/tests/ethernet/test_ethernet_register.py
+++ b/tests/ethernet/test_ethernet_register.py
@@ -1,14 +1,14 @@
 import pytest
 
 from ingenialink.ethernet.register import EthernetRegister
-from ingenialink.register import REG_ACCESS, REG_ADDRESS_TYPE, REG_PHY, RegDtype
+from ingenialink.register import REG_ADDRESS_TYPE, REG_PHY, RegAccess, RegDtype
 
 
 @pytest.mark.no_connection
 def test_getters_ethernet_register():
     reg_address = 0x58F0
     reg_dtype = RegDtype.U32
-    reg_access = REG_ACCESS.RW
+    reg_access = RegAccess.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,9 +1,9 @@
 import io
 import os
 import tempfile
-import xml.etree.ElementTree as ET
 from os.path import join as join_path
 from xml.dom import minidom
+from xml.etree import ElementTree
 
 import pytest
 
@@ -110,10 +110,10 @@ def test_dictionary_v2_image(dictionary_class, dictionary_path):
 @pytest.mark.no_connection
 def test_dictionary_v2_image_none(dictionary_class, dictionary_path):
     with open(dictionary_path, "r", encoding="utf-8") as xdf_file:
-        tree = ET.parse(xdf_file)
+        tree = ElementTree.parse(xdf_file)
     root = tree.getroot()
     root.remove(root.find(DictionaryV2._DictionaryV2__DICT_IMAGE))
-    xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(
+    xml_str = minidom.parseString(ElementTree.tostring(root)).toprettyxml(
         indent="  ", newl="", encoding="UTF-8"
     )
     temp_file = join_path(PATH_RESOURCE, "temp.xdf")
@@ -317,11 +317,11 @@ def test_merge_dictionaries_no_coco_exception():
 @pytest.mark.no_connection
 def test_dictionary_no_product_code(xml_attribute, class_attribute):
     with open(PATH_TO_DICTIONARY, "r", encoding="utf-8") as xdf_file:
-        tree = ET.parse(xdf_file)
+        tree = ElementTree.parse(xdf_file)
     root = tree.getroot()
     device = root.find(DictionaryV2._DictionaryV2__DICT_ROOT_DEVICE)
     device.attrib.pop(xml_attribute)
-    xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(
+    xml_str = minidom.parseString(ElementTree.tostring(root)).toprettyxml(
         indent="  ", newl="", encoding="UTF-8"
     )
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_mcb.py
+++ b/tests/test_mcb.py
@@ -1,7 +1,7 @@
 import pytest
 
 from ingenialink.constants import MCB_CMD_READ, MCB_CMD_WRITE
-from ingenialink.ethernet.register import REG_DTYPE
+from ingenialink.ethernet.register import RegDtype
 from ingenialink.exceptions import ILNACKError, ILWrongCRCError, ILWrongRegisterError
 from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_bytes
 from ingenialink.utils.mcb import MCB
@@ -11,14 +11,14 @@ from ingenialink.utils.mcb import MCB
 @pytest.mark.parametrize(
     "cmd, subnode, address, data, reg_dtype, extended, result",
     [
-        (MCB_CMD_READ, 1, 0x630, None, REG_DTYPE.FLOAT, False, "a100026300000000000000009fcc"),
-        (MCB_CMD_WRITE, 1, 0x630, 25.5, REG_DTYPE.FLOAT, False, "a10004630000cc4100000000cab1"),
+        (MCB_CMD_READ, 1, 0x630, None, RegDtype.FLOAT, False, "a100026300000000000000009fcc"),
+        (MCB_CMD_WRITE, 1, 0x630, 25.5, RegDtype.FLOAT, False, "a10004630000cc4100000000cab1"),
         (
             MCB_CMD_WRITE,
             1,
             0x6E5,
             "http://www.ingeniamc.com",
-            REG_DTYPE.STR,
+            RegDtype.STR,
             True,
             "a100556e1800000000000000b44b687474703a2f2f7777772e696e67656e69616d632e636f6d",
         ),
@@ -43,7 +43,7 @@ def test_build_mcb_frame(cmd, subnode, address, data, reg_dtype, extended, resul
         (
             0x6E5,
             "http://www.ingeniamc.com",
-            REG_DTYPE.STR,
+            RegDtype.STR,
             "a100576e18000000000000003e95687474703a2f2f7777772e696e67656e69616d632e636f6d",
         )
     ],

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -5,7 +5,7 @@ import pytest
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILAccessError, ILValueError
-from ingenialink.register import REG_ACCESS, REG_DTYPE, REG_PHY, Register
+from ingenialink.register import REG_ACCESS, REG_PHY, RegDtype, Register
 
 
 @pytest.fixture
@@ -15,15 +15,15 @@ def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
 
         boolean_reg_uid = "TEST_BOOLEAN"
         bool_register = EthernetRegister(
-            0x0200, REG_DTYPE.BOOL, REG_ACCESS.RW, identifier=boolean_reg_uid
+            0x0200, RegDtype.BOOL, REG_ACCESS.RW, identifier=boolean_reg_uid
         )
         server._VirtualDrive__dictionary._add_register_list(bool_register)
         server._VirtualDrive__dictionary.registers(bool_register.subnode)[
             boolean_reg_uid
         ].storage_valid = True
-        server._VirtualDrive__reg_address_to_id[bool_register.subnode][
-            bool_register.address
-        ] = boolean_reg_uid
+        server._VirtualDrive__reg_address_to_id[bool_register.subnode][bool_register.address] = (
+            boolean_reg_uid
+        )
         server.reg_signals[boolean_reg_uid] = []
         servo.dictionary.registers(1)[boolean_reg_uid] = bool_register
 
@@ -34,7 +34,7 @@ def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
 
 @pytest.mark.no_connection
 def test_getters_register():
-    reg_dtype = REG_DTYPE.U32
+    reg_dtype = RegDtype.U32
     reg_access = REG_ACCESS.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
@@ -45,7 +45,7 @@ def test_getters_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": 1,
@@ -77,12 +77,12 @@ def test_register_type_errors():
     with pytest.raises(ILValueError):
         Register(dtype, access)
 
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     access = "False access"
     with pytest.raises(ILAccessError):
         Register(dtype, access)
 
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     access = REG_ACCESS.RW
     with pytest.raises(ILValueError):
         Register(dtype, access, phy="False Phy")
@@ -93,32 +93,32 @@ def test_register_get_storage():
     access = REG_ACCESS.RW
 
     # invalid storage
-    dtype = REG_DTYPE.STR
+    dtype = RegDtype.STR
     register = Register(dtype, access, storage=1)
     assert register.storage_valid == 0
     assert register.storage is None
 
     # no storage
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     register = Register(dtype, access)
     assert register.storage_valid == 0
     assert register.storage is None
 
     # float storage
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     storage = 12.34
     register = Register(dtype, access, storage=storage)
     assert register.storage_valid == 1
     assert register.storage == storage
 
     # parse float storage
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     storage = 123
     register = Register(dtype, access, storage=storage)
     assert isinstance(register.storage, float)
 
     # parse int storage
-    dtype = REG_DTYPE.U8
+    dtype = RegDtype.U8
     storage = 123.1
     register = Register(dtype, access, storage=storage)
     assert isinstance(register.storage, int)
@@ -128,7 +128,7 @@ def test_register_get_storage():
 @pytest.mark.no_connection
 def test_register_set_storage():
     access = REG_ACCESS.RW
-    dtype = REG_DTYPE.FLOAT
+    dtype = RegDtype.FLOAT
     storage = 20.0
     register = Register(dtype, access, storage=storage)
     assert register.storage == storage
@@ -141,12 +141,12 @@ def test_register_set_storage():
 @pytest.mark.parametrize(
     "dtype, reg_range, expected_range, reg_type",
     [
-        (REG_DTYPE.U8, (0, 100), (0, 100), int),
-        (REG_DTYPE.FLOAT, (0.0, 1.0), (0.0, 1.0), float),
-        (REG_DTYPE.S16, (-100, None), (-100, 32767), int),
-        (REG_DTYPE.U32, (None, 100), (0, 100), int),
-        (REG_DTYPE.S32, (None, None), (-2147483648, 2147483647), int),
-        (REG_DTYPE.FLOAT, (None, None), (-3.4e38, 3.4e38), float),
+        (RegDtype.U8, (0, 100), (0, 100), int),
+        (RegDtype.FLOAT, (0.0, 1.0), (0.0, 1.0), float),
+        (RegDtype.S16, (-100, None), (-100, 32767), int),
+        (RegDtype.U32, (None, 100), (0, 100), int),
+        (RegDtype.S32, (None, None), (-2147483648, 2147483647), int),
+        (RegDtype.FLOAT, (None, None), (-3.4e38, 3.4e38), float),
     ],
 )
 @pytest.mark.no_connection
@@ -172,14 +172,14 @@ def test_register_mapped_address(subnode, address, mapped_address_eth, mapped_ad
     ethernet_param_dict = {
         "subnode": subnode,
         "address": address,
-        "dtype": REG_DTYPE.U16,
+        "dtype": RegDtype.U16,
         "access": REG_ACCESS.RW,
     }
     canopen_param_dict = {
         "subnode": subnode,
         "idx": address,
         "subidx": 0x00,
-        "dtype": REG_DTYPE.U16,
+        "dtype": RegDtype.U16,
         "access": REG_ACCESS.RW,
         "identifier": "",
         "units": "",

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -45,7 +45,7 @@ def test_getters_register():
         "storage": 1,
         "reg_range": (-20, 20),
         "labels": "Monitoring trigger type",
-        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},  # FIXME: INGK-1022
+        "enums": {"TRIGGER_EVENT_AUTO": 0, "TRIGGER_EVENT_FORCED": 1},
         "cat_id": "MONITORING",
         "scat_id": "SUB_CATEGORY_TEST",
         "internal_use": 1,

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -5,7 +5,7 @@ import pytest
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILAccessError, ILValueError
-from ingenialink.register import REG_ACCESS, REG_PHY, RegDtype, Register
+from ingenialink.register import REG_PHY, RegAccess, RegDtype, Register
 
 
 @pytest.fixture
@@ -15,7 +15,7 @@ def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
 
         boolean_reg_uid = "TEST_BOOLEAN"
         bool_register = EthernetRegister(
-            0x0200, RegDtype.BOOL, REG_ACCESS.RW, identifier=boolean_reg_uid
+            0x0200, RegDtype.BOOL, RegAccess.RW, identifier=boolean_reg_uid
         )
         server._VirtualDrive__dictionary._add_register_list(bool_register)
         server._VirtualDrive__dictionary.registers(bool_register.subnode)[
@@ -35,7 +35,7 @@ def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
 @pytest.mark.no_connection
 def test_getters_register():
     reg_dtype = RegDtype.U32
-    reg_access = REG_ACCESS.RW
+    reg_access = RegAccess.RW
     reg_kwargs = {
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
@@ -73,7 +73,7 @@ def test_getters_register():
 @pytest.mark.no_connection
 def test_register_type_errors():
     dtype = "False type"
-    access = REG_ACCESS.RW
+    access = RegAccess.RW
     with pytest.raises(ILValueError):
         Register(dtype, access)
 
@@ -83,14 +83,14 @@ def test_register_type_errors():
         Register(dtype, access)
 
     dtype = RegDtype.FLOAT
-    access = REG_ACCESS.RW
+    access = RegAccess.RW
     with pytest.raises(ILValueError):
         Register(dtype, access, phy="False Phy")
 
 
 @pytest.mark.no_connection
 def test_register_get_storage():
-    access = REG_ACCESS.RW
+    access = RegAccess.RW
 
     # invalid storage
     dtype = RegDtype.STR
@@ -127,7 +127,7 @@ def test_register_get_storage():
 
 @pytest.mark.no_connection
 def test_register_set_storage():
-    access = REG_ACCESS.RW
+    access = RegAccess.RW
     dtype = RegDtype.FLOAT
     storage = 20.0
     register = Register(dtype, access, storage=storage)
@@ -151,7 +151,7 @@ def test_register_set_storage():
 )
 @pytest.mark.no_connection
 def test_register_range(dtype, reg_range, expected_range, reg_type):
-    register = Register(dtype, REG_ACCESS.RW, reg_range=reg_range)
+    register = Register(dtype, RegAccess.RW, reg_range=reg_range)
 
     assert type(register.range[0]) is reg_type
     assert type(register.range[1]) is reg_type
@@ -173,14 +173,14 @@ def test_register_mapped_address(subnode, address, mapped_address_eth, mapped_ad
         "subnode": subnode,
         "address": address,
         "dtype": RegDtype.U16,
-        "access": REG_ACCESS.RW,
+        "access": RegAccess.RW,
     }
     canopen_param_dict = {
         "subnode": subnode,
         "idx": address,
         "subidx": 0x00,
         "dtype": RegDtype.U16,
-        "access": REG_ACCESS.RW,
+        "access": RegAccess.RW,
         "identifier": "",
         "units": "",
         "cyclic": "CONFIG",

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -21,9 +21,9 @@ def connect_virtual_drive_with_bool_register(virtual_drive_custom_dict):
         server._VirtualDrive__dictionary.registers(bool_register.subnode)[
             boolean_reg_uid
         ].storage_valid = True
-        server._VirtualDrive__reg_address_to_id[bool_register.subnode][bool_register.address] = (
-            boolean_reg_uid
-        )
+        server._VirtualDrive__reg_address_to_id[bool_register.subnode][
+            bool_register.address
+        ] = boolean_reg_uid
         server.reg_signals[boolean_reg_uid] = []
         servo.dictionary.registers(1)[boolean_reg_uid] = bool_register
 

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -5,7 +5,7 @@ import pytest
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.exceptions import ILAccessError, ILValueError
-from ingenialink.register import REG_PHY, RegAccess, RegDtype, Register
+from ingenialink.register import RegAccess, RegDtype, Register, RegPhy
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def test_getters_register():
         "identifier": "MON_CFG_SOC_TYPE",
         "units": "none",
         "cyclic": "CONFIG",
-        "phy": REG_PHY.NONE,
+        "phy": RegPhy.NONE,
         "subnode": 0,
         "storage": 1,
         "reg_range": (-20, 20),

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -9,7 +9,7 @@ import pytest
 from packaging import version
 
 from ingenialink.canopen.servo import CanopenServo
-from ingenialink.ethernet.register import REG_DTYPE
+from ingenialink.ethernet.register import RegDtype
 from ingenialink.exceptions import (
     ILConfigurationError,
     ILError,
@@ -100,9 +100,9 @@ def create_disturbance(connect_to_slave, pytestconfig):
     reg = servo._get_reg("CL_POS_SET_POINT_VALUE", subnode=1)
     address = _get_reg_address(reg, protocol)
     servo.disturbance_set_mapped_register(
-        0, address, 1, REG_DTYPE.S32.value, DISTURBANCE_CH_DATA_SIZE
+        0, address, 1, RegDtype.S32.value, DISTURBANCE_CH_DATA_SIZE
     )
-    servo.disturbance_write_data(0, REG_DTYPE.S32, data)
+    servo.disturbance_write_data(0, RegDtype.S32, data)
     yield servo, net
     servo.disturbance_disable()
 
@@ -627,11 +627,11 @@ def test_disturbance_overflow(connect_to_slave, pytestconfig):
     reg = servo._get_reg("DRV_OP_CMD", subnode=1)
     address = _get_reg_address(reg, protocol)
     servo.disturbance_set_mapped_register(
-        0, address, 1, REG_DTYPE.U16.value, DISTURBANCE_CH_DATA_SIZE
+        0, address, 1, RegDtype.U16.value, DISTURBANCE_CH_DATA_SIZE
     )
     data = list(range(-10, 11))
     with pytest.raises(ILValueError):
-        servo.disturbance_write_data(0, REG_DTYPE.U16, data)
+        servo.disturbance_write_data(0, RegDtype.U16, data)
 
 
 @pytest.mark.no_connection

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -2,8 +2,8 @@ import os
 import re
 import shutil
 import time
-import xml.etree.ElementTree as ET
 from pathlib import Path
+from xml.etree import ElementTree
 
 import pytest
 from packaging import version
@@ -322,7 +322,7 @@ def test_load_configuration_to_subnode_zero(read_config, pytestconfig, connect_t
     modified_path = Path(filename.replace(file, "config_0_test.xdf"))
     shutil.copy(path, modified_path)
     with open(modified_path, "r", encoding="utf-8") as xml_file:
-        tree = ET.parse(xml_file)
+        tree = ElementTree.parse(xml_file)
         root = tree.getroot()
         axis = tree.findall("*/Device/Axes/Axis")
         if axis:

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -18,7 +18,7 @@ from ingenialink.exceptions import (
     ILTimeoutError,
     ILValueError,
 )
-from ingenialink.register import REG_ADDRESS_TYPE
+from ingenialink.register import RegAddressType
 from ingenialink.servo import SERVO_STATE, Servo
 from tests.virtual.test_virtual_network import RESOURCES_FOLDER
 
@@ -167,7 +167,7 @@ def test_save_configuration(connect_to_slave):
         assert registers[reg_id].dtype == servo.dictionary.dtype_xdf_options[dtype]
 
         assert access == "rw"
-        assert registers[reg_id].address_type != REG_ADDRESS_TYPE.NVM_NONE
+        assert registers[reg_id].address_type != RegAddressType.NVM_NONE
 
     _clean(filename)
 

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -19,7 +19,7 @@ from ingenialink.exceptions import (
     ILValueError,
 )
 from ingenialink.register import RegAddressType
-from ingenialink.servo import SERVO_STATE, Servo
+from ingenialink.servo import Servo, ServoState
 from tests.virtual.test_virtual_network import RESOURCES_FOLDER
 
 MONITORING_CH_DATA_SIZE = 4
@@ -576,9 +576,9 @@ def test_disturbance_data_size(create_disturbance):
 def test_enable_disable(connect_to_slave):
     servo, net = connect_to_slave
     servo.enable()
-    assert servo.status[1] == SERVO_STATE.ENABLED
+    assert servo.status[1] == ServoState.ENABLED
     servo.disable()
-    assert servo.status[1] == SERVO_STATE.DISABLED
+    assert servo.status[1] == ServoState.DISABLED
 
 
 @pytest.mark.canopen
@@ -591,7 +591,7 @@ def test_fault_reset(connect_to_slave):
     with pytest.raises(ILStateError):
         servo.enable()
     servo.fault_reset()
-    assert servo.status[1] != SERVO_STATE.FAULT
+    assert servo.status[1] != ServoState.FAULT
     servo.write("DRV_PROT_USER_OVER_VOLT", data=prev_val, subnode=1)
 
 
@@ -679,7 +679,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.NRDY,
+            ServoState.NRDY,
         ),
         (
             {
@@ -695,7 +695,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.DISABLED,
+            ServoState.DISABLED,
         ),
         (
             {
@@ -711,7 +711,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.RDY,
+            ServoState.RDY,
         ),
         (
             {
@@ -727,7 +727,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.ON,
+            ServoState.ON,
         ),
         (
             {
@@ -743,7 +743,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.ENABLED,
+            ServoState.ENABLED,
         ),
         (
             {
@@ -759,7 +759,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.QSTOP,
+            ServoState.QSTOP,
         ),
         (
             {
@@ -775,7 +775,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.FAULTR,
+            ServoState.FAULTR,
         ),
         (
             {
@@ -791,7 +791,7 @@ def test_subscribe_register_updates(virtual_drive_custom_dict):  # noqa: F811
                 "SWITCH_LIMITS_ACTIVE": 0,
                 "COMMUTATION_FEEDBACK_ALIGNED": 0,
             },
-            SERVO_STATE.FAULT,
+            ServoState.FAULT,
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import RegDtype
 from ingenialink.exceptions import ILValueError
 from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_bytes
 
@@ -9,17 +9,17 @@ from ingenialink.utils._utils import convert_bytes_to_dtype, convert_dtype_to_by
 @pytest.mark.parametrize(
     "byts, value, dtype",
     [
-        (b"\x03", 3, REG_DTYPE.U8),
-        (b"\x75\x00", 0x0075, REG_DTYPE.U16),
-        (b"\x35\x23", 0x2335, REG_DTYPE.U16),
-        (b"\x34\x12\x75\x45", 0x45751234, REG_DTYPE.U32),
-        (b"\xF2", -14, REG_DTYPE.S8),
-        (b"\x75\xF0", -3979, REG_DTYPE.S16),
-        (b"\x35\x23", 0x2335, REG_DTYPE.S16),
-        (b"\x34\x12\x75\x45", 0x45751234, REG_DTYPE.S32),
-        (b"\x00\x00\x0a\x42", 34.5, REG_DTYPE.FLOAT),
-        (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", REG_DTYPE.STR),
-        (bytes(512), bytes(512), REG_DTYPE.BYTE_ARRAY_512),
+        (b"\x03", 3, RegDtype.U8),
+        (b"\x75\x00", 0x0075, RegDtype.U16),
+        (b"\x35\x23", 0x2335, RegDtype.U16),
+        (b"\x34\x12\x75\x45", 0x45751234, RegDtype.U32),
+        (b"\xf2", -14, RegDtype.S8),
+        (b"\x75\xf0", -3979, RegDtype.S16),
+        (b"\x35\x23", 0x2335, RegDtype.S16),
+        (b"\x34\x12\x75\x45", 0x45751234, RegDtype.S32),
+        (b"\x00\x00\x0a\x42", 34.5, RegDtype.FLOAT),
+        (b"\x74\x68\x61\x74\x27\x73\x20\x61\x20\x74\x65\x73\x74", "that's a test", RegDtype.STR),
+        (bytes(512), bytes(512), RegDtype.BYTE_ARRAY_512),
     ],
 )
 def test_bytes_dtype_conversions(byts, value, dtype):
@@ -32,7 +32,7 @@ def test_bytes_dtype_conversions(byts, value, dtype):
 def test_null_terminated_string():
     assert (
         convert_bytes_to_dtype(
-            b"\x74\x68\x61\x74\x27\x73\x20\x67\x6f\x6f\x64\x00\xca\xca", REG_DTYPE.STR
+            b"\x74\x68\x61\x74\x27\x73\x20\x67\x6f\x6f\x64\x00\xca\xca", RegDtype.STR
         )
         == "that's good"
     )
@@ -42,4 +42,4 @@ def test_null_terminated_string():
 def test_convert_bytes_to_dtype_wrong_string():
     wrong_data = b"\xff\xff\xff\xff\xff\x00"
     with pytest.raises(ILValueError):
-        convert_bytes_to_dtype(wrong_data, REG_DTYPE.STR)
+        convert_bytes_to_dtype(wrong_data, RegDtype.STR)

--- a/tests/test_virtual_drive.py
+++ b/tests/test_virtual_drive.py
@@ -5,7 +5,7 @@ import pytest
 from scipy import signal
 
 from ingenialink.enums.register import RegDtype
-from ingenialink.enums.servo import SERVO_STATE
+from ingenialink.enums.servo import ServoState
 from virtual_drive.core import OperationMode
 
 MONITORING_CH_DATA_SIZE = 4
@@ -160,11 +160,11 @@ def test_virtual_disturbance(virtual_drive, register_key):
 def test_virtual_motor_enable_disable(virtual_drive):
     _, servo = virtual_drive
 
-    assert servo.get_state() == SERVO_STATE.RDY
+    assert servo.get_state() == ServoState.RDY
     servo.enable()
-    assert servo.get_state() == SERVO_STATE.ENABLED
+    assert servo.get_state() == ServoState.ENABLED
     servo.disable()
-    assert servo.get_state() == SERVO_STATE.DISABLED
+    assert servo.get_state() == ServoState.DISABLED
 
 
 @pytest.mark.no_connection

--- a/tests/test_virtual_drive.py
+++ b/tests/test_virtual_drive.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from scipy import signal
 
-from ingenialink.enums.register import REG_DTYPE
+from ingenialink.enums.register import RegDtype
 from ingenialink.enums.servo import SERVO_STATE
 from virtual_drive.core import OperationMode
 
@@ -144,7 +144,7 @@ def test_virtual_disturbance(virtual_drive, register_key):
     address = reg.address
     servo.disturbance_set_mapped_register(0, address, subnode, reg.dtype.value, 4)
     data_arr = []
-    if reg.dtype == REG_DTYPE.FLOAT:
+    if reg.dtype == RegDtype.FLOAT:
         data_arr.append([0.0, -1.0, 2.0, 3.0])
     else:
         data_arr.append([0, -1, 2, 3])

--- a/tests/test_virtual_drive.py
+++ b/tests/test_virtual_drive.py
@@ -143,10 +143,7 @@ def test_virtual_disturbance(virtual_drive, register_key):
     reg = servo._get_reg(register_key, subnode=1)
     address = reg.address
     servo.disturbance_set_mapped_register(0, address, subnode, reg.dtype.value, 4)
-    if reg.dtype == RegDtype.FLOAT:
-        data_arr = [0.0, -1.0, 2.0, 3.0]
-    else:
-        data_arr = [0, -1, 2, 3]
+    data_arr = [0.0, -1.0, 2.0, 3.0] if reg.dtype == RegDtype.FLOAT else [0, -1, 2, 3]
 
     channels = [0]
     servo.disturbance_write_data(channels, [reg.dtype], data_arr)

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 
-from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
+from ingenialink.enums.register import REG_ACCESS, RegDtype
 from ingenialink.network import NetState
 from virtual_drive.core import VirtualDrive
 
@@ -52,7 +52,7 @@ def test_connect_virtual_custom_dictionaries(virtual_drive_custom_dict, read_con
                 if register.enums_count > 0:
                     continue
                 value = random.uniform(0, 100)
-                if register.dtype != REG_DTYPE.FLOAT:
+                if register.dtype != RegDtype.FLOAT:
                     value = int(value)
                 servo.write(reg_key, value)
                 assert pytest.approx(value) == server.get_value_by_id(1, reg_key)

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -4,7 +4,7 @@ import random
 import pytest
 
 from ingenialink.enums.register import REG_ACCESS, REG_DTYPE
-from ingenialink.network import NET_STATE
+from ingenialink.network import NetState
 from virtual_drive.core import VirtualDrive
 
 RESOURCES_FOLDER = "virtual_drive/resources/"
@@ -25,7 +25,7 @@ def test_virtual_drive_disconnection(virtual_drive_custom_dict):
     dictionary = os.path.join(RESOURCES_FOLDER, "virtual_drive.xdf")
     server, net, servo = virtual_drive_custom_dict(dictionary)
     net.disconnect_from_slave(servo)
-    assert net.get_servo_state(VirtualDrive.IP_ADDRESS) == NET_STATE.DISCONNECTED
+    assert net.get_servo_state(VirtualDrive.IP_ADDRESS) == NetState.DISCONNECTED
     assert len(net.servos) == 0
     assert servo.socket._closed
 

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -3,7 +3,7 @@ import random
 
 import pytest
 
-from ingenialink.enums.register import REG_ACCESS, RegDtype
+from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.network import NetState
 from virtual_drive.core import VirtualDrive
 
@@ -44,11 +44,11 @@ def test_connect_virtual_custom_dictionaries(virtual_drive_custom_dict, read_con
         assert fw_version is not None and fw_version != ""
 
         for reg_key, register in servo.dictionary.registers(1).items():
-            if register.access in [REG_ACCESS.RO, REG_ACCESS.RW]:
+            if register.access in [RegAccess.RO, RegAccess.RW]:
                 value = servo.read(reg_key)
                 assert pytest.approx(server.get_value_by_id(1, reg_key), abs=0.02) == value
 
-            if register.access in [REG_ACCESS.WO, REG_ACCESS.RW]:
+            if register.access in [RegAccess.WO, RegAccess.RW]:
                 if register.enums_count > 0:
                     continue
                 value = random.uniform(0, 100)

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -38,8 +38,7 @@ INC_ENC1_RESOLUTION = 4096
 INC_ENC2_RESOLUTION = 2000
 
 
-# FIXME: INGK-1022
-class MSG_TYPE(Enum):
+class MsgType(Enum):
     RECEIVED = "RECEIVED"
     SENT = "SENT"
 
@@ -1319,7 +1318,7 @@ class VirtualDrive(Thread):
             except Exception:
                 continue
             reg_add, subnode, cmd, data = MCB.read_mcb_frame(frame)
-            self.__log(add, frame, MSG_TYPE.RECEIVED)
+            self.__log(add, frame, MsgType.RECEIVED)
             register = self.get_register(subnode, reg_add)
             if cmd == self.WRITE_CMD:
                 response = self.__get_response_to_write_command(register, data)
@@ -1469,7 +1468,7 @@ class VirtualDrive(Thread):
             address: IP address and port.
         """
         self.socket.sendto(response, address)
-        self.__log(address, response, MSG_TYPE.SENT)
+        self.__log(address, response, MsgType.SENT)
 
     def _response_monitoring_data(self, data: bytes) -> bytes:
         """Creates a response for monitoring data.
@@ -1491,7 +1490,7 @@ class VirtualDrive(Thread):
         self._monitoring.available_bytes = len(data_left)
         return response
 
-    def __log(self, ip_port: Tuple[str, int], message: bytes, msg_type: MSG_TYPE) -> None:
+    def __log(self, ip_port: Tuple[str, int], message: bytes, msg_type: MsgType) -> None:
         """Updates log.
 
         Args:

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -13,7 +13,7 @@ from scipy import signal
 
 from ingenialink.constants import ETH_BUF_SIZE, MONITORING_BUFFER_SIZE
 from ingenialink.dictionary import Interface
-from ingenialink.enums.register import REG_ACCESS, RegDtype
+from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.ethernet.servo import EthernetServo
 from ingenialink.servo import DictionaryFactory
@@ -1342,7 +1342,7 @@ class VirtualDrive(Thread):
             bytes: Response to be sent.
         """
         response = MCB.build_mcb_frame(self.ACK_CMD, register.subnode, register.address, data[:8])
-        if register.access in [REG_ACCESS.RW, REG_ACCESS.WO]:
+        if register.access in [RegAccess.RW, RegAccess.WO]:
             value = convert_bytes_to_dtype(data, register.dtype)
             self.__decode_msg(register.address, register.subnode, data)
             self.set_value_by_id(register.subnode, str(register.identifier), value)


### PR DESCRIPTION
### Description

Change all `Enums` to follow `CapWords` convention. 

### Type of change

- [X] `Enum` uses `CapWords` convention

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [X] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- Old `Enums` still supported for backwards compatibility, but will be deprecated.
