### PR TITLE
INGK-1051 Check if virtual drive implements monitoring

### DIFF
--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -4,6 +4,7 @@ import random
 import pytest
 
 from ingenialink.enums.register import RegAccess, RegDtype
+from ingenialink.exceptions import ILNACKError
 from ingenialink.network import NetState
 from virtual_drive.core import VirtualDrive
 
@@ -64,4 +65,5 @@ def test_connect_to_virtual_drive_old_disturbance(virtual_drive_custom_dict):
     dictionary = os.path.join(TESTS_RESOURCES_FOLDER, "ethercat/test_dict_ethercat_old_dist.xdf")
     server, net, servo = virtual_drive_custom_dict(dictionary)
     assert servo is not None and net is not None
-    assert server._monitoring is None and server._disturbance is None
+    with pytest.raises(ILNACKError):
+        servo.read("MON_DIST_STATUS", subnode=0)

--- a/virtual_drive/core.py
+++ b/virtual_drive/core.py
@@ -1245,6 +1245,7 @@ class VirtualDrive(Thread):
     IP_ADDRESS = "127.0.0.1"
 
     ACK_CMD = 3
+    NACK_CMD = 5
     WRITE_CMD = 2
     READ_CMD = 1
 
@@ -1381,6 +1382,18 @@ class VirtualDrive(Thread):
         ):
             self._monitoring.update_data()
             response = self._response_monitoring_data(value)
+        elif register.address == self.id_to_address(0, VirtualMonitoring.STATUS_REGISTER) and (
+            self._disturbance is None and self._monitoring is None
+        ):
+            # If a request to read the MON_DIST_STATUS register is made
+            # Respond with a read error
+            # This is done because the MONITORING_V1 is not supported by the virtual drive.
+            response = MCB.build_mcb_frame(
+                self.NACK_CMD,
+                register.subnode,
+                register.address,
+                convert_dtype_to_bytes(0, register.dtype),
+            )
         else:
             if not isinstance(value, bytes):
                 data = convert_dtype_to_bytes(value, register.dtype)


### PR DESCRIPTION
### Description

When ML3 is connected to a virtual drive using a dictionary that supports V1 it fails to recognize that monitoring V1 is not supported by the VirtualDrive.

Force an error when the monitoring version is checked.

Fixes # INGK-1051

### Type of change

- Force a read error when the MON_DIST_STATUS register is read if the virtual drive's dictionary supports Monitoring V1.
- Update test.

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
