### PR TITLE
Ingk 1073 coverage is not being reported

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,8 @@
 [run]
 relative_files = True
+
+; Skip empty files
+[report]
+skip_empty = true
+omit =
+    */__init__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,6 @@
 [run]
 relative_files = True
 omit = tests/*
-source =
-    .tox/py39/Lib/site-packages/ingenialink
-    .tox/py310/Lib/site-packages/ingenialink
-    .tox/py311/Lib/site-packages/ingenialink
-    .tox/py312/Lib/site-packages/ingenialink
 
 ; Specify that all these paths should be considered as a single package, otherwise
 ; it would duplicate the lines for each python version that has coverage data

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,23 @@
 [run]
 relative_files = True
+omit = tests/*
+source =
+    .tox/py39/Lib/site-packages/ingenialink
+    .tox/py310/Lib/site-packages/ingenialink
+    .tox/py311/Lib/site-packages/ingenialink
+    .tox/py312/Lib/site-packages/ingenialink
+
+; Specify that all these paths should be considered as a single package, otherwise
+; it would duplicate the lines for each python version that has coverage data
+; `ingenialink` path is included because the coverage step runs skipping installation in tox
+; so it is needed to indicate that the site-packages and the cloned repo should be the same
+[paths]
+source =
+    ingenialink
+    .tox/py39/Lib/site-packages/ingenialink
+    .tox/py310/Lib/site-packages/ingenialink
+    .tox/py311/Lib/site-packages/ingenialink
+    .tox/py312/Lib/site-packages/ingenialink
 
 ; Skip empty files
 [report]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ def runTest(protocol, slave = 0, tox_skip_install = false) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "--protocol ${protocol} " +
                     "--slave ${slave} " +
-                    "--cov " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${protocol}-${slave}\""
 
         } catch (err) {
@@ -237,8 +236,7 @@ pipeline {
                                     restoreIngenialinkWheelEnvVar()
                                 }
                                 bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                        "-m docker " +
-                                        "--cov"
+                                        "-m docker "
                             }
                             post {
                                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,6 @@ def runTest(protocol, slave = 0, tox_skip_install = false) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "--protocol ${protocol} " +
                     "--slave ${slave} " +
-                    "--cov=ingenialink " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${protocol}-${slave}\""
 
         } catch (err) {
@@ -237,8 +236,7 @@ pipeline {
                                     restoreIngenialinkWheelEnvVar()
                                 }
                                 bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                        "-m docker " +
-                                        "--cov=ingenialink"
+                                        "-m docker "
                             }
                             post {
                                 always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,7 @@ def runTest(protocol, slave = 0, tox_skip_install = false) {
             bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +
                     "--protocol ${protocol} " +
                     "--slave ${slave} " +
+                    "--cov " +
                     "--job_name=\"${env.JOB_NAME}-#${env.BUILD_NUMBER}-${protocol}-${slave}\""
 
         } catch (err) {
@@ -236,7 +237,8 @@ pipeline {
                                     restoreIngenialinkWheelEnvVar()
                                 }
                                 bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
-                                        "-m docker "
+                                        "-m docker " +
+                                        "--cov"
                             }
                             post {
                                 always {

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     pytest==7.0.1
     pytest-cov==2.12.1
 commands =
-    ; python -I -m coverage combine {posargs}
+    python -I -m coverage combine {posargs}
     python -I -m coverage xml --include='*/ingenialink/*'
 
 [testenv:format]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest-console-scripts==1.4.1
     twisted==24.11.0
 commands =
-    python -I -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
+    python -I -m pytest {posargs:tests} --cov={envsitepackagesdir}/ingenialink --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 
 [testenv:coverage]
 description = combine and export coverage report
@@ -24,7 +24,7 @@ deps =
     pytest==7.0.1
     pytest-cov==2.12.1
 commands =
-    python -I -m coverage combine {posargs}
+    ; python -I -m coverage combine {posargs}
     python -I -m coverage xml --include='*/ingenialink/*'
 
 [testenv:format]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest-console-scripts==1.4.1
     twisted==24.11.0
 commands =
-    python -I -m pytest {posargs:tests} --cov={envsitepackagesdir}/ingenialink --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
+    python -I -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 
 [testenv:coverage]
 description = combine and export coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     pytest-console-scripts==1.4.1
     twisted==24.11.0
 commands =
-    python -I -m pytest {posargs:tests} --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
+    python -I -m pytest {posargs:tests} --cov={envsitepackagesdir}/ingenialink --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 
 [testenv:coverage]
 description = combine and export coverage report


### PR DESCRIPTION
### Description

Since `--import-mode=importlib` pytest adoption, coverage was not working properly. 
The issue was that it was looking for the executed lines of the local repo copy (`--cov=ingenialink`) rather than from the installed package.

Removed `--cov` from `Jenkins` file and added it to `[testenv]` configuration in `tox.ini`.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Fix coverage

### Tests
- [ ] Add new unit tests if it applies.
- [ ] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
