### PR TITLE
INGK-1055 Test status word wait change fails sometimes

### DIFF
--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -594,8 +594,12 @@ def test_status_word_wait_change(connect_to_slave):
     subnode = 1
     timeout = 0.5
     status_word = servo.read(servo.STATUS_WORD_REGISTERS, subnode=subnode)
-    with pytest.raises(ILTimeoutError):
+    try:
         servo.status_word_wait_change(status_word, timeout, subnode)
+    except ILTimeoutError:
+        return
+    current_status_word = servo.read(servo.STATUS_WORD_REGISTERS, subnode=subnode)
+    pytest.fail(f"The status word changed from {status_word} to {current_status_word}.")
 
 
 @pytest.mark.ethernet

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -593,13 +593,14 @@ def test_status_word_wait_change(connect_to_slave):
     servo, _ = connect_to_slave
     subnode = 1
     timeout = 0.5
-    status_word = servo.read(servo.STATUS_WORD_REGISTERS, subnode=subnode)
-    try:
-        servo.status_word_wait_change(status_word, timeout, subnode)
-    except ILTimeoutError:
-        return
     current_status_word = servo.read(servo.STATUS_WORD_REGISTERS, subnode=subnode)
-    pytest.fail(f"The status word changed from {status_word} to {current_status_word}.")
+    try:
+        servo.status_word_wait_change(current_status_word, timeout, subnode)
+    except ILTimeoutError:
+        # Success. The status word did not change
+        return
+    new_status_word = servo.read(servo.STATUS_WORD_REGISTERS, subnode=subnode)
+    pytest.fail(f"The status word changed from {current_status_word} to {new_status_word}.")
 
 
 @pytest.mark.ethernet


### PR DESCRIPTION
### Description

I could not reproduce the failure. Added more info in case of failure.

Fixes # INGK-1055

### Type of change
- Add more info in case of a failure.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
