### PR TITLE
INGK-1129 Add the unknown frame received error message

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -80,6 +80,7 @@ class EthercatServo(PDOServo):
     NO_RESPONSE_WORKING_COUNTER = 0
     TIMEOUT_WORKING_COUNTER = -5
     NOFRAME_WORKING_COUNTER = -1
+    UNKNOWN_FRAME_WORKING_COUNTER = -2
 
     ETHERCAT_PDO_WATCHDOG = "processdata"
     SECONDS_TO_MS_CONVERSION_FACTOR = 1000
@@ -265,8 +266,9 @@ class EthercatServo(PDOServo):
                 self.NO_RESPONSE_WORKING_COUNTER: "The working counter remained unchanged.",
                 self.NOFRAME_WORKING_COUNTER: "No frame.",
                 self.TIMEOUT_WORKING_COUNTER: "Timeout.",
+                self.UNKNOWN_FRAME_WORKING_COUNTER: "Unknown frame received.",
             }
-            reason = wkc_errors[exception.wkc]
+            reason = wkc_errors.get(exception.wkc, f"Working counter: {exception.wkc}")
         elif isinstance(exception, (pysoem.SdoError, pysoem.MailboxError, pysoem.PacketError)):
             reason = f"{type(exception).__name__}: Slave {exception.slave_pos}, "
             if isinstance(exception, pysoem.SdoError):


### PR DESCRIPTION
### Description

On rare occasions, the EtherCAT master may receive an unexpected frame. This scenario was not considered in the working counter error dictionary.

### Type of change

- Add the unknown frame received error message.
- Add a default working counter error message.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
