### PR TITLE
Volcano 632 include information of canopen item type on xdfv 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### Deprecated
 - Changed `Enums` names to follow CapWords convention. Old names are still supported, but will soon be deprecated.
 
+### Changed
+- Change dictionary registers groups to objects
+- Parse CanOpen object type from xdf v3 dictionaries
+
 ## [7.4.1] - 2025-01-28
 ### Fixed
 - Avoid mapping a PDO map twice.

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -56,7 +56,7 @@ class SubnodeType(enum.Enum):
 
 
 class CanOpenObjectType(enum.Enum):
-    """CanOpen Object Type"""
+    """CanOpen Object Type."""
 
     VAR = enum.auto()
     """VAR object type"""
@@ -70,11 +70,15 @@ class CanOpenObjectType(enum.Enum):
 
 @dataclass()
 class CanOpenObject:
-    """CanOpenObject"""
+    """CanOpenObject."""
 
     uid: Optional[str]
     object_type: CanOpenObjectType
-    registers: List[CanopenRegister]
+    registers: list[CanopenRegister]
+
+    def __iter__(self) -> Iterator[CanopenRegister]:
+        """Iterator operator."""
+        return self.registers.__iter__()
 
 
 @dataclass
@@ -323,7 +327,7 @@ class Dictionary(ABC):
         """Reads the dictionary file and initializes all its components."""
 
     def get_object(self, uid: str, subnode: int) -> CanOpenObject:
-        """Return object by an UID and subnode
+        """Return object by an UID and subnode.
 
         Args:
             uid: object UID

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -55,6 +55,28 @@ class SubnodeType(enum.Enum):
     """Safety"""
 
 
+class CanOpenObjectType(enum.Enum):
+    """CanOpen Object Type"""
+
+    VAR = enum.auto()
+    """VAR object type"""
+
+    RECORD = enum.auto()
+    """RECORD object type"""
+
+    ARRAY = enum.auto()
+    """ARRAY object type"""
+
+
+@dataclass()
+class CanOpenObject:
+    """CanOpenObject"""
+
+    uid: Optional[str]
+    object_type: CanOpenObjectType
+    registers: List[CanopenRegister]
+
+
 @dataclass
 class DictionarySafetyPDO:
     """Safety PDOs dictionary descriptor."""
@@ -225,7 +247,7 @@ class Dictionary(ABC):
     """True if has SafetyPDOs element, else False"""
     _registers: dict[int, dict[str, Register]]
     """Instance of all the registers in the dictionary"""
-    registers_group: dict[int, dict[str, list[Register]]]
+    items: dict[int, dict[str, CanOpenObject]]
     """Registers group by subnode and UID"""
     safety_rpdos: dict[str, DictionarySafetyPDO]
     """Safety RPDOs by UID"""
@@ -233,7 +255,7 @@ class Dictionary(ABC):
     """Safety TPDOs by UID"""
 
     def __init__(self, dictionary_path: str, interface: Interface) -> None:
-        self.registers_group = {}
+        self.items = {}
         self.safety_rpdos = {}
         self.safety_tpdos = {}
         self._registers = {}
@@ -300,23 +322,23 @@ class Dictionary(ABC):
     def read_dictionary(self) -> None:
         """Reads the dictionary file and initializes all its components."""
 
-    def child_registers(self, uid: str, subnode: int) -> list[Register]:
-        """Return group registers by an UID.
+    def get_object(self, uid: str, subnode: int) -> CanOpenObject:
+        """Return object by an UID and subnode
 
         Args:
-            uid: registers group UID
-            subnode: registers group subnode
+            uid: object UID
+            subnode: object subnode
 
         Returns:
-            All registers in the group
+            CanOpen Object
 
         Raises:
-            KeyError: Registers group does not exist
+            KeyError: Object does not exist
 
         """
-        if subnode in self.registers_group and uid in self.registers_group[subnode]:
-            return self.registers_group[subnode][uid]
-        raise KeyError(f"Registers group {uid} in subnode {subnode} not exist")
+        if subnode in self.items and uid in self.items[subnode]:
+            return self.items[subnode][uid]
+        raise KeyError(f"Object {uid} in subnode {subnode} not exist")
 
     def get_safety_rpdo(self, uid: str) -> DictionarySafetyPDO:
         """Get Safe RPDO by uid.
