### PR TITLE
Remove subnode from ECAT/CAN devices

### DIFF
--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1093,8 +1093,6 @@ class DictionaryV3(Dictionary):
             if axis == 0:
                 self.subnodes[axis] = SubnodeType.COMMUNICATION
             else:
-                if axis != 1:
-                    logger.warning(f"Found {axis=}, will treat it as a Motion axis.")
                 self.subnodes[axis] = SubnodeType.MOTION
         if register.identifier is None:
             raise ValueError("Identifier must be provided.")

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1159,7 +1159,7 @@ class DictionaryV3(Dictionary):
         """
         object_uid = root.attrib.get(self.__UID_ATTR)
         reg_index = int(root.attrib[self.__INDEX_ATTR], 16)
-        axis = int(root.attrib[self.__AXIS_ATTR])
+        axis = int(root.attrib[self.__AXIS_ATTR]) if self.__AXIS_ATTR in root.attrib else 0
         data_type = DictionaryV3._get_canopen_object_data_type_options(
             root.attrib[self.__OBJECT_DATA_TYPE_ATTR]
         )

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1084,6 +1084,9 @@ class DictionaryV3(Dictionary):
         Args:
             register: register to add.
             axis: register's axis.
+
+        Raises:
+            ValueError: if register identifier is not provided.
         """
         if axis not in self._registers:
             self._registers[axis] = {}
@@ -1093,6 +1096,8 @@ class DictionaryV3(Dictionary):
                 if axis != 1:
                     logger.warning(f"Found {axis=}, will treat it as a Motion axis.")
                 self.subnodes[axis] = SubnodeType.MOTION
+        if register.identifier is None:
+            raise ValueError("Identifier must be provided.")
         self._registers[axis][register.identifier] = register
 
     def __read_mcb_register(self, register: ElementTree.Element) -> None:

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -81,8 +81,6 @@ class SubnodeType(enum.Enum):
     """Communication"""
     MOTION = enum.auto()
     """Motion"""
-    SAFETY = enum.auto()  # TODO: remove
-    """Safety"""
 
 
 class CanOpenObjectType(enum.Enum):
@@ -387,8 +385,6 @@ class Dictionary(XMLBase, ABC):
             return SubnodeType.COMMUNICATION
         if subnode == "Motion":
             return SubnodeType.MOTION
-        if subnode == "Safety":
-            return SubnodeType.SAFETY
         raise ILDictionaryParseError(f"{subnode=} does not exist.")
 
     @classmethod

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -9,18 +9,12 @@ from ingenialink.dictionary import (
     DictionarySafetyPDO,
     DictionaryV3,
     Interface,
-    SubnodeType,
 )
 from ingenialink.exceptions import ILDictionaryParseError
 
 path_resources = "./tests/resources/"
 dict_ecat_v3 = "test_dict_ecat_eoe_v3.0.xdf"
 dict_ecat_v3_safe = "test_dict_ecat_eoe_safe_v3.0.xdf"
-SINGLE_AXIS_SAFETY_SUBNODES = {
-    0: SubnodeType.COMMUNICATION,
-    1: SubnodeType.MOTION,
-    4: SubnodeType.SAFETY,
-}
 
 
 @pytest.mark.no_connection
@@ -34,7 +28,6 @@ def test_read_dictionary():
         "part_number": "EVS-NET-E",
         "revision_number": 196617,
         "interface": Interface.ECAT,
-        "subnodes": SINGLE_AXIS_SAFETY_SUBNODES,
         "is_safe": True,
         "image": "image-text",
     }

--- a/tests/resources/canopen/test_dict_can_v3.0.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0.xdf
@@ -19,12 +19,8 @@
 		</Categories>
 		<Devices>
 			<CANDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-C" RevisionNumber="196617">
-				<Subnodes>
-					<Subnode index="0">Communication</Subnode>
-					<Subnode index="1">Motion</Subnode>
-				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -33,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -42,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1400" datatype="RECORD" subnode="0">
+					<CANopenObject index="0x1400" datatype="RECORD" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="CIA301_COMMS_RPDO1" cyclic="CONFIG" desc="" default="0300" cat_id="CIA402">
 								<Labels>
@@ -66,7 +62,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" datatype="RECORD" subnode="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD" axis="0" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -83,7 +79,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" axis="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>
@@ -101,7 +97,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2010" datatype="VAR" subnode="1">
+					<CANopenObject index="0x2010" datatype="VAR" axis="1">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="u16" id="DRV_STATE_CONTROL" cyclic="CYCLIC_RX" desc="Parameter to manage the drive state machine. It is compliant with DS402." units="none" default="0000" cat_id="TARGET">
                 <Labels>

