### PR TITLE
Ingk 1068 check_node_state return False with empty servo list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - FTP login exception.
+- Return False on ECAT node-state check when servo list is empty
 
 ## [7.4.1] - 2025-01-28
 ### Fixed

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -429,16 +429,15 @@ class EthercatNetwork(Network):
         Returns:
             True if all nodes reached the target state, else False.
         """
+        if not nodes:
+            return False
+
         node_list = nodes if isinstance(nodes, list) else [nodes]
         self._ecat_master.read_state()
 
-        return (
-            all(
-                target_state == drive.slave.state_check(target_state, ECAT_STATE_CHANGE_TIMEOUT_US)
-                for drive in node_list
-            )
-            if nodes
-            else False
+        return all(
+            target_state == drive.slave.state_check(target_state, ECAT_STATE_CHANGE_TIMEOUT_US)
+            for drive in node_list
         )
 
     def subscribe_to_status(  # type: ignore [override]

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -667,6 +667,11 @@ class EthercatNetwork(Network):
         if self._ecat_master.state == pysoem.PREOP_STATE:
             return True
         self.__init_nodes()
+        if not self.servos:
+            log_message = (
+                "The CoE communication cannot be recovered. No slaves where detected in the network"
+            )
+            return False
         all_drives_in_preop = self._check_node_state(self.servos, pysoem.PREOP_STATE)
         if all_drives_in_preop:
             log_message = "CoE communication recovered."

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -432,9 +432,13 @@ class EthercatNetwork(Network):
         node_list = nodes if isinstance(nodes, list) else [nodes]
         self._ecat_master.read_state()
 
-        return all(
-            target_state == drive.slave.state_check(target_state, ECAT_STATE_CHANGE_TIMEOUT_US)
-            for drive in node_list
+        return (
+            all(
+                target_state == drive.slave.state_check(target_state, ECAT_STATE_CHANGE_TIMEOUT_US)
+                for drive in node_list
+            )
+            if nodes
+            else False
         )
 
     def subscribe_to_status(  # type: ignore [override]

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -128,3 +128,12 @@ def test_update_pysoem_timeouts(connect_to_slave):
     assert pysoem.settings.timeouts.tx_mailbox == old_tx_mailbox
     assert pysoem.settings.timeouts.rx_mailbox == old_rx_mailbox
     assert pysoem.settings.timeouts.state == old_state
+
+
+@pytest.mark.ethercat
+def test_check_node_state(connect_to_slave):
+    servo, net = connect_to_slave
+    # True when list is not empty
+    assert net._check_node_state(servo, pysoem.PREOP_STATE)
+    # False when list is not empty
+    assert not net._check_node_state([], pysoem.PREOP_STATE)


### PR DESCRIPTION
### Description

"_check_node_state" returns a True when called with an empty servos list. This sometimes leads to unhandled exceptions.

Fixes # INGK-1068

### Type of change

- [x] Function "_check_node_state" will return False if called with empty list.

### Tests
- [x] New test "test_check_node_state".
- [x] Run tests.

### Documentation

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Fixed]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