@@ -495,6 +517,7 @@ class DictionaryV3(Dictionary):
     __SUBNODE_INDEX_ATTR = "index"
 
     __SUBNODE_ATTR = "subnode"
+    __OBJECT_DATA_TYPE_ATTR = "datatype"
     __ADDRESS_TYPE_ATTR = "address_type"
     __ACCESS_ATTR = "access"
     __DTYPE_ATTR = "dtype"
@@ -547,6 +570,12 @@ class DictionaryV3(Dictionary):
     __PDO_ENTRY_ELEMENT = "PDOEntry"
     __PDO_ENTRY_SIZE_ATTR = "size"
     __PDO_ENTRY_SUBNODE_ATTR = "subnode"
+
+    __canopen_object_data_type_options = {
+        "VAR": CanOpenObjectType.VAR,
+        "RECORD": CanOpenObjectType.RECORD,
+        "ARRAY": CanOpenObjectType.ARRAY,
+    }
 
     @override
     @classmethod
@@ -943,16 +972,19 @@ class DictionaryV3(Dictionary):
         object_uid = root.attrib.get(self.__UID_ATTR)
         reg_index = int(root.attrib[self.__INDEX_ATTR], 16)
         subnode = int(root.attrib[self.__SUBNODE_ATTR])
-        subitmes_element = self.__find_and_check(root, self.__SUBITEMS_ELEMENT)
-        subitem_list = self._findall_and_check(subitmes_element, self.__SUBITEM_ELEMENT)
+        data_type = self.__canopen_object_data_type_options[
+            root.attrib[self.__OBJECT_DATA_TYPE_ATTR]
+        ]
+        subitems_element = self.__find_and_check(root, self.__SUBITEMS_ELEMENT)
+        subitem_list = self._findall_and_check(subitems_element, self.__SUBITEM_ELEMENT)
         register_list = [
             self.__read_canopen_subitem(subitem, reg_index, subnode) for subitem in subitem_list
         ]
         if object_uid:
             register_list.sort(key=lambda val: val.subidx)
-            if subnode not in self.registers_group:
-                self.registers_group[subnode] = {}
-            self.registers_group[subnode][object_uid] = list(register_list)
+            if subnode not in self.items:
+                self.items[subnode] = {}
+            self.items[subnode][object_uid] = CanOpenObject(object_uid, data_type, register_list)
 
     def __read_canopen_subitem(
         self, subitem: ElementTree.Element, reg_index: int, subnode: int

--- a/tests/canopen/test_canopen_dictionary_v2.py
+++ b/tests/canopen/test_canopen_dictionary_v2.py
@@ -135,7 +135,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_can.xdf")
     canopen_dict = CanopenDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):
-        canopen_dict.child_registers("NOT_EXISTING_UID", 0)
+        canopen_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/canopen/test_canopen_dictionary_v2.py
+++ b/tests/canopen/test_canopen_dictionary_v2.py
@@ -131,7 +131,7 @@ def test_read_xdf_register():
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_can.xdf")
     canopen_dict = CanopenDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -4,7 +4,7 @@ import pytest
 
 from ingenialink import CanopenRegister
 from ingenialink.bitfield import BitField
-from ingenialink.dictionary import DictionaryV3, Interface, SubnodeType
+from ingenialink.dictionary import CanOpenObjectType, DictionaryV3, Interface, SubnodeType
 from ingenialink.exceptions import ILDictionaryParseError
 
 path_resources = "./tests/resources/canopen/"
@@ -125,14 +125,16 @@ def test_read_xdf_register():
 
 
 @pytest.mark.no_connection
-def test_child_registers():
+def test_object():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
-    reg_list = canopen_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
+    canopen_object = canopen_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
+    assert canopen_object.uid == "CIA301_COMMS_RPDO1_MAP"
+    assert canopen_object.object_type == CanOpenObjectType.RECORD
     reg_subindex = [0, 1]
     reg_uids = ["CIA301_COMMS_RPDO1_MAP", "CIA301_COMMS_RPDO1_MAP_1"]
     reg_index = [0x1600, 0x1600]
