### PR TITLE
INGK-1037 Improve ethernet network status listener tests

### DIFF
--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -114,10 +114,23 @@ def test_net_status_listener_connection(virtual_drive):
     assert status_list[0] == NetDevEvt.ADDED
 
 
-@pytest.mark.skip
 @pytest.mark.no_connection
-def test_net_status_listener_disconnection():
-    pass
+def test_net_status_listener_disconnection(virtual_drive, mocker):
+    server, _ = virtual_drive
+    net = EthernetNetwork()
+    net.connect_to_slave(server.ip, dictionary=server.dictionary_path, port=server.port)
+
+    status_list = []
+    net.subscribe_to_status(server.ip, status_list.append)
+    net.start_status_listener()
+
+    time.sleep(1)
+    mocker.patch("ingenialink.servo.Servo.is_alive", return_value=False)
+    time.sleep(1)
+    net.stop_status_listener()
+
+    assert len(status_list) == 1
+    assert status_list[0] == NetDevEvt.REMOVED
 
 
 @pytest.mark.no_connection


### PR DESCRIPTION
### Description

Improve ethernet network status listener tests.

Fixes # INGK-1037

### Type of change

- Implement the net status listener disconnection test.
- Unify the net status listener connection and disconnection tests.
- Improve the unsubscribe from status test.


### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
