### PR TITLE
INGM-637 added phase I safety registers to xdfv2

### DIFF
--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -77,7 +77,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="MDP_CONFIGURED_MODULE_1",
@@ -94,7 +94,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_TIME_TO_STO_1",
@@ -103,7 +103,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP256_TOTAL",
@@ -129,7 +129,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_1",
@@ -139,7 +139,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SAFE_INPUTS_VALUE",
@@ -149,7 +149,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
         ]
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -77,6 +77,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="MDP_CONFIGURED_MODULE_1",
@@ -93,6 +94,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_TIME_TO_STO_1",
@@ -101,6 +103,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP256_TOTAL",
@@ -126,6 +129,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_1",
@@ -135,6 +139,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SAFE_INPUTS_VALUE",
@@ -144,6 +149,7 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
         ]
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -118,6 +118,33 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
                 access=RegAccess.RO,  # XDF V2 only supports phase I, where the pdo map is read-only
                 subnode=1,
             ),
+            EthercatRegister(
+                identifier="FSOE_STO",
+                idx=0x6640,
+                subidx=0,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
+                subnode=1,
+            ),
+            EthercatRegister(
+                identifier="FSOE_SS1_1",
+                idx=0x6650,
+                subidx=1,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
+                subnode=1,
+            ),
+            EthercatRegister(
+                identifier="FSOE_SAFE_INPUTS_VALUE",
+                idx=0x46D1,
+                subidx=0,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT,
+                subnode=1,
+            ),
         ]
 
     @cached_property

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -72,7 +72,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="MDP_CONFIGURED_MODULE_1",
@@ -89,7 +89,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_TIME_TO_STO_1",
@@ -98,7 +98,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP256_TOTAL",
@@ -124,7 +124,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_1",
@@ -134,7 +134,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SAFE_INPUTS_VALUE",
@@ -144,7 +144,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT,
                 subnode=1,
-                cat_id="FSOE"
+                cat_id="FSOE",
             ),
         ]
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -72,6 +72,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="MDP_CONFIGURED_MODULE_1",
@@ -88,6 +89,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_TIME_TO_STO_1",
@@ -96,6 +98,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP256_TOTAL",
@@ -111,7 +114,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 subidx=0,
                 dtype=RegDtype.U8,
                 access=RegAccess.RO,  # XDF V2 only supports phase I, where the pdo map is read-only
-                subnode=0,
+                subnode=1,
             ),
             EthercatRegister(
                 identifier="FSOE_STO",
@@ -121,6 +124,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_1",
@@ -130,6 +134,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
             EthercatRegister(
                 identifier="FSOE_SAFE_INPUTS_VALUE",
@@ -139,6 +144,7 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,
                 pdo_access=RegCyclicType.SAFETY_INPUT,
                 subnode=1,
+                cat_id="FSOE"
             ),
         ]
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -113,6 +113,33 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
                 access=RegAccess.RO,  # XDF V2 only supports phase I, where the pdo map is read-only
                 subnode=0,
             ),
+            EthercatRegister(
+                identifier="FSOE_STO",
+                idx=0x6640,
+                subidx=0,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
+                subnode=1,
+            ),
+            EthercatRegister(
+                identifier="FSOE_SS1_1",
+                idx=0x6650,
+                subidx=1,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT_OUTPUT,
+                subnode=1,
+            ),
+            EthercatRegister(
+                identifier="FSOE_SAFE_INPUTS_VALUE",
+                idx=0x46D1,
+                subidx=0,
+                dtype=RegDtype.BOOL,
+                access=RegAccess.RO,
+                pdo_access=RegCyclicType.SAFETY_INPUT,
+                subnode=1,
+            ),
         ]
 
     @cached_property


### PR DESCRIPTION
### Description

Added more information of registers for safety on the hardcoded values of xdf v2. Makes the ingeniamotion fsoe dictionary reader simpler here:
https://github.com/ingeniamc/ingeniamotion/pull/361/files#diff-1322868ebcf8a78a9cd8d609b9883745df286cb31e9dc223971f5d183b538701R527

All registers are from phase I, and are still valid for phase II. For phase II we will not continue to increase these hard coded values.

### Type of change

Please add a description and delete options that are not relevant.

- [x] Add more fsoe register information

### Tests
- [x] Run together with tests of IM on PR

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