--- a/tests/resources/canopen/test_dict_can_v3.0.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0.xdf
@@ -20,7 +20,7 @@
 		<Devices>
 			<CANDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-C" RevisionNumber="196617">
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" axis="0">
+					<CANopenObject index="0x580F" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -29,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
+					<CANopenObject index="0x58A0" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -38,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1400" datatype="RECORD" axis="0">
+					<CANopenObject index="0x1400" datatype="RECORD">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u8" id="CIA301_COMMS_RPDO1" cyclic="CONFIG" desc="" default="0300" cat_id="CIA402">
 								<Labels>
@@ -62,7 +62,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" datatype="RECORD" axis="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>

--- a/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
@@ -20,7 +20,7 @@
 		<Devices>
 			<CANDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-C" RevisionNumber="196617">
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" axis="0">
+					<CANopenObject index="0x580F" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -29,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
+					<CANopenObject index="0x58A0" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -38,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" axis="0" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>

--- a/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
+++ b/tests/resources/canopen/test_dict_can_v3.0_axis.xdf
@@ -19,13 +19,8 @@
 		</Categories>
 		<Devices>
 			<CANDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-C" RevisionNumber="196617">
-				<Subnodes>
-					<Subnode index="0">Communication</Subnode>
-					<Subnode index="1">Motion</Subnode>
-					<Subnode index="2">Motion</Subnode>
-				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -34,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -43,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" subnode="0" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" axis="0" datatype="RECORD" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -60,7 +55,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" axis="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>
@@ -78,7 +73,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" datatype="VAR" subnode="2">
+					<CANopenObject index="0x2151" datatype="VAR" axis="2">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>

--- a/tests/resources/test_dict_ecat_eoe_safe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_safe_v3.0.xdf
@@ -19,13 +19,8 @@
     </Categories>
     <Devices>
       <ECATDevice firmwareVersion="2.4.1" ProductCode="58790914" PartNumber="DEN-S-NET-E" RevisionNumber="327689">
-        <Subnodes>
-          <Subnode index="0">Communication</Subnode>
-          <Subnode index="1">Motion</Subnode>
-          <Subnode index="4">Safety</Subnode>
-        </Subnodes>
         <CANopenObjects>
-          <CANopenObject index="0x580F" datatype="VAR" subnode="0">
+          <CANopenObject index="0x580F" datatype="VAR" axis="0">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" units="none" default="00000000" cat_id="REPORTING">
                 <Labels>
@@ -34,7 +29,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x5E49" datatype="VAR" subnode="0">
+          <CANopenObject index="0x5E49" datatype="VAR" axis="0">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_SYS_ERROR_LAST" cyclic="CYCLIC_TX" desc="Contains the last system generated error" units="none" default="00000000" cat_id="REPORTING">
                 <Labels>
@@ -48,7 +43,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x58A0" datatype="VAR" subnode="0">
+          <CANopenObject index="0x58A0" datatype="VAR" axis="0">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" cyclic="CONFIG" desc="" units="none" default="0100" cat_id="IDENTIFICATION">
                 <Labels>
@@ -57,7 +52,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x1600" datatype="RECORD" subnode="0">
+          <CANopenObject index="0x1600" datatype="RECORD" axis="0">
             <Subitems>
               <Subitem subindex="0" address_type="NVM" access="rw" dtype="u8" id="CIA301_COMMS_RPDO1_MAP" cyclic="CONFIG" desc="" units="none" default="01" cat_id="CIA402">
                 <Labels>
@@ -71,7 +66,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x2151" datatype="VAR" subnode="1">
+          <CANopenObject index="0x2151" datatype="VAR" axis="1">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" units="none" default="0400" cat_id="COMMUTATION">
                 <Labels>

--- a/tests/resources/test_dict_ecat_eoe_safe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_safe_v3.0.xdf
@@ -20,7 +20,7 @@
     <Devices>
       <ECATDevice firmwareVersion="2.4.1" ProductCode="58790914" PartNumber="DEN-S-NET-E" RevisionNumber="327689">
         <CANopenObjects>
-          <CANopenObject index="0x580F" datatype="VAR" axis="0">
+          <CANopenObject index="0x580F" datatype="VAR">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" units="none" default="00000000" cat_id="REPORTING">
                 <Labels>
