### PR TITLE
INGK-1028 Analyze ingenialink nightly test failures

### DIFF
--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -69,17 +69,15 @@ def skip_if_monitoring_is_not_available(servo):
 class SDOReadTimeoutManager:
     def __init__(self, network, new_value):
         self.__net = network
-        self.__new_value = new_value
+        self.__new_value = int(1_000_000 * new_value)
+        self.__initial_value = self.__net._ecat_master.sdo_read_timeout
 
     def __enter__(self):
-        self.__set_sdo_read_timeout(self.__new_value)
+        self.__net._ecat_master.sdo_read_timeout = self.__new_value
         return self
 
-    def __set_sdo_read_timeout(self, value_s):
-        self.__net._ecat_master.sdo_read_timeout = int(1_000_000 * value_s)
-
     def __exit__(self, exc_type, exc_value, traceback):
-        self.__set_sdo_read_timeout(self.__net.DEFAULT_ECAT_CONNECTION_TIMEOUT_S)
+        self.__net._ecat_master.sdo_read_timeout = self.__initial_value
 
 
 @pytest.fixture()

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -599,7 +599,11 @@ def test_enable_disable(connect_to_slave):
 @pytest.mark.canopen
 @pytest.mark.ethernet
 @pytest.mark.ethercat
-def test_fault_reset(connect_to_slave):
+def test_fault_reset(connect_to_slave, get_configuration_from_rack_service):
+    drive_idx, config = get_configuration_from_rack_service
+    drive = config[drive_idx]
+    if drive.identifier == "eve-xcr-e":
+        pytest.skip("There is a specific fault test for the EVE-XCR-E")
     servo, net = connect_to_slave
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)
     servo.write("DRV_PROT_USER_OVER_VOLT", data=10.0, subnode=1)


### PR DESCRIPTION
### Description

The fault reset operation on the EVE-XCR-E sometimes takes longer than the SDO read timeout to complete.

Fixes #INGK-1028

### Type of change

- Create a new test for the EVE-XCR-E exclusively, where the SDO read timeout is increased. 


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
