### PR TITLE
Ingk 1111 xdf v 3 parser creates can open register instead of ethercat register for ethercat device

### DIFF
--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1244,7 +1244,7 @@ class DictionaryV3(Dictionary):
 
     def __read_canopen_subitem(
         self, subitem: ElementTree.Element, reg_index: int, subnode: int
-    ) -> CanopenRegister:
+    ) -> Union[CanopenRegister, EthercatRegister]:
         """Process Subitem element and add it to _registers.
 
         Args:
@@ -1259,7 +1259,7 @@ class DictionaryV3(Dictionary):
             ValueError: if Canopen/Ethercat register cannot be created for
                 the communication interface.
         """
-        reg_subindex = int(subitem.attrib[self.__SUBINDEX_ATTR])
+        reg_subindex: int = int(subitem.attrib[self.__SUBINDEX_ATTR])
         address_type = Dictionary._get_address_type_xdf_options(
             subitem.attrib[self.__ADDRESS_TYPE_ATTR]
         )
@@ -1291,36 +1291,37 @@ class DictionaryV3(Dictionary):
         bitfields_element = subitem.find(self.__BITFIELDS_ELEMENT)
         bitfields = self.__read_bitfields(bitfields_element)
 
-        register_kwargs = {
-            "idx": reg_index,
-            "subidx": reg_subindex,
-            "dtype": dtype,
-            "access": access,
-            "identifier": identifier,
-            "units": units,
-            "pdo_access": pdo_access,
-            "subnode": subnode,
-            "reg_range": reg_range,
-            "labels": labels,
-            "enums": enums,
-            "cat_id": cat_id,
-            "address_type": address_type,
-            "description": description,
-            "default": default,
-            "bitfields": bitfields,
-            "monitoring": monitoring,
-            "is_node_id_dependent": is_node_id_dependent,
-        }
-
         if self.interface == Interface.CAN:
-            canopen_register = CanopenRegister(**register_kwargs)
-            self.__add_register(register=canopen_register, axis=subnode)
-            return canopen_register
+            register_instance = CanopenRegister
         elif self.interface == Interface.ECAT:
-            ethercat_register = EthercatRegister(**register_kwargs)
-            self.__add_register(register=ethercat_register, axis=subnode)
-            return ethercat_register
-        raise ValueError(f"Cannot create Canopen/Ethercat register for interface {self.interface}")
+            register_instance = EthercatRegister
+        else:
+            raise ValueError(
+                f"Cannot create Canopen/Ethercat register for interface {self.interface}"
+            )
+
+        reg = register_instance(
+            idx=reg_index,
+            subidx=reg_subindex,
+            dtype=dtype,
+            access=access,
+            identifier=identifier,
+            units=units,
+            pdo_access=pdo_access,
+            subnode=subnode,
+            reg_range=reg_range,
+            labels=labels,
+            enums=enums,
+            cat_id=cat_id,
+            address_type=address_type,
+            description=description,
+            default=default,
+            bitfields=bitfields,
+            monitoring=monitoring,
+            is_node_id_dependent=is_node_id_dependent,
+        )
+        self.__add_register(register=reg, axis=subnode)
+        return reg
 
     def __read_safety_pdos(self, root: ElementTree.Element) -> None:
         """Process SafetyPDOs element.

--- a/tests/canopen/test_canopen_dictionary_v3.py
+++ b/tests/canopen/test_canopen_dictionary_v3.py
@@ -63,7 +63,10 @@ def test_read_dictionary_registers():
     canopen_dict = DictionaryV3(dictionary_path, Interface.CAN)
 
     for subnode in expected_regs_per_subnode:
-        assert expected_regs_per_subnode[subnode] == list(canopen_dict.registers(subnode))
+        subnode_registers = canopen_dict.registers(subnode)
+        assert expected_regs_per_subnode[subnode] == list(subnode_registers)
+        for reg in subnode_registers.values():
+            assert isinstance(reg, CanopenRegister)
 
 
 @pytest.mark.no_connection

--- a/tests/ethercat/test_ethercat_dictionary_v3.py
+++ b/tests/ethercat/test_ethercat_dictionary_v3.py
@@ -10,6 +10,7 @@ from ingenialink.dictionary import (
     DictionaryV3,
     Interface,
 )
+from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.exceptions import ILDictionaryParseError
 
 path_resources = "./tests/resources/"
@@ -63,7 +64,10 @@ def test_read_dictionary_registers():
     ethercat_dict = DictionaryV3(dictionary_path, Interface.ECAT)
 
     for subnode in expected_regs_per_subnode:
-        assert expected_regs_per_subnode[subnode] == list(ethercat_dict.registers(subnode))
+        subnode_registers = ethercat_dict.registers(subnode)
+        assert expected_regs_per_subnode[subnode] == list(subnode_registers)
+        for reg in subnode_registers.values():
+            assert isinstance(reg, EthercatRegister)
 
 
 @pytest.mark.no_connection


### PR DESCRIPTION
### Description

Create ECAT register for ECAT device.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] ecat xdf v3 parses an ecat register instead of canopen register

### Tests
- [X] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [X] Set fix version field in the Jira issue.