@@ -29,7 +29,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x5E49" datatype="VAR" axis="0">
+          <CANopenObject index="0x5E49" datatype="VAR">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_SYS_ERROR_LAST" cyclic="CYCLIC_TX" desc="Contains the last system generated error" units="none" default="00000000" cat_id="REPORTING">
                 <Labels>
@@ -43,7 +43,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x58A0" datatype="VAR" axis="0">
+          <CANopenObject index="0x58A0" datatype="VAR">
             <Subitems>
               <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" cyclic="CONFIG" desc="" units="none" default="0100" cat_id="IDENTIFICATION">
                 <Labels>
@@ -52,7 +52,7 @@
               </Subitem>
             </Subitems>
           </CANopenObject>
-          <CANopenObject index="0x1600" datatype="RECORD" axis="0">
+          <CANopenObject index="0x1600" datatype="RECORD">
             <Subitems>
               <Subitem subindex="0" address_type="NVM" access="rw" dtype="u8" id="CIA301_COMMS_RPDO1_MAP" cyclic="CONFIG" desc="" units="none" default="01" cat_id="CIA402">
                 <Labels>

--- a/tests/resources/test_dict_ecat_eoe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_v3.0.xdf
@@ -19,13 +19,8 @@
 		</Categories>
 		<Devices>
 			<ECATDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-E" RevisionNumber="196617">
-				<Subnodes>
-					<Subnode index="0">Communication</Subnode>
-					<Subnode index="1">Motion</Subnode>
-					<Subnode index="4">Safety</Subnode>
-				</Subnodes>
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" subnode="0">
+					<CANopenObject index="0x580F" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -34,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x5E49" datatype="VAR" subnode="0">
+					<CANopenObject index="0x5E49" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="TEST_RXTX_REGISTER" cyclic="CYCLIC_RXTX" desc="Test RXTX register" default="00000000" cat_id="OTHERS">
 								<Labels>
@@ -43,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" subnode="0">
+					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -52,7 +47,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" datatype="RECORD"  subnode="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD"  axis="0" id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>
@@ -69,7 +64,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x2151" datatype="VAR" subnode="1">
+					<CANopenObject index="0x2151" datatype="VAR" axis="1">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_CFG" access="rw" dtype="u16" id="COMMU_ANGLE_SENSOR" cyclic="CONFIG" desc="Indicates the sensor used for angle readings" default="0400" cat_id="COMMUTATION">
 								<Labels>

--- a/tests/resources/test_dict_ecat_eoe_v3.0.xdf
+++ b/tests/resources/test_dict_ecat_eoe_v3.0.xdf
@@ -20,7 +20,7 @@
 		<Devices>
 			<ECATDevice firmwareVersion="2.4.1" ProductCode="61939713" PartNumber="EVS-NET-E" RevisionNumber="196617">
 				<CANopenObjects>
-					<CANopenObject index="0x580F" datatype="VAR" axis="0">
+					<CANopenObject index="0x580F" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="s32" id="DRV_DIAG_ERROR_LAST_COM" cyclic="CYCLIC_TX" desc="Contains the last generated error" default="00000000" cat_id="REPORTING">
 								<Labels>
@@ -29,7 +29,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x5E49" datatype="VAR" axis="0">
+					<CANopenObject index="0x5E49" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="rw" dtype="s32" id="TEST_RXTX_REGISTER" cyclic="CYCLIC_RXTX" desc="Test RXTX register" default="00000000" cat_id="OTHERS">
 								<Labels>
@@ -38,7 +38,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject>
-					<CANopenObject index="0x58A0" datatype="VAR" axis="0">
+					<CANopenObject index="0x58A0" datatype="VAR">
 						<Subitems>
 							<Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u16" id="DRV_AXIS_NUMBER" units="cnt" cyclic="CONFIG" desc="" default="0100" cat_id="IDENTIFICATION">
 								<Labels>
@@ -47,7 +47,7 @@
 							</Subitem>
 						</Subitems>
 					</CANopenObject >
-					<CANopenObject index="0x1600" datatype="RECORD"  axis="0" id="CIA301_COMMS_RPDO1_MAP">
+					<CANopenObject index="0x1600" datatype="RECORD"  id="CIA301_COMMS_RPDO1_MAP">
 						<Labels>
 							<Label lang="en_US">RPDO 1 mapping parameter</Label>
 						</Labels>


### PR DESCRIPTION
### Description

Remove subnode from ECAT/CAN devices in xdf v3. 

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [ ] Use axis from CanOpenObjects instead of subnode


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.
