### PR TITLE
INGK-1043 Create EthercatEmergencyMessage and CanopenEmergencyMessage

### DIFF
--- a/ingenialink/canopen/servo.py
+++ b/ingenialink/canopen/servo.py
@@ -17,6 +17,18 @@ logger = ingenialogger.get_logger(__name__)
 CANOPEN_SDO_RESPONSE_TIMEOUT = 0.3
 
 
+class CanopenEmergencyMessage(EmergencyMessage):
+    """Canopen emergency message class.
+
+    Args:
+        servo: The servo that generated the emergency error.
+        emergency_msg: The emergency message instance from canopen.
+    """
+
+    def __init__(self, servo: Servo, emergency_msg: EmcyError):
+        super().__init__(servo, emergency_msg.code, emergency_msg.register, emergency_msg.data)
+
+
 class CanopenServo(Servo):
     """CANopen Servo instance.
 
@@ -116,14 +128,14 @@ class CanopenServo(Servo):
         self.__emcy_observers.remove(callback)
 
     def _on_emcy(self, emergency_msg: EmcyError) -> None:
-        """Receive an emergency message from canopen and transform it to a EmergencyMessage.
-        Afterward, send the EmergencyMessage to all the subscribed callbacks.
+        """Receive an emergency message from canopen and transform it to a CanopenEmergencyMessage.
+        Afterward, send the CanopenEmergencyMessage to all the subscribed callbacks.
 
         Args:
             emergency_msg: The EmcyError instance.
 
         """
-        emergency_message = EmergencyMessage(self, emergency_msg)
+        emergency_message = CanopenEmergencyMessage(self, emergency_msg)
         logger.warning(f"Emergency message received from node {self.target}: {emergency_message}")
         for callback in self.__emcy_observers:
             callback(emergency_message)

--- a/ingenialink/emcy.py
+++ b/ingenialink/emcy.py
@@ -1,14 +1,6 @@
-from typing import TYPE_CHECKING, Optional, Union
-
-try:
-    import pysoem
-except ImportError:
-    pysoem = None
-from canopen.emcy import EmcyError
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
-    from pysoem import Emergency
-
     from ingenialink import Servo
 
 
@@ -17,26 +9,16 @@ class EmergencyMessage:
 
     Args:
         servo: The servo that generated the emergency error.
-        emergency_msg: The emergency message instance from PySOEM or canopen.
-
+        error_code: EMCY code
+        register: Error register
+        data: Vendor specific data
     """
 
-    def __init__(self, servo: "Servo", emergency_msg: Union["Emergency", EmcyError]):
+    def __init__(self, servo: "Servo", error_code: int, register: int, data: bytes):
         self.servo = servo
-        if isinstance(emergency_msg, pysoem.Emergency):
-            self.error_code = emergency_msg.error_code
-            self.register = emergency_msg.error_reg
-            self.data = (
-                emergency_msg.b1.to_bytes(1, "little")
-                + emergency_msg.w1.to_bytes(2, "little")
-                + emergency_msg.w2.to_bytes(2, "little")
-            )
-        elif isinstance(emergency_msg, EmcyError):
-            self.error_code = emergency_msg.code
-            self.register = emergency_msg.register
-            self.data = emergency_msg.data
-        else:
-            raise NotImplementedError
+        self.error_code = error_code
+        self.register = register
+        self.data = data
 
     def get_desc(self) -> Optional[str]:
         """Get the error description from the servo's dictionary"""

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -41,7 +41,7 @@ class EthercatEmergencyMessage(EmergencyMessage):
         emergency_msg: The emergency message instance from PySOEM.
     """
 
-    def __init__(self, servo: Servo, emergency_msg: pysoem.Emergency):
+    def __init__(self, servo: Servo, emergency_msg: "pysoem.Emergency"):
         data = (
             emergency_msg.b1.to_bytes(1, "little")
             + emergency_msg.w1.to_bytes(2, "little")

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import ingenialogger
 
+from ingenialink import Servo
 from ingenialink.emcy import EmergencyMessage
 
 try:
@@ -30,6 +31,23 @@ class SDO_OPERATION_MSG(Enum):
 
     READ = "reading"
     WRITE = "writing"
+
+
+class EthercatEmergencyMessage(EmergencyMessage):
+    """Ethercat emergency message class.
+
+    Args:
+        servo: The servo that generated the emergency error.
+        emergency_msg: The emergency message instance from PySOEM.
+    """
+
+    def __init__(self, servo: Servo, emergency_msg: pysoem.Emergency):
+        data = (
+            emergency_msg.b1.to_bytes(1, "little")
+            + emergency_msg.w1.to_bytes(2, "little")
+            + emergency_msg.w2.to_bytes(2, "little")
+        )
+        super().__init__(servo, emergency_msg.error_code, emergency_msg.error_reg, data)
 
 
 class EthercatServo(PDOServo):
@@ -285,14 +303,14 @@ class EthercatServo(PDOServo):
         self.__emcy_observers.remove(callback)
 
     def _on_emcy(self, emergency_msg: "pysoem.Emergency") -> None:
-        """Receive an emergency message from PySOEM and transform it to a EmergencyMessage.
-        Afterward, send the EmergencyMessage to all the subscribed callbacks.
+        """Receive an emergency message from PySOEM and transform it to a EthercatEmergencyMessage.
+        Afterward, send the EthercatEmergencyMessage to all the subscribed callbacks.
 
         Args:
             emergency_msg: The pysoem.Emergency instance.
 
         """
-        emergency_message = EmergencyMessage(self, emergency_msg)
+        emergency_message = EthercatEmergencyMessage(self, emergency_msg)
         logger.warning(f"Emergency message received from slave {self.target}: {emergency_message}")
         for callback in self.__emcy_observers:
             callback(emergency_message)


### PR DESCRIPTION
### Description

Create Canopen and Ethercat childs of EmergencyMessage class to avoid confusion between canopen folder and canopen module

Fixes # INGK-1043

### Type of change

- [x] Create EthercatEmergencyMessage
- [x] Create CanopenEmergencyMessage


### Tests
- [x] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
