### PR TITLE
MOT3-4747 Raise exception if slave object has been deleted

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -210,6 +210,8 @@ class EthercatServo(PDOServo):
             ILIOError,
         ) as e:
             self._handle_sdo_exception(reg, SdoOperationMsg.READ, e)
+        except AttributeError:
+            raise ILIOError(f"Error reading {reg.identifier}. The drive has been disconnected.")
         finally:
             self._lock.release()
         return value
@@ -237,6 +239,8 @@ class EthercatServo(PDOServo):
             ILIOError,
         ) as e:
             self._handle_sdo_exception(reg, SdoOperationMsg.WRITE, e)
+        except AttributeError:
+            raise ILIOError(f"Error writing {reg.identifier}. The drive has been disconnected.")
         finally:
             self._lock.release()
 


### PR DESCRIPTION
### Description

The slave object is unreferenced after a disconnection, causing an exception if trying to read/write afterwards. 

Fixes # MOT3-4747

### Type of change

- Raise an exception if the slave has been unreferenced.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Test:

- Follow the steps described in the issue.
- Check that no unhandled exception occurs.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
