### PR TITLE
INGK-1054 Move XMLBase to dictionary.py and use it to dictionary

### DIFF
--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -9,7 +9,7 @@ import ingenialogger
 import numpy as np
 
 from ingenialink import RegAccess, RegDtype
-from ingenialink.dictionary import ACCESS_XDF_OPTIONS, DTYPE_XDF_OPTIONS, Interface
+from ingenialink.dictionary import ACCESS_XDF_OPTIONS, DTYPE_XDF_OPTIONS, Interface, XMLBase
 from ingenialink.exceptions import ILConfigurationFileParseError
 from ingenialink.register import Register
 
@@ -195,52 +195,6 @@ class ConfigRegister:
         else:
             register_xml.set(self.__STORAGE_ATTR, str(self.storage))
         return register_xml
-
-
-class XMLBase(ABC):
-    """Base class to manipulate XML files."""
-
-    _CHECK_FAIL_EXCEPTION = Exception
-
-    @classmethod
-    def _findall_and_check(cls, root: ElementTree.Element, path: str) -> list[ElementTree.Element]:
-        """Return list of elements in the target root element if existed, else, raises an exception.
-
-        Args:
-          root: root element
-          path: target elements path
-
-        Returns:
-          list of path elements
-
-        Raises:
-          path elements not found
-
-        """
-        element = root.findall(path)
-        if not element:
-            raise cls._CHECK_FAIL_EXCEPTION(f"{path} element is not found")
-        return element
-
-    @classmethod
-    def _find_and_check(cls, root: ElementTree.Element, path: str) -> ElementTree.Element:
-        """Return the path element in the target root element if exists, else, raises an exception.
-
-        Args:
-            root: root element
-            path: target element path
-
-        Returns:
-            path element
-
-        Raises:
-            path element not found
-
-        """
-        element = root.find(path)
-        if element is None:
-            raise cls._CHECK_FAIL_EXCEPTION(f"{path} element is not found")
-        return element
 
 
 class ConfigurationFile(XMLBase, ABC):


### PR DESCRIPTION

Use XMLBase in dictionary.py and configuration_file.py to not duplicate functions

Fixes # INGK-1054

### Type of change

- [x] Move XMLBase to dictionary.py
- [x] Use XMLBase in Dictionary class

### Tests
- [x] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [x] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