-    for index, reg in enumerate(reg_list.registers):
+    for index, reg in enumerate(canopen_object.registers):
         assert isinstance(reg, CanopenRegister)
         assert reg.idx == reg_index[index]
         assert reg.identifier == reg_uids[index]
@@ -140,7 +142,7 @@ def test_child_registers():
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
     with pytest.raises(KeyError):

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -128,11 +128,11 @@ def test_read_xdf_register():
 def test_child_registers():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
-    reg_list = canopen_dict.child_registers("CIA301_COMMS_RPDO1_MAP", 0)
+    reg_list = canopen_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
     reg_subindex = [0, 1]
     reg_uids = ["CIA301_COMMS_RPDO1_MAP", "CIA301_COMMS_RPDO1_MAP_1"]
     reg_index = [0x1600, 0x1600]
-    for index, reg in enumerate(reg_list):
+    for index, reg in enumerate(reg_list.registers):
         assert isinstance(reg, CanopenRegister)
         assert reg.idx == reg_index[index]
         assert reg.identifier == reg_uids[index]
@@ -144,7 +144,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
     with pytest.raises(KeyError):
-        canopen_dict.child_registers("NOT_EXISTING_UID", 0)
+        canopen_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/eoe/test_eoe_dictionary_v3.py
+++ b/tests/eoe/test_eoe_dictionary_v3.py
@@ -84,7 +84,7 @@ def test_read_dictionary_errors():
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, dict_eoe_v3)
     ethernet_dict = DictionaryV3(dictionary_path, Interface.EoE)
     with pytest.raises(KeyError):

--- a/tests/eoe/test_eoe_dictionary_v3.py
+++ b/tests/eoe/test_eoe_dictionary_v3.py
@@ -88,7 +88,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, dict_eoe_v3)
     ethernet_dict = DictionaryV3(dictionary_path, Interface.EoE)
     with pytest.raises(KeyError):
-        ethernet_dict.child_registers("NOT_EXISTING_UID", 0)
+        ethernet_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/ethercat/test_ethercat_dictionary_v2.py
+++ b/tests/ethercat/test_ethercat_dictionary_v2.py
@@ -150,7 +150,7 @@ def test_mcb_to_can_mapping(register_uid, subnode, idx):
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_ethercat.xdf")
     ethercat_dict = EthercatDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):

--- a/tests/ethercat/test_ethercat_dictionary_v2.py
+++ b/tests/ethercat/test_ethercat_dictionary_v2.py
@@ -154,7 +154,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_ethercat.xdf")
     ethercat_dict = EthercatDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):
-        ethercat_dict.child_registers("NOT_EXISTING_UID", 0)
+        ethercat_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -109,14 +109,14 @@ def test_read_xdf_register():
 
 
 @pytest.mark.no_connection
-def test_child_registers():
+def test_object_registers():
     dictionary_path = join_path(path_resources, dict_ecat_v3)
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
-    reg_list = ethercat_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
+    canopen_object = ethercat_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
     reg_subindex = [0, 1]
     reg_uids = ["CIA301_COMMS_RPDO1_MAP", "CIA301_COMMS_RPDO1_MAP_1"]
     reg_index = [0x1600, 0x1600]
-    for index, reg in enumerate(reg_list):
+    for index, reg in enumerate(canopen_object):
         assert isinstance(reg, CanopenRegister)
         assert reg.idx == reg_index[index]
         assert reg.identifier == reg_uids[index]
@@ -124,7 +124,7 @@ def test_child_registers():
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, dict_ecat_v3)
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
     with pytest.raises(KeyError):

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -112,7 +112,7 @@ def test_read_xdf_register():
 def test_child_registers():
     dictionary_path = join_path(path_resources, dict_ecat_v3)
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
-    reg_list = ethercat_dict.child_registers("CIA301_COMMS_RPDO1_MAP", 0)
+    reg_list = ethercat_dict.get_object("CIA301_COMMS_RPDO1_MAP", 0)
     reg_subindex = [0, 1]
     reg_uids = ["CIA301_COMMS_RPDO1_MAP", "CIA301_COMMS_RPDO1_MAP_1"]
     reg_index = [0x1600, 0x1600]
