### PR TITLE
INGK-1064 Make sure all drives are operational before running tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ pipeline {
                         }
                         stage('EtherCAT Multislave') {
                             steps {
-                                runTest("multislave", tox_skip_install=true)
+                                runTest("multislave", 0, true)
                             }
                         }
                         stage('Run no-connection tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,6 +298,11 @@ pipeline {
                                 runTest("ethercat", 1, true)
                             }
                         }
+                        stage('EtherCAT Multislave') {
+                            steps {
+                                runTest("multislave", tox_skip_install=true)
+                            }
+                        }
                         stage('Run no-connection tests') {
                             steps {
                                 runTest("no_connection", 0, true)

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,7 @@ markers =
     ethercat: EtherCAT tests
     eoe: EtherCAT service tests
     canopen: CANopen tests
+    multislave: EtherCAT tests that require multiple slaves
     docker: Test executed in docker
 log_cli = False
 log_cli_level = INFO

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -226,6 +226,7 @@ def test_register_description(dictionary_path):
             )
 
 
+@pytest.mark.no_connection
 def test_register_bitfields():
     dictionary_path = join_path(path_resources, dict_can_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from virtual_drive.core import VirtualDrive
 
 DEFAULT_PROTOCOL = "no_connection"
 
-ALLOW_PROTOCOLS = [DEFAULT_PROTOCOL, "ethernet", "ethercat", "canopen", "eoe"]
+ALLOW_PROTOCOLS = [DEFAULT_PROTOCOL, "ethernet", "ethercat", "canopen", "eoe", "multislave"]
 
 
 def pytest_addoption(parser):
@@ -194,7 +194,7 @@ def get_drive_idx_from_rack_config(protocol_contents, rack_config):
 @pytest.fixture(scope="session", autouse=True)
 def load_firmware(pytestconfig, read_config, request):
     protocol = pytestconfig.getoption("--protocol")
-    if protocol == DEFAULT_PROTOCOL:
+    if protocol in [DEFAULT_PROTOCOL, "multislave"]:
         return
 
     client = request.getfixturevalue("connect_to_rack_service")

--- a/tests/eoe/test_eoe_dictionary_v3.py
+++ b/tests/eoe/test_eoe_dictionary_v3.py
@@ -144,6 +144,7 @@ def test_register_description():
             )
 
 
+@pytest.mark.no_connection
 def test_register_bitfields():
     dictionary_path = join_path(path_resources, dict_eoe_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.EoE)

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -244,6 +244,7 @@ def test_register_description():
             )
 
 
+@pytest.mark.no_connection
 def test_register_bitfields():
     dictionary_path = join_path(path_resources, dict_ecat_v3)
     canopen_dict = DictionaryV3(dictionary_path, Interface.ECAT)

--- a/tests/ethercat/test_ethercat_examples.py
+++ b/tests/ethercat/test_ethercat_examples.py
@@ -29,7 +29,7 @@ def test_load_firmware_example(arguments, script_runner, mocker, read_config):
     mock.assert_called_once_with("dummy_file.lfu", False, slave_id=slave_id)
 
 
-@pytest.mark.ethercat
+@pytest.mark.multislave
 def test_pdo_example(read_config, script_runner):
     protocol_contents = read_config["ethercat"]
     ifname = protocol_contents["ifname"]

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -309,12 +309,12 @@ def test_servo_reset_pdos(connect_to_slave, create_pdo_map):
 @pytest.fixture
 def connect_to_all_slave(pytestconfig):
     protocol = pytestconfig.getoption("--protocol")
-    if protocol != "ethercat":
+    if protocol != "multislave":
         raise AssertionError("Wrong protocol")
     config = "tests/config.json"
     with open(config, encoding="utf-8") as fp:
         contents = json.load(fp)
-    protocol_contents = contents[protocol]
+    protocol_contents = contents["ethercat"]
     net = EthercatNetwork(protocol_contents[0]["ifname"])
     servos = [
         net.connect_to_slave(slave_content["slave"], slave_content["dictionary"])
@@ -354,7 +354,7 @@ def start_stop_pdos(net):
         assert servo.slave.state_check(pysoem.PREOP_STATE) == pysoem.PREOP_STATE
 
 
-@pytest.mark.ethercat
+@pytest.mark.multislave
 def test_start_stop_pdo(connect_to_all_slave):
     servos, net = connect_to_all_slave
     operation_mode_uid = "DRV_OP_CMD"

--- a/tests/test_bitfields.py
+++ b/tests/test_bitfields.py
@@ -24,6 +24,7 @@ def test_parse_bitfields(value, values):
     assert BitField.parse_bitfields(BITFIELD_EXAMPLES, value) == values
 
 
+@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "old_value, new_value, values",
     [
@@ -41,6 +42,7 @@ def test_set_bitfields(old_value, new_value, values):
     assert BitField.set_bitfields(BITFIELD_EXAMPLES, values, old_value) == new_value
 
 
+@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "values, error",
     [

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -22,6 +22,7 @@ PATH_RESOURCE = "./tests/resources/"
 PATH_TO_DICTIONARY = "./virtual_drive/resources/virtual_drive.xdf"
 
 
+@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "dict_path, interface, fw_version, product_code, part_number, revision_number",
     [
@@ -71,6 +72,7 @@ def test_dictionary_description(
     )
 
 
+@pytest.mark.no_connection
 @pytest.mark.parametrize(
     "dict_path, interface, raises",
     [


### PR DESCRIPTION
### Description

Create a new stage for the multislave tests.

Fixes # INGK-1064

### Type of change

Please add a description and delete options that are not relevant.

- Add a multislave marker to the corresponding tests.
- Create the multislave stage.
- Add a no-connection marker to the tests without markers.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
