### PR TITLE
INGK-1087 Close the EtherCAT master if it was previously not running

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -288,10 +288,14 @@ class EthercatNetwork(Network):
         """
         if self.servos:
             raise ILError("Some slaves are already connected")
-        if not self.__is_master_running:
+        is_master_running_before_scan = self.__is_master_running
+        if not is_master_running_before_scan:
             self._start_master()
         self.__init_nodes()
-        return self.__last_init_nodes
+        slaves_found = self.__last_init_nodes
+        if not is_master_running_before_scan:
+            self.close_ecat_master(release_reference=False)
+        return slaves_found
 
     def scan_slaves_info(self) -> OrderedDict[int, SlaveInfo]:
         """Scans for slaves in the network and return an ordered dict with the slave information.
@@ -383,12 +387,21 @@ class EthercatNetwork(Network):
             self.start_status_listener()
         return servo
 
-    def close_ecat_master(self) -> None:
-        """Closes the connection with the EtherCAT master."""
+    def close_ecat_master(self, release_reference: bool = True) -> None:
+        """Closes the connection with the EtherCAT master.
+
+        Args:
+            release_reference: Whether to release the network reference.
+        If the network will be reused afterward it should be set to False.
+
+        """
         self._lock.acquire()
         self._ecat_master.close()
         self._lock.release()
-        release_network_reference(network=self)
+        self.__is_master_running = False
+        self.__last_init_nodes = []
+        if release_reference:
+            release_network_reference(network=self)
 
     def disconnect_from_slave(self, servo: EthercatServo) -> None:  # type: ignore [override]
         """Disconnects the slave from the network.
@@ -404,8 +417,6 @@ class EthercatNetwork(Network):
         if not self.servos:
             self.stop_status_listener()
             self.close_ecat_master()
-            self.__is_master_running = False
-            self.__last_init_nodes = []
 
     def config_pdo_maps(self) -> None:
         """Configure the PDO maps.
@@ -630,7 +641,8 @@ class EthercatNetwork(Network):
 
         if not isinstance(slave_id, int) or slave_id < 0:
             raise ValueError("Invalid slave ID value")
-        if not self.__is_master_running:
+        is_master_running_before_loading_firmware = self.__is_master_running
+        if not is_master_running_before_loading_firmware:
             self._start_master()
             self.__init_nodes()
         if len(self.__last_init_nodes) == 0:
@@ -669,6 +681,8 @@ class EthercatNetwork(Network):
             logger.info("Firmware updated successfully")
         else:
             logger.info(f"The slave {slave_id} cannot reach the PreOp state.")
+        if not is_master_running_before_loading_firmware:
+            self.close_ecat_master(release_reference=False)
 
     def _switch_to_boot_state(self, slave: "CdefSlave") -> None:
         """Transitions the slave to the boot state.

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -226,13 +226,13 @@ def test_master_reference_is_kept_while_network_is_alive(mocker, ethercat_networ
 
 
 @pytest.mark.ethercat
-def test_master_reference_is_kept_after_scan(mocker, ethercat_network_teardown):  # noqa: ARG001
+def test_master_reference_is_kept_after_scan(ethercat_network_teardown, read_config):  # noqa: ARG001
     assert len(ETHERCAT_NETWORK_REFERENCES) == 0
-    net_1 = EthercatNetwork("dummy_network_1", gil_release_config=GilReleaseConfig.always())
+    net_1 = EthercatNetwork(
+        read_config["ethercat"]["ifname"], gil_release_config=GilReleaseConfig.always()
+    )
     assert len(ETHERCAT_NETWORK_REFERENCES) == 1
     assert net_1 in ETHERCAT_NETWORK_REFERENCES
-
-    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.scan_slaves")
 
     net_1.scan_slaves()
 

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -226,6 +226,25 @@ def test_master_reference_is_kept_while_network_is_alive(mocker, ethercat_networ
 
 
 @pytest.mark.ethercat
+def test_master_reference_is_kept_after_scan(mocker, ethercat_network_teardown):  # noqa: ARG001
+    assert len(ETHERCAT_NETWORK_REFERENCES) == 0
+    net_1 = EthercatNetwork("dummy_network_1", gil_release_config=GilReleaseConfig.always())
+    assert len(ETHERCAT_NETWORK_REFERENCES) == 1
+    assert net_1 in ETHERCAT_NETWORK_REFERENCES
+
+    mocker.patch("ingenialink.ethercat.network.EthercatNetwork.scan_slaves")
+
+    net_1.scan_slaves()
+
+    assert len(ETHERCAT_NETWORK_REFERENCES) == 1
+    assert net_1 in ETHERCAT_NETWORK_REFERENCES
+
+    net_1.close_ecat_master()
+
+    assert len(ETHERCAT_NETWORK_REFERENCES) == 0
+
+
+@pytest.mark.ethercat
 def test_network_is_not_released_if_gil_operation_ongoing(mocker, read_config):
     blocking_time = 5
 


### PR DESCRIPTION
### Description

Close the EtherCAT master if it was previously not running.

Fixes # INGK-1087

### Type of change

- Close the master in the scan method.
- Close the master in the load_firmware method.
- Add an optional argument to the close_master method. It is used in case the network instance will be used to connect to a servo after the scan or load_firmware method is called.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
