### PR TITLE
INGK-1062 Perform a power cycle before loading firmware

### DIFF
--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -95,7 +95,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     slaves_info = net.scan_slaves_info()
 
     drive_idx, config = get_configuration_from_rack_service
-    drive = config[drive_idx]
+    drive = config.drives[drive_idx]
 
     assert len(slaves_info) > 0
     assert read_config["canopen"]["node_id"] in slaves_info

--- a/tests/canopen/test_canopen_network.py
+++ b/tests/canopen/test_canopen_network.py
@@ -86,7 +86,7 @@ def test_scan_slaves_missing_drivers(can_device):
 
 
 @pytest.mark.canopen
-def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
+def test_scan_slaves_info(read_config, get_drive_configuration_from_rack_service):
     net = CanopenNetwork(
         device=CanDevice(read_config["canopen"]["device"]),
         channel=read_config["canopen"]["channel"],
@@ -94,8 +94,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     )
     slaves_info = net.scan_slaves_info()
 
-    drive_idx, config = get_configuration_from_rack_service
-    drive = config.drives[drive_idx]
+    drive = get_drive_configuration_from_rack_service
 
     assert len(slaves_info) > 0
     assert read_config["canopen"]["node_id"] in slaves_info

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,13 +163,13 @@ def connect_to_rack_service(request):
 
 
 @pytest.fixture(scope="session")
-def get_configuration_from_rack_service(pytestconfig, read_config, connect_to_rack_service):
+def get_drive_configuration_from_rack_service(pytestconfig, read_config, connect_to_rack_service):
     client = connect_to_rack_service
     rack_config = client.exposed_get_configuration()
     protocol = pytestconfig.getoption("--protocol")
     protocol_contents = read_config[protocol]
     drive_idx = get_drive_idx_from_rack_config(protocol_contents, rack_config)
-    return drive_idx, rack_config
+    return rack_config.drives[drive_idx]
 
 
 def get_drive_idx_from_rack_config(protocol_contents, rack_config):

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -82,7 +82,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     slaves_info = net.scan_slaves_info()
 
     drive_idx, config = get_configuration_from_rack_service
-    drive = config[drive_idx]
+    drive = config.drives[drive_idx]
 
     assert len(slaves_info) > 0
     assert read_config["ethercat"]["slave"] in slaves_info

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -77,12 +77,11 @@ def test_scan_slaves_raises_exception_if_drive_is_already_connected(connect_to_s
 
 
 @pytest.mark.ethercat
-def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
+def test_scan_slaves_info(read_config, get_drive_configuration_from_rack_service):
     net = EthercatNetwork(read_config["ethercat"]["ifname"])
     slaves_info = net.scan_slaves_info()
 
-    drive_idx, config = get_configuration_from_rack_service
-    drive = config.drives[drive_idx]
+    drive = get_drive_configuration_from_rack_service
 
     assert len(slaves_info) > 0
     assert read_config["ethercat"]["slave"] in slaves_info

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -66,7 +66,7 @@ def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
     slaves_info = net.scan_slaves_info()
 
     drive_idx, config = get_configuration_from_rack_service
-    drive = config[drive_idx]
+    drive = config.drives[drive_idx]
 
     assert len(slaves_info) > 0
     assert drive_ip in slaves_info

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -59,14 +59,13 @@ def test_scan_slaves(read_config):
 
 
 @pytest.mark.ethernet
-def test_scan_slaves_info(read_config, get_configuration_from_rack_service):
+def test_scan_slaves_info(read_config, get_drive_configuration_from_rack_service):
     drive_ip = read_config["ethernet"]["ip"]
     subnet = drive_ip + "/24"
     net = EthernetNetwork(subnet)
     slaves_info = net.scan_slaves_info()
 
-    drive_idx, config = get_configuration_from_rack_service
-    drive = config.drives[drive_idx]
+    drive = get_drive_configuration_from_rack_service
 
     assert len(slaves_info) > 0
     assert drive_ip in slaves_info

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -547,7 +547,7 @@ def test_enable_disable(connect_to_slave):
 @pytest.mark.ethercat
 def test_fault_reset(connect_to_slave, get_configuration_from_rack_service):
     drive_idx, config = get_configuration_from_rack_service
-    drive = config[drive_idx]
+    drive = config.drives[drive_idx]
     if drive.identifier == "eve-xcr-e":
         pytest.skip("There is a specific fault test for the EVE-XCR-E")
     servo, net = connect_to_slave
@@ -563,7 +563,7 @@ def test_fault_reset(connect_to_slave, get_configuration_from_rack_service):
 @pytest.mark.ethercat
 def test_fault_reset_eve_xcr(connect_to_slave, get_configuration_from_rack_service):
     drive_idx, config = get_configuration_from_rack_service
-    drive = config[drive_idx]
+    drive = config.drives[drive_idx]
     if drive.identifier != "eve-xcr-e":
         pytest.skip("The test is only for the EVE-XCR-E")
     servo, net = connect_to_slave

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -545,9 +545,8 @@ def test_enable_disable(connect_to_slave):
 @pytest.mark.canopen
 @pytest.mark.ethernet
 @pytest.mark.ethercat
-def test_fault_reset(connect_to_slave, get_configuration_from_rack_service):
-    drive_idx, config = get_configuration_from_rack_service
-    drive = config.drives[drive_idx]
+def test_fault_reset(connect_to_slave, get_drive_configuration_from_rack_service):
+    drive = get_drive_configuration_from_rack_service
     if drive.identifier == "eve-xcr-e":
         pytest.skip("There is a specific fault test for the EVE-XCR-E")
     servo, net = connect_to_slave
@@ -561,9 +560,8 @@ def test_fault_reset(connect_to_slave, get_configuration_from_rack_service):
 
 
 @pytest.mark.ethercat
-def test_fault_reset_eve_xcr(connect_to_slave, get_configuration_from_rack_service):
-    drive_idx, config = get_configuration_from_rack_service
-    drive = config.drives[drive_idx]
+def test_fault_reset_eve_xcr(connect_to_slave, get_drive_configuration_from_rack_service):
+    drive = get_drive_configuration_from_rack_service
     if drive.identifier != "eve-xcr-e":
         pytest.skip("The test is only for the EVE-XCR-E")
     servo, net = connect_to_slave


### PR DESCRIPTION
### Description

Make the drive setup for the tests more robust.

Fixes # INGK-1062

### Type of change

Please add a description and delete options that are not relevant.

- Perform a power cycle before loading the firmware file.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