@@ -128,7 +128,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, dict_ecat_v3)
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
     with pytest.raises(KeyError):
-        ethercat_dict.child_registers("NOT_EXISTING_UID", 0)
+        ethercat_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/ethernet/test_ethernet_dictionary_v2.py
+++ b/tests/ethernet/test_ethernet_dictionary_v2.py
@@ -118,7 +118,7 @@ def test_read_xdf_register():
 
 
 @pytest.mark.no_connection
-def test_child_registers_not_exist():
+def test_object_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
     ethernet_dict = EthernetDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):

--- a/tests/ethernet/test_ethernet_dictionary_v2.py
+++ b/tests/ethernet/test_ethernet_dictionary_v2.py
@@ -122,7 +122,7 @@ def test_child_registers_not_exist():
     dictionary_path = join_path(path_resources, "test_dict_eth.xdf")
     ethernet_dict = EthernetDictionaryV2(dictionary_path)
     with pytest.raises(KeyError):
-        ethernet_dict.child_registers("NOT_EXISTING_UID", 0)
+        ethernet_dict.get_object("NOT_EXISTING_UID", 0)
 
 
 @pytest.mark.no_connection

--- a/tests/resources/canopen/test_dict_can_v3.0.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0.xdf
@@ -24,7 +24,7 @@
 					<Subnode index="1">Motion</Subnode>
 				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR"  subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -33,7 +33,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -42,7 +42,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1400" subnode="0">
+					<CANopenObject index="0x1400" datatype="RECORD" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="CIA301_COMMS_RPDO1" cyclic="CONFIG" desc="" default="0300" cat_id="CIA402">
 								<Labels>
@@ -66,7 +66,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -83,7 +83,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>
@@ -101,7 +101,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2010" subnode="1">
+					<CANopenObject index="0x2010" datatype="VAR"  subnode="1">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="DRV_STATE_CONTROL" cyclic="CYCLIC_RX" desc="Parameter to manage the drive state machine. It is compliant with DS402." units="none" default="0000" cat_id="TARGET">
                 <Labels>

--- a/tests/resources/canopen/test_dict_can_v3.0.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0.xdf
@@ -24,7 +24,7 @@
 					<Subnode index="1">Motion</Subnode>
 				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR"  subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -101,7 +101,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2010" datatype="VAR"  subnode="1">
+					<CANopenObject index="0x2010" datatype="VAR" subnode="1">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="DRV_STATE_CONTROL" cyclic="CYCLIC_RX" desc="Parameter to manage the drive state machine. It is compliant with DS402." units="none" default="0000" cat_id="TARGET">
                 <Labels>

--- a/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
@@ -25,7 +25,7 @@
 					<Subnode index="2">Motion</Subnode>
 				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -34,7 +34,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -43,7 +43,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" subnode="0" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -60,7 +60,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>
@@ -78,7 +78,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" subnode="2">
+					<CANopenObject index="0x2151" datatype="VAR" subnode="2">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>

--- a/tests/resources/test_dict_ecat_eoe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_v3.0.xdf
@@ -25,7 +25,7 @@
 					<Subnode index="4">Safety</Subnode>
 				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -34,7 +34,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x5E49" subnode="0">
+					<CANopenObject index="0x5E49" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="TEST_TXRX_REGISTER" cyclic="CYCLIC_TXRX" desc="Test TXRX register" default="00000000" cat_id="OTHERS">
 								<Labels>
@@ -43,7 +43,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -52,7 +52,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD"  subnode="0" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -69,7 +69,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>


### PR DESCRIPTION
### Description

Added parsing of the canopen item datatype from xdf v3

Fixes VOLCANO-632/INGK-1057

### Type of change

- [x] Update XDF V3 parser according to spec changed on vesuvius PR
- [x] Change "register_groups" to "objects (This internal API is still unused)

### Tests
- [x] Adapted unit tests
- [x] Added checks of item data types on unit tests

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
