### PR TITLE
Ingk 1128 safety registers for eo e have the wrong type

### DIFF
--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -81,4 +81,4 @@ def __getattr__(name: str) -> Any:
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
 
 
-__version__ = "7.4.2"
+__version__ = "7.4.3"

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1586,7 +1586,6 @@ class DictionaryV2(Dictionary):
             logger.error(f"Dictionary {Path(self.path).name} has no image section.")
         # Closing xdf file
         xdf_file.close()
-        self._append_missing_safety_modules()
         self._append_missing_registers()
 
     def _read_xdf_register(self, register: ElementTree.Element) -> Optional[Register]:
@@ -1699,17 +1698,6 @@ class DictionaryV2(Dictionary):
             return
         self._registers[subnode][identifier] = register
 
-    def _append_missing_safety_modules(self) -> None:
-        """Append  missing safety modules to the dictionary.
-
-        It will also create the safety subnode and initialize safe registers.
-        """
-        if not self.is_safe and self.part_number not in ["DEN-S-NET-E", "EVS-S-NET-E"]:
-            return
-        self.is_safe = True
-        for safety_submodule in self._safety_modules:
-            self.safety_modules[safety_submodule.module_ident] = safety_submodule
-
     def _append_missing_registers(
         self,
     ) -> None:
@@ -1722,11 +1710,3 @@ class DictionaryV2(Dictionary):
             for register in self._monitoring_disturbance_registers:
                 if register.identifier is not None:
                     self._registers[register.subnode][register.identifier] = register
-
-        if not self.is_safe:
-            return
-
-        # Append safety registers
-        for register in self._safety_registers:
-            if register.identifier is not None:
-                self._registers[register.subnode][register.identifier] = register

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -271,3 +271,11 @@ class EthercatDictionaryV2(DictionaryV2):
         for register in self.__pdo_registers:
             if register.identifier is not None:
                 self._registers[register.subnode][register.identifier] = register
+        if self.part_number not in ["DEN-S-NET-E", "EVS-S-NET-E"]:
+            return
+        self.is_safe = True
+        for safety_submodule in self._safety_modules:
+            self.safety_modules[safety_submodule.module_ident] = safety_submodule
+        for register in self._safety_registers:
+            if register.identifier is not None:
+                self._registers[register.subnode][register.identifier] = register

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -45,68 +45,13 @@ class EthernetDictionaryV2(DictionaryV2):
             ),
         ]
 
-    @cached_property
+    @property
     def _safety_registers(self) -> list[EthercatRegister]:
-        return [
-            EthercatRegister(
-                identifier="FSOE_TOTAL_ERROR",
-                idx=0x4193,
-                subidx=0x00,
-                dtype=RegDtype.U16,
-                access=RegAccess.RW,
-                subnode=0,
-            ),
-            EthercatRegister(
-                identifier="MDP_CONFIGURED_MODULE_1",
-                idx=0xF030,
-                subidx=0x01,
-                dtype=RegDtype.U32,
-                access=RegAccess.RW,
-                subnode=0,
-            ),
-            EthercatRegister(
-                identifier="FSOE_SAFE_INPUTS_MAP",
-                idx=0x46D2,
-                subidx=0x00,
-                dtype=RegDtype.U16,
-                access=RegAccess.RW,
-                subnode=0,
-            ),
-            EthercatRegister(
-                identifier="FSOE_SS1_TIME_TO_STO_1",
-                idx=0x6651,
-                subidx=0x01,
-                dtype=RegDtype.U16,
-                access=RegAccess.RW,
-                subnode=0,
-            ),
-        ]
+        raise NotImplementedError("Safety registers are not implemented for this device.")
 
-    @cached_property
+    @property
     def _safety_modules(self) -> list[DictionarySafetyModule]:
-        def __module_ident(module_idx: int) -> int:
-            if self.product_code is None:
-                raise ValueError("Module ident cannot be calculated, product code missing.")
-            return (self.product_code & 0x7F00000) + module_idx
-
-        return [
-            DictionarySafetyModule(
-                uses_sra=False,
-                module_ident=__module_ident(0),
-                application_parameters=[
-                    DictionarySafetyModule.ApplicationParameter(uid="FSOE_SAFE_INPUTS_MAP"),
-                    DictionarySafetyModule.ApplicationParameter(uid="FSOE_SS1_TIME_TO_STO_1"),
-                ],
-            ),
-            DictionarySafetyModule(
-                uses_sra=True,
-                module_ident=__module_ident(1),
-                application_parameters=[
-                    DictionarySafetyModule.ApplicationParameter(uid="FSOE_SAFE_INPUTS_MAP"),
-                    DictionarySafetyModule.ApplicationParameter(uid="FSOE_SS1_TIME_TO_STO_1"),
-                ],
-            ),
-        ]
+        raise NotImplementedError("Safety modules are not implemented for this device.")
 
     def _read_xdf_register(self, register: ElementTree.Element) -> Optional[EthernetRegister]:
         current_read_register = super()._read_xdf_register(register)


### PR DESCRIPTION
### Description

Safety registers are not accessible via EoE. 

### Type of change

- Remove safety registers/modules from the EthernetDictionaryV2.
- Only append safety register modules to EthercatDictionaryV2 dictionaries.


### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [x] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
