### PR TITLE
INGK-1048 Review new foe with old drives

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -114,6 +114,7 @@ class EthercatNetwork(Network):
     EXPECTED_WKC_PROCESS_DATA = 3
 
     DEFAULT_FOE_PASSWORD = 0x70636675
+    __FOE_WRITE_TIMEOUT_US = 500_000
 
     __FORCE_BOOT_PASSWORD = 0x424F4F54
     __FORCE_COCO_BOOT_IDX = 0x5EDE
@@ -538,7 +539,9 @@ class EthercatNetwork(Network):
         """
         with open(file_path, "rb") as file:
             file_data = file.read()
-            r: int = slave.foe_write(self.__DEFAULT_FOE_FILE_NAME, password, file_data)
+            r: int = slave.foe_write(
+                self.__DEFAULT_FOE_FILE_NAME, password, file_data, self.__FOE_WRITE_TIMEOUT_US
+            )
         return r
 
     def _start_master(self) -> None:


### PR DESCRIPTION
### Description

Set a FoE write timeout that is suitable for all drives.

Fixes # INGK-1048

### Type of change

- Set a FoE write timeout.

### Tests
- Load firmware to "old" drives.
- Check that the firmware loading process is successful.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
