### PR TITLE
Ingk 1058 ethernet load firmware login error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 - Created ConfigurationFile class, used in load_configuration, save_configuration and check_configuration
 - Functions to update pysoem timeouts
 
+### Fixed
+- FTP login exception.
+
 ## [7.4.1] - 2025-01-28
 ### Fixed
 - Avoid mapping a PDO map twice.

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -136,7 +136,10 @@ class EthernetNetwork(Network):
                 raise ILFirmwareLoadError("Unable to open the FTP session")
             # Login into FTP session.
             logger.info("Logging into FTP session...")
-            ftp_output = ftp.login(ftp_user, ftp_pwd)
+            try:
+                ftp_output = ftp.login(ftp_user, ftp_pwd)
+            except ftplib.error_perm as e:
+                raise ILFirmwareLoadError("Unable to login the FTP session") from e
             logger.info(ftp_output)
             if FTP_LOGIN_OK_CODE not in ftp_output:
                 raise ILFirmwareLoadError("Unable to login the FTP session")

--- a/tests/ethernet/test_ethernet_network.py
+++ b/tests/ethernet/test_ethernet_network.py
@@ -1,7 +1,7 @@
 import os
 import socket
 import time
-from ftplib import error_perm, error_temp
+from ftplib import error_temp
 from threading import Thread
 
 import pytest
@@ -166,7 +166,6 @@ def test_load_firmware_no_connection():
     os.remove(fw_file)
 
 
-@pytest.mark.skip(reason="Skipping for now. Check INGK-1035 & INGK-1058.")
 @pytest.mark.no_connection
 @pytest.mark.parametrize(
     "ftp_server_manager",
@@ -187,7 +186,6 @@ def test_load_firmware_wrong_user_pwd(ftp_server_manager):
     with pytest.raises(ILFirmwareLoadError) as excinfo:
         net.load_firmware(fw_file, target="localhost", ftp_user=fake_user, ftp_pwd=fake_password)
     assert str(excinfo.value) == "Unable to login the FTP session"
-    assert isinstance(excinfo.value.__cause__, error_perm)
     os.remove(fw_file)
 
 


### PR DESCRIPTION
### Description

Include an unhandled ftp-login exception and fix test_load_firmware_wrong_user_pwd.

Fixes # INGK-1058

### Type of change

- [x] FTP-login exception added to load_firmware function for correct exception management.


### Tests
- [x] Fix test_load_firmware_wrong_user_pwd
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
