### PR TITLE
INGM-637 change register mapping property to int

### DIFF
--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -164,14 +164,14 @@ class PDOMapItem:
         return value
 
     @property
-    def register_mapping(self) -> bytes:
+    def register_mapping(self) -> int:
         """Arrange register information into PDO mapping format.
 
         Returns:
             PDO register mapping format.
 
         """
-        mapped_register = BitField.set_bitfields(
+        return BitField.set_bitfields(
             self.__ITEM_BITFIELDS,
             {
                 self.__LENGTH_BITFIELD: self.size_bits,
@@ -179,9 +179,6 @@ class PDOMapItem:
                 self.__INDEX_BITFIELD: self.register.idx,
             },
         )
-
-        mapped_register_bytes: bytes = mapped_register.to_bytes(MAP_REGISTER_BYTES, BIT_ENDIAN)
-        return mapped_register_bytes
 
     @classmethod
     def from_register_mapping(cls, mapping: int, dictionary: "CanopenDictionary") -> "PDOMapItem":
@@ -417,7 +414,7 @@ class PDOMap:
         """
         map_bytes = bytearray()
         for pdo_map_item in self.items:
-            map_bytes += pdo_map_item.register_mapping
+            map_bytes += pdo_map_item.register_mapping.to_bytes(MAP_REGISTER_BYTES, BIT_ENDIAN)
         return map_bytes
 
     def to_pdo_value(self) -> bytes:

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -134,7 +134,8 @@ def test_pdo_item_register_mapping(open_dictionary, uid, expected_value):
     ethercat_dictionary = open_dictionary
     register = ethercat_dictionary.registers(1)[uid]
     tpdo_item = TPDOMapItem(register)
-    assert expected_value.to_bytes(4, "little") == tpdo_item.register_mapping
+
+    assert expected_value == tpdo_item.register_mapping
 
 
 @pytest.mark.no_connection


### PR DESCRIPTION
### Description

Needed the integer value of the register mapping value for: https://github.com/ingeniamc/ingeniamotion/pull/366/files
But IL was providing it on bytes only. Since I have not found little usage of it I have moved the conversion to the complete pdo map value calculation, which is the only place where it really does make sense.

Fixes INGM-637

### Type of change

Please add a description and delete options that are not relevant.

- [x] Change PDOItem.register_mapping from bytes to int
- [x] Adapted usage and tests

### Tests
- [x] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
