### PR TITLE
Use detached state to get original commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,16 +121,18 @@ pipeline {
                                     def currentCommit = bat(script: "git rev-parse HEAD", returnStdout: true).trim()
                                     def currentCommitHash = (currentCommit =~ /\b[0-9a-f]{40}\b/)[0]
                                     echo "Current Commit Hash: ${currentCommitHash}"
-                                    def parentCommits = bat(script: "git rev-list --parents -n 1 ${currentCommitHash}", returnStdout: true).trim().split(" ")
-                                    def parentCommitsHashes = (parentCommits =~ /\b[0-9a-f]{40}\b/).findAll()
+                                    def currentCommitBranch = bat(script: "git branch --contains ${currentCommitHash}", returnStdout: true).trim().split("\n").find { it.contains('*') }.replace('* ', '').trim()
+                                    echo "currentCommitBranch: ${currentCommitBranch}"
                                     
-                                    if (parentCommitsHashes.size() > 2) { // This is a merge commit
-                                        def originalCommitHash = parentCommitsHashes[2]
-                                        echo "Original Commit Hash (before merge): ${originalCommitHash}"
-                                        currentBuild.description = "ORGINAL_GIT_COMMIT_HASH=${originalCommitHash}"
-                                    } else { // This is not a merge commit
-                                        echo "Current Commit Hash: ${currentCommitHash}"
-                                        currentBuild.description = "ORGINAL_GIT_COMMIT_HASH=${currentCommitHash}"
+                                    if (currentCommitBranch.contains('detached')) {
+                                        def shortCommitHash = (currentCommitBranch =~ /\b[0-9a-f]{7,40}\b/)[0]
+                                        def detachedCommit = bat(script: "git rev-parse ${shortCommitHash}", returnStdout: true).trim()
+                                        def detachedCommitHash = (detachedCommit =~ /\b[0-9a-f]{40}\b/)[0]
+                                        echo "Detached Commit Hash: ${detachedCommitHash}"
+                                        currentBuild.description = "ORIGINAL_GIT_COMMIT_HASH=${detachedCommitHash}"
+                                    } else {
+                                        echo "No detached HEAD state found. Using current commit hash ${currentCommitHash}."
+                                        currentBuild.description = "ORIGINAL_GIT_COMMIT_HASH=${currentCommitHash}"
                                     }
                                 }
                             }


### PR DESCRIPTION
### Description

Use the current commit to get the working branch, which will give the detached state.
```
currentCommitBranch: (HEAD detached at 13bd60f5)
```
The indicated detached commit is the last one of the current branch, without any jenkins merge.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Check detached branch


### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
