### PR TITLE
Ingk 1130 fix hardcoded registers information

### DIFF
--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -27,21 +27,27 @@ class CanopenDictionaryV2(DictionaryV2):
         return [
             CanopenRegister(
                 identifier="MON_DATA_VALUE",
+                units="",
                 idx=0x58B2,
                 subidx=0x00,
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.RO,
                 subnode=0,
+                labels={"en_US": "Monitoring data"},
+                cat_id="MONITORING",
             ),
             CanopenRegister(
                 identifier="DIST_DATA_VALUE",
+                units="",
                 idx=0x58B4,
                 subidx=0x00,
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.WO,
                 subnode=0,
+                labels={"en_US": "Disturbance data"},
+                cat_id="MONITORING",
             ),
         ]
 

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -27,7 +27,7 @@ class CanopenDictionaryV2(DictionaryV2):
         return [
             CanopenRegister(
                 identifier="MON_DATA_VALUE",
-                units="",
+                units="none",
                 idx=0x58B2,
                 subidx=0x00,
                 cyclic=RegCyclicType.CONFIG,
@@ -39,7 +39,7 @@ class CanopenDictionaryV2(DictionaryV2):
             ),
             CanopenRegister(
                 identifier="DIST_DATA_VALUE",
-                units="",
+                units="none",
                 idx=0x58B4,
                 subidx=0x00,
                 cyclic=RegCyclicType.CONFIG,

--- a/ingenialink/canopen/register.py
+++ b/ingenialink/canopen/register.py
@@ -63,7 +63,7 @@ class CanopenRegister(Register):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[RegAddressType] = None,
+        address_type: Optional[RegAddressType] = RegAddressType.NVM_NONE,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[dict[str, BitField]] = None,

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1696,6 +1696,12 @@ class DictionaryV2(Dictionary):
         subnode = register.subnode
         if identifier is None:
             return
+        # Check category
+        register.cat_id = register.cat_id or "UNCATEGORIZED"
+        category = register.cat_id
+        if category not in self.categories.category_ids:
+            self.categories._cat_ids.append(category)
+            self.categories._categories[category] = {"en_US": category.capitalize()}
         self._registers[subnode][identifier] = register
 
     def _append_missing_registers(
@@ -1708,17 +1714,4 @@ class DictionaryV2(Dictionary):
         """
         if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
             for register in self._monitoring_disturbance_registers:
-                if register.identifier is not None:
-                    if register.cat_id not in self.categories.category_ids:
-                        self._append_missing_category(register.cat_id)
-                    self._registers[register.subnode][register.identifier] = register
-
-    def _append_missing_category(self, new_category: Optional[str]) -> None:
-        """Append missing register category to the categories dictionary.
-
-        Args:
-            new_category: New category name
-        """
-        new_category = new_category or "UNCATEGORIZED"
-        self.categories._cat_ids.append(new_category)
-        self.categories._categories[new_category] = {"en_US": new_category.capitalize()}
+                self._add_register_list(register)

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1709,4 +1709,16 @@ class DictionaryV2(Dictionary):
         if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
             for register in self._monitoring_disturbance_registers:
                 if register.identifier is not None:
+                    if register.cat_id not in self.categories.category_ids:
+                        self._append_missing_category(register.cat_id)
                     self._registers[register.subnode][register.identifier] = register
+
+    def _append_missing_category(self, new_category: Optional[str]) -> None:
+        """Append missing register category to the categories dictionary.
+
+        Args:
+            new_category: New category name
+        """
+        new_category = new_category or "UNCATEGORIZED"
+        self.categories._cat_ids.append(new_category)
+        self.categories._categories[new_category] = {"en_US": new_category.capitalize()}

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -105,6 +105,7 @@ class EthercatDictionaryV2(DictionaryV2):
                 access=RegAccess.RW,
                 subnode=0,
                 labels={"en_US": "SS1 Time to STO"},
+                cat_id="FSOE",
             ),
         ]
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -36,7 +36,7 @@ class EthercatDictionaryV2(DictionaryV2):
         return [
             EthercatRegister(
                 identifier="MON_DATA_VALUE",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x58B2,
                 subidx=0x01,
@@ -48,7 +48,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="DIST_DATA_VALUE",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x58B4,
                 subidx=0x01,
@@ -153,7 +153,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_ASSIGN_1",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1C12,
                 subidx=0x01,
@@ -166,7 +166,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP1_TOTAL",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1600,
                 subidx=0x00,
@@ -179,7 +179,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP1_1",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1600,
                 subidx=0x01,
@@ -192,7 +192,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_ASSIGN_TOTAL",
-                units="",
+                units="cnt",
                 subnode=0,
                 idx=0x1C13,
                 subidx=0x00,
@@ -205,7 +205,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_ASSIGN_1",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1C13,
                 subidx=0x01,
@@ -218,7 +218,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_MAP1_TOTAL",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1A00,
                 subidx=0x00,
@@ -231,7 +231,7 @@ class EthercatDictionaryV2(DictionaryV2):
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_MAP1_1",
-                units="",
+                units="none",
                 subnode=0,
                 idx=0x1A00,
                 subidx=0x01,

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -43,6 +43,8 @@ class EthercatDictionaryV2(DictionaryV2):
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.RO,
+                labels={"en_US": "Monitoring data"},
+                cat_id="MONITORING",
             ),
             EthercatRegister(
                 identifier="DIST_DATA_VALUE",
@@ -53,6 +55,8 @@ class EthercatDictionaryV2(DictionaryV2):
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.WO,
+                labels={"en_US": "Disturbance data"},
+                cat_id="MONITORING",
             ),
         ]
 
@@ -60,36 +64,48 @@ class EthercatDictionaryV2(DictionaryV2):
     def _safety_registers(self) -> list[EthercatRegister]:
         return [
             EthercatRegister(
-                identifier="FSOE_TOTAL_ERROR",
+                identifier="FSOE_MANUF_SAFETY_ADDRESS",
                 idx=0x4193,
                 subidx=0x00,
+                cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
-                subnode=0,
+                subnode=1,
+                labels={"en_US": "Safety address"},
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="MDP_CONFIGURED_MODULE_1",
                 idx=0xF030,
                 subidx=0x01,
+                cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.U32,
                 access=RegAccess.RW,
                 subnode=0,
+                labels={"en_US": "Configured module ident of the module 1"},
+                cat_id="MDP",
             ),
             EthercatRegister(
                 identifier="FSOE_SAFE_INPUTS_MAP",
                 idx=0x46D2,
                 subidx=0x00,
+                cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=0,
+                labels={"en_US": "Safe Inputs Map"},
+                cat_id="FSOE",
             ),
             EthercatRegister(
                 identifier="FSOE_SS1_TIME_TO_STO_1",
                 idx=0x6651,
                 subidx=0x01,
+                cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 subnode=0,
+                labels={"en_US": "SS1 Time to STO"},
+                cat_id="FSOE",
             ),
         ]
 
@@ -124,13 +140,16 @@ class EthercatDictionaryV2(DictionaryV2):
         return [
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_ASSIGN_TOTAL",
-                units="",
+                units="cnt",
                 subnode=0,
                 idx=0x1C12,
                 subidx=0x00,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U8,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "SubIndex 000"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_ASSIGN_1",
@@ -138,9 +157,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1C12,
                 subidx=0x01,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "RxPDO assign Element 1"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP1_TOTAL",
@@ -148,9 +170,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1600,
                 subidx=0x00,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U8,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "Subindex 000"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_RPDO_MAP1_1",
@@ -158,9 +183,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1600,
                 subidx=0x01,
-                dtype=RegDtype.STR,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U32,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "RxPDO Map 1 Element 1"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_ASSIGN_TOTAL",
@@ -168,9 +196,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1C13,
                 subidx=0x00,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U8,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "SubIndex 000"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_ASSIGN_1",
@@ -178,9 +209,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1C13,
                 subidx=0x01,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U16,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "TxPDO assign Element 1"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_MAP1_TOTAL",
@@ -188,9 +222,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1A00,
                 subidx=0x00,
-                dtype=RegDtype.S32,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U8,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "Subindex 000"},
+                cat_id="COMMUNICATIONS",
             ),
             EthercatRegister(
                 identifier="ETG_COMMS_TPDO_MAP1_1",
@@ -198,9 +235,12 @@ class EthercatDictionaryV2(DictionaryV2):
                 subnode=0,
                 idx=0x1A00,
                 subidx=0x01,
-                dtype=RegDtype.STR,
+                cyclic=RegCyclicType.CONFIG,
+                dtype=RegDtype.U32,
                 access=RegAccess.RW,
                 address_type=RegAddressType.NVM_NONE,
+                labels={"en_US": "TxPDO Map 1 Element 1"},
+                cat_id="COMMUNICATIONS",
             ),
         ]
 
@@ -270,6 +310,8 @@ class EthercatDictionaryV2(DictionaryV2):
         super()._append_missing_registers()
         for register in self.__pdo_registers:
             if register.identifier is not None:
+                if register.cat_id not in self.categories.category_ids:
+                    self._append_missing_category(register.cat_id)
                 self._registers[register.subnode][register.identifier] = register
         if self.part_number not in ["DEN-S-NET-E", "EVS-S-NET-E"]:
             return
@@ -278,4 +320,6 @@ class EthercatDictionaryV2(DictionaryV2):
             self.safety_modules[safety_submodule.module_ident] = safety_submodule
         for register in self._safety_registers:
             if register.identifier is not None:
+                if register.cat_id not in self.categories.category_ids:
+                    self._append_missing_category(register.cat_id)
                 self._registers[register.subnode][register.identifier] = register

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -105,7 +105,6 @@ class EthercatDictionaryV2(DictionaryV2):
                 access=RegAccess.RW,
                 subnode=0,
                 labels={"en_US": "SS1 Time to STO"},
-                cat_id="FSOE",
             ),
         ]
 
@@ -309,17 +308,11 @@ class EthercatDictionaryV2(DictionaryV2):
         """
         super()._append_missing_registers()
         for register in self.__pdo_registers:
-            if register.identifier is not None:
-                if register.cat_id not in self.categories.category_ids:
-                    self._append_missing_category(register.cat_id)
-                self._registers[register.subnode][register.identifier] = register
+            self._add_register_list(register)
         if self.part_number not in ["DEN-S-NET-E", "EVS-S-NET-E"]:
             return
         self.is_safe = True
         for safety_submodule in self._safety_modules:
             self.safety_modules[safety_submodule.module_ident] = safety_submodule
         for register in self._safety_registers:
-            if register.identifier is not None:
-                if register.cat_id not in self.categories.category_ids:
-                    self._append_missing_category(register.cat_id)
-                self._registers[register.subnode][register.identifier] = register
+            self._add_register_list(register)

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -33,6 +33,8 @@ class EthernetDictionaryV2(DictionaryV2):
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.RO,
+                labels={"en_US": "Monitoring data"},
+                cat_id="MONITORING",
             ),
             EthernetRegister(
                 identifier="DIST_DATA_VALUE",
@@ -42,6 +44,8 @@ class EthernetDictionaryV2(DictionaryV2):
                 cyclic=RegCyclicType.CONFIG,
                 dtype=RegDtype.BYTE_ARRAY_512,
                 access=RegAccess.WO,
+                labels={"en_US": "Disturbance data"},
+                cat_id="MONITORING",
             ),
         ]
 

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -27,7 +27,7 @@ class EthernetDictionaryV2(DictionaryV2):
         return [
             EthernetRegister(
                 identifier="MON_DATA_VALUE",
-                units="",
+                units="none",
                 subnode=0,
                 address=0x00B2,
                 cyclic=RegCyclicType.CONFIG,
@@ -38,7 +38,7 @@ class EthernetDictionaryV2(DictionaryV2):
             ),
             EthernetRegister(
                 identifier="DIST_DATA_VALUE",
-                units="",
+                units="none",
                 subnode=0,
                 address=0x00B4,
                 cyclic=RegCyclicType.CONFIG,

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -63,7 +63,7 @@ class EthernetRegister(Register):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[RegAddressType] = None,
+        address_type: Optional[RegAddressType] = RegAddressType.NVM_NONE,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[dict[str, BitField]] = None,

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -242,6 +242,11 @@ class Register(ABC):
         """Category ID."""
         return self._cat_id
 
+    @cat_id.setter
+    def cat_id(self, category: str) -> Optional[str]:
+        """Category ID."""
+        self._cat_id = category
+
     @property
     def scat_id(self) -> Optional[str]:
         """Sub-Category ID."""

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -73,7 +73,7 @@ class Register(ABC):
         cat_id: Optional[str] = None,
         scat_id: Optional[str] = None,
         internal_use: int = 0,
-        address_type: Optional[RegAddressType] = None,
+        address_type: Optional[RegAddressType] = RegAddressType.NVM_NONE,
         description: Optional[str] = None,
         default: Optional[bytes] = None,
         bitfields: Optional[dict[str, BitField]] = None,

--- a/ingenialink/register.py
+++ b/ingenialink/register.py
@@ -243,7 +243,7 @@ class Register(ABC):
         return self._cat_id
 
     @cat_id.setter
-    def cat_id(self, category: str) -> Optional[str]:
+    def cat_id(self, category: str) -> None:
         """Category ID."""
         self._cat_id = category
 

--- a/tests/ethercat/test_ethercat_dictionary_v2.py
+++ b/tests/ethercat/test_ethercat_dictionary_v2.py
@@ -98,6 +98,7 @@ def test_read_dictionary_categories():
         "COMMUNICATIONS",
         "REPORTING",
         "MONITORING",
+        "TARGET",
     ]
     dictionary_path = join_path(path_resources, "test_dict_ethercat.xdf")
 


### PR DESCRIPTION
### Description

The hardcoded Monitoring, Safety and PDO registers have some missing or wrong information.

This change relates also to this one:
https://github.com/ingeniamc/ingeniamotion/pull/364

Fixes # INGK-1130

### Type of change

- [x] Add missing information on hardcoded registers (category, label...)
- [x] Fix wrong information on hardcoded registers (type, units...)
- [x] Add function that appends missing categories 


### Tests

- [x] Run manual tests.

### Documentation

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
