### PR TITLE
INGK-1136 moved build system from setup.py to pyproject.toml and build

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -9,10 +9,6 @@ omit = tests/*
 [paths]
 source =
     ingenialink
-    .tox/py39/Lib/site-packages/ingenialink
-    .tox/py310/Lib/site-packages/ingenialink
-    .tox/py311/Lib/site-packages/ingenialink
-    .tox/py312/Lib/site-packages/ingenialink
 
 ; Skip empty files
 [report]

--- a/.coveragerc
+++ b/.coveragerc
@@ -19,3 +19,4 @@ source =
 skip_empty = true
 omit =
     */__init__.py
+    */ingenialink/_version.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -9,6 +9,10 @@ omit = tests/*
 [paths]
 source =
     ingenialink
+    .tox/py39/Lib/site-packages/ingenialink
+    .tox/py310/Lib/site-packages/ingenialink
+    .tox/py311/Lib/site-packages/ingenialink
+    .tox/py312/Lib/site-packages/ingenialink
 
 ; Skip empty files
 [report]

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ temp/*
 
 # tests setups
 tests/setups/tests_setup.py
+
+# Version
+ingenialink/_version.py

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,23 +230,25 @@ pipeline {
                             image PUBLISHER_DOCKER_IMAGE
                         }
                     }
-                    stage('Unstash')
-                    {
-                        steps {
-                            unstash 'wheels'
+                    stages {
+                        stage('Unstash')
+                        {
+                            steps {
+                                unstash 'wheels'
+                            }
                         }
-                    }
-                    stage('Publish Ingenia PyPi') {
-                        steps {
-                            publishIngeniaPyPi('dist/*')
+                        stage('Publish Ingenia PyPi') {
+                            steps {
+                                publishIngeniaPyPi('dist/*')
+                            }
                         }
-                    }
-                    stage('Publish PyPi') {
-                        when {
-                            branch 'master'
-                        }
-                        steps {
-                            publishPyPi('dist/*')
+                        stage('Publish PyPi') {
+                            when {
+                                branch 'master'
+                            }
+                            steps {
+                                publishPyPi('dist/*')
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,8 +221,8 @@ pipeline {
                                     pythonVersions.each { version ->
                                         bat """
                                             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
-                                            py -${DEFAULT_PYTHON_VERSION} -m tox -e build
-                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i /y
+                                            py -${version} -m tox -e build
+                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i
                                         """
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,8 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-def LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:1.5"
-def WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.6"
+LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:1.5"
+WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.6"
 def PUBLISHER_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/publisher:1.8"
 
 DEFAULT_PYTHON_VERSION = "3.9"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
                                         bat """
                                             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
                                             py -${version} -m tox -e build
-                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i
+                                            echo N | XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i /-Y
                                         """
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,16 @@ def getImageForPlatform(String platform) {
     }
 }
 
+def getArgsForPlatform(String platform) {
+    if (platform == 'windows') {
+        return ''
+    } else if (platform == 'linux') {
+        return '-u root:root'
+    } else {
+        throw new Exception('Unknown platform')
+    }
+}
+
 LINUX_PYTHON_PATH = ['3.9' : '/opt/python/cp39-cp39/bin', '3.10': '/opt/python/cp310-cp310/bin',
                      '3.11': '/opt/python/cp311-cp311/bin', '3.12': '/opt/python/cp312-cp312/bin']
 
@@ -218,6 +228,7 @@ pipeline {
                             docker {
                                 label getAgentForPlatform(env.PLATFORM)
                                 image getImageForPlatform(env.PLATFORM)
+                                args getArgsForPlatform(env.PLATFORM)
                             }
                         }
                         environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -498,7 +498,7 @@ pipeline {
 
                     bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
                     bat "py -3.9 -m coverage combine ${coverage_files}"
-                    bat "py -3.9 -m coverage coverage xml --include='*/ingenialink/*'"
+                    bat "py -3.9 -m coverage xml --include='*/ingenialink/*'"
                 }
                 recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
                 archiveArtifacts artifacts: '*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-LIN_DOCKER_IMAGE = "quay.io/pypa/manylinux2014_x86_64:2024.07.02-0"
+LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:1.5"
 WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.6"
 def PUBLISHER_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/publisher:1.8"
 
@@ -71,13 +71,10 @@ def getArgsForPlatform(String platform) {
     }
 }
 
-LINUX_PYTHON_PATH = ['3.9' : '/opt/python/cp39-cp39/bin', '3.10': '/opt/python/cp310-cp310/bin',
-                     '3.11': '/opt/python/cp311-cp311/bin', '3.12': '/opt/python/cp312-cp312/bin']
-
 
 def python(String command) {
     if (isUnix()) {
-        sh "${LINUX_PYTHON_PATH[env.PYTHON_BUILD_VERSION]}/python ${command}"
+        sh "python${env.PYTHON_BUILD_VERSION} ${command}"
     } else {
         bat """
             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
@@ -262,21 +259,6 @@ pipeline {
                                             }
                                         }
                                     }
-                                }
-                                post {
-                                    always {
-                                        reassignFilePermissions()
-                                    }
-                                }
-                            }
-
-                            stage('Repair Linux Wheel') {
-                                when {
-                                    environment name: 'PLATFORM', value: 'linux'
-                                }
-                                steps {
-                                    sh 'auditwheel repair dist/*.whl -w dist/'
-                                    sh "find dist -type f -not -name '*many*.whl' -delete"
                                 }
                                 post {
                                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -481,6 +481,9 @@ pipeline {
             }
         }
         stage('Publish coverage') {
+            options {
+                skipDefaultCheckout()
+            }
             agent {
                 docker {
                     label SW_NODE
@@ -489,6 +492,8 @@ pipeline {
             }
             steps {
                 script {
+                    cleanWs()
+
                     def coverage_files = ""
 
                     for (coverage_stash in coverage_stashes) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,15 +71,12 @@ def getArgsForPlatform(String platform) {
     }
 }
 
-LINUX_PYTHON_PATH = ['3.9' : '/opt/python/cp39-cp39/bin', '3.10': '/opt/python/cp310-cp310/bin',
-                     '3.11': '/opt/python/cp311-cp311/bin', '3.12': '/opt/python/cp312-cp312/bin']
-
 def python(String command) {
     if (isUnix()) {
-        sh "${LINUX_PYTHON_PATH[env.PYTHON_BUILD_VERSION]}/python ${command}"
+        sh "python${env.PYTHON_BUILD_VERSION} ${command}"
     } else {
         bat """
-            cd C:\\Users\\ContainerAdministrator\\fsoe_master_python
+            cd C:\\Users\\ContainerAdministrator\\ingenialink_python
             py -${env.PYTHON_BUILD_VERSION} ${command}
         """
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,7 @@ pipeline {
                                 expression { env.PLATFORM == 'windows' };
                             }
                             steps {
-                                python("-m tox -e docs"
+                                python("-m tox -e docs")
                                 bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
                                 stash includes: 'docs.zip', name: 'docs'
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,20 +223,31 @@ pipeline {
                         publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
                     }
                 }
-                stage('Publish to pypi') {
-                    when {
-                        beforeAgent true
-                        branch BRANCH_NAME_MASTER
-                    }
+                stage('Publish wheels') {
                     agent {
                         docker {
                             label 'worker'
                             image PUBLISHER_DOCKER_IMAGE
                         }
                     }
-                    steps {
-                        unstash 'wheels'
-                        publishPyPi("dist/*")
+                    stage('Unstash')
+                    {
+                        steps {
+                            unstash 'wheels'
+                        }
+                    }
+                    stage('Publish Ingenia PyPi') {
+                        steps {
+                            publishIngeniaPyPi('dist/*')
+                        }
+                    }
+                    stage('Publish PyPi') {
+                        when {
+                            branch 'master'
+                        }
+                        steps {
+                            publishPyPi('dist/*')
+                        }
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,16 +182,16 @@ pipeline {
                                 bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"
                             }
                         }
-                        // stage('Type checking') {
-                        //     steps {
-                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
-                        //     }
-                        // }
-                        // stage('Format checking') {
-                        //     steps {
-                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
-                        //     }
-                        // }
+                        stage('Type checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
+                            }
+                        }
+                        stage('Format checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
+                            }
+                        }
                         stage('Build') {
                             steps {
                                 script {
@@ -216,29 +216,29 @@ pipeline {
                                 stash includes: "dist\\*", name: 'wheels'
                             }
                         }
-                        // stage('Generate documentation') {
-                        //     steps {
-                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
-                        //         bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
-                        //         stash includes: 'docs.zip', name: 'docs'
-                        //     }
-                        // }
+                        stage('Generate documentation') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
+                                bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
+                                stash includes: 'docs.zip', name: 'docs'
+                            }
+                        }
                     }
                 }
-                // stage('Publish documentation') {
-                //     when {
-                //         beforeAgent true
-                //         branch BRANCH_NAME_MASTER
-                //     }
-                //     agent {
-                //         label 'worker'
-                //     }
-                //     steps {
-                //         unstash 'docs'
-                //         unzip zipFile: 'docs.zip', dir: '.'
-                //         publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
-                //     }
-                // }
+                stage('Publish documentation') {
+                    when {
+                        beforeAgent true
+                        branch BRANCH_NAME_MASTER
+                    }
+                    agent {
+                        label 'worker'
+                    }
+                    steps {
+                        unstash 'docs'
+                        unzip zipFile: 'docs.zip', dir: '.'
+                        publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
+                    }
+                }
                 stage('Publish wheels') {
                     agent {
                         docker {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -215,34 +215,7 @@ pipeline {
         }
 
         stage('Build') {
-            parallel {
-                stage('Type checking and Documentation') {
-                    agent {
-                        docker {
-                            label SW_NODE
-                            image WIN_DOCKER_IMAGE
-                        }
-                    }
-                    stages {
-                        stage('Type checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
-                            }
-                        }
-                        stage('Format checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
-                            }
-                        }
-                        stage('Generate documentation') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
-                                bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
-                                stash includes: 'docs.zip', name: 'docs'
-                            }
-                        }
-                    }
-                }
+            stages {
                 stage('Build') {
                     matrix {
                         axes {
@@ -320,8 +293,33 @@ pipeline {
                         }
                     }
                 }
-            }
-            stage ('Publish') {
+                stage('Type checking and Documentation') {
+                    agent {
+                        docker {
+                            label SW_NODE
+                            image WIN_DOCKER_IMAGE
+                        }
+                    }
+                    stages {
+                        stage('Type checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
+                            }
+                        }
+                        stage('Format checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
+                            }
+                        }
+                        stage('Generate documentation') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
+                                bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
+                                stash includes: 'docs.zip', name: 'docs'
+                            }
+                        }
+                    }
+                }
                 stage('Publish documentation') {
                     when {
                         beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -222,7 +222,7 @@ pipeline {
                                         bat """
                                             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
                                             py -${DEFAULT_PYTHON_VERSION} -m tox -e build
-                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i
+                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i /y
                                         """
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -227,12 +227,12 @@ pipeline {
                         stages {
                             stage('Type checking') {
                                 steps {
-                                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type")
+                                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
                                 }
                             }
                             stage('Format checking') {
                                 steps {
-                                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format")
+                                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
                                 }
                             }
                             stage('Generate documentation') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -507,7 +507,7 @@ pipeline {
 
                     bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
                     bat "py -3.9 -m coverage combine ${coverage_files}"
-                    bat "py -3.9 -m coverage xml --include='ingenialink/*'"
+                    bat "py -3.9 -m coverage xml --include='*/ingenialink/*'"
                 }
                 recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
                 archiveArtifacts artifacts: '*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ def ECAT_NODE_LOCK = "test_execution_lock_ecat"
 def CAN_NODE = "canopen-test"
 def CAN_NODE_LOCK = "test_execution_lock_can"
 
-LIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/docker-python:1.5"
+LIN_DOCKER_IMAGE = "quay.io/pypa/manylinux2014_x86_64:2024.07.02-0"
 WIN_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/win-python-builder:1.6"
 def PUBLISHER_DOCKER_IMAGE = "ingeniacontainers.azurecr.io/publisher:1.8"
 
@@ -265,6 +265,22 @@ pipeline {
                                     }
                                 }
                             }
+
+                            stage('Repair Linux Wheel') {
+                                when {
+                                    environment name: 'PLATFORM', value: 'linux'
+                                }
+                                steps {
+                                    sh 'auditwheel repair dist/*.whl -w dist/'
+                                    sh "find dist -type f -not -name '*many*.whl' -delete"
+                                }
+                                post {
+                                    always {
+                                        reassignFilePermissions()
+                                    }
+                                }
+                            }
+
                             stage('Archive artifacts') {
                                 steps {
                                     archiveArtifacts(artifacts: "dist\\*", followSymlinks: false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,16 +204,16 @@ pipeline {
                                 bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"
                             }
                         }
-                        stage('Type checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
-                            }
-                        }
-                        stage('Format checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
-                            }
-                        }
+                        // stage('Type checking') {
+                        //     steps {
+                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
+                        //     }
+                        // }
+                        // stage('Format checking') {
+                        //     steps {
+                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
+                        //     }
+                        // }
                         stage('Build') {
                             steps {
                                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,29 +176,6 @@ pipeline {
                         SETUPTOOLS_SCM_PRETEND_VERSION = getVersionForPR()
                     }
                     stages {
-                        stage ('Git Commit to Build description') {
-                            steps {
-                                // Build description should follow the format VAR1=value1;VAR2=value2...
-                                script {
-                                    def currentCommit = bat(script: "git rev-parse HEAD", returnStdout: true).trim()
-                                    def currentCommitHash = (currentCommit =~ /\b[0-9a-f]{40}\b/)[0]
-                                    echo "Current Commit Hash: ${currentCommitHash}"
-                                    def currentCommitBranch = bat(script: "git branch --contains ${currentCommitHash}", returnStdout: true).trim().split("\n").find { it.contains('*') }.replace('* ', '').trim()
-                                    echo "currentCommitBranch: ${currentCommitBranch}"
-                                    
-                                    if (currentCommitBranch.contains('detached')) {
-                                        def shortCommitHash = (currentCommitBranch =~ /\b[0-9a-f]{7,40}\b/)[0]
-                                        def detachedCommit = bat(script: "git rev-parse ${shortCommitHash}", returnStdout: true).trim()
-                                        def detachedCommitHash = (detachedCommit =~ /\b[0-9a-f]{40}\b/)[0]
-                                        echo "Detached Commit Hash: ${detachedCommitHash}"
-                                        currentBuild.description = "ORIGINAL_GIT_COMMIT_HASH=${detachedCommitHash}"
-                                    } else {
-                                        echo "No detached HEAD state found. Using current commit hash ${currentCommitHash}."
-                                        currentBuild.description = "ORIGINAL_GIT_COMMIT_HASH=${currentCommitHash}"
-                                    }
-                                }
-                            }
-                        }
                         stage('Move workspace') {
                             steps {
                                 bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,17 +217,12 @@ pipeline {
                         stage('Build') {
                             steps {
                                 script {
-                                    def pythonVersions = RUN_PYTHON_VERSIONS.split(',')
+                                    def pythonVersions = ALL_PYTHON_VERSIONS.split(',')
                                     pythonVersions.each { version ->
-                                        def distDir = version == PYTHON_VERSION_MIN ? "dist" : "dist_${version}"
-                                        def buildDir = version == PYTHON_VERSION_MIN ? "build" : "build_${version}"
-                                        env.TOX_PYTHON_VERSION = version
-                                        env.TOX_DIST_DIR = distDir
-                                        env.TOX_BUILD_ENV_DIR = buildDir
                                         bat """
                                             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
                                             py -${DEFAULT_PYTHON_VERSION} -m tox -e build
-                                            XCOPY ${distDir}\\*.whl ${env.WORKSPACE}\\dist /s /i
+                                            XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i
                                         """
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,7 @@ pipeline {
                                         bat """
                                             cd C:\\Users\\ContainerAdministrator\\ingenialink_python
                                             py -${version} -m tox -e build
-                                            echo N | XCOPY dist\\*.whl ${env.WORKSPACE}\\dist /s /i /-Y
+                                            robocopy dist ${env.WORKSPACE}\\dist *.whl /XO /NFL /NDL /NJH /NJS
                                         """
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -495,7 +495,10 @@ pipeline {
                         unstash coverage_stash
                         coverage_files += " " + coverage_stash
                     }
-                    bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e coverage -- ${coverage_files}"
+
+                    bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
+                    bat "py -3.9 -m coverage combine ${coverage_files}"
+                    bat "py -3.9 -m coverage coverage xml --include='*/ingenialink/*'"
                 }
                 recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
                 archiveArtifacts artifacts: '*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -201,7 +201,7 @@ pipeline {
                         }
                         stage('Move workspace') {
                             steps {
-                                bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y"
+                                bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"
                             }
                         }
                         stage('Type checking') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,22 +265,6 @@ pipeline {
                                     }
                                 }
                             }
-
-                            stage('Repair Linux Wheel') {
-                                when {
-                                    environment name: 'PLATFORM', value: 'linux'
-                                }
-                                steps {
-                                    sh 'auditwheel repair dist/*.whl -w dist/'
-                                    sh "find dist -type f -not -name '*many*.whl' -delete"
-                                }
-                                post {
-                                    always {
-                                        reassignFilePermissions()
-                                    }
-                                }
-                            }
-
                             stage('Archive artifacts') {
                                 steps {
                                     archiveArtifacts(artifacts: "dist\\*", followSymlinks: false)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,9 +71,13 @@ def getArgsForPlatform(String platform) {
     }
 }
 
+LINUX_PYTHON_PATH = ['3.9' : '/opt/python/cp39-cp39/bin', '3.10': '/opt/python/cp310-cp310/bin',
+                     '3.11': '/opt/python/cp311-cp311/bin', '3.12': '/opt/python/cp312-cp312/bin']
+
+
 def python(String command) {
     if (isUnix()) {
-        sh "python${env.PYTHON_BUILD_VERSION} ${command}"
+        sh "${LINUX_PYTHON_PATH[env.PYTHON_BUILD_VERSION]}/python ${command}"
     } else {
         bat """
             cd C:\\Users\\ContainerAdministrator\\ingenialink_python

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -498,7 +498,7 @@ pipeline {
 
                     bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
                     bat "py -3.9 -m coverage combine ${coverage_files}"
-                    bat "py -3.9 -m coverage xml --include='*/ingenialink/*'"
+                    bat "py -3.9 -m coverage xml --include='ingenialink/*'"
                 }
                 recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
                 archiveArtifacts artifacts: '*.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -504,9 +504,13 @@ pipeline {
                         unstash coverage_stash
                         coverage_files += " " + coverage_stash
                     }
+                    // Archive coverage before combining it
+                    archiveArtifacts artifacts: '*'
 
                     bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
                     bat "py -3.9 -m coverage combine ${coverage_files}"
+                    // Archive coverage combined
+                    archiveArtifacts artifacts: '*'
                     bat "py -3.9 -m coverage xml --include='*/ingenialink/*'"
                 }
                 recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,16 +182,16 @@ pipeline {
                                 bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"
                             }
                         }
-                        // stage('Type checking') {
-                        //     steps {
-                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
-                        //     }
-                        // }
-                        // stage('Format checking') {
-                        //     steps {
-                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
-                        //     }
-                        // }
+                        stage('Type checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
+                            }
+                        }
+                        stage('Format checking') {
+                            steps {
+                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
+                            }
+                        }
                         stage('Build') {
                             steps {
                                 script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,6 +69,10 @@ def clearWiresharkLogs() {
     bat(script: 'del /f "%WIRESHARK_DIR%\\*.pcap"', returnStatus: true)
 }
 
+def clearCoverageFiles() {
+    bat(script: 'del /f "*.coverage*"', returnStatus: true)
+}
+
 def archiveWiresharkLogs() {
     archiveArtifacts artifacts: "${WIRESHARK_DIR}\\*.pcap", allowEmptyArchive: true
 }
@@ -76,6 +80,7 @@ def archiveWiresharkLogs() {
 def runTestHW(markers, setup_name, tox_skip_install = false, extra_args = "") {
     try {
         timeout(time: 1, unit: 'HOURS') {
+            clearCoverageFiles()
             def firstIteration = true
             def pythonVersions = RUN_PYTHON_VERSIONS.split(',')
             pythonVersions.each { version ->
@@ -334,6 +339,7 @@ pipeline {
                     stages {
                         stage('Run no-connection tests on docker') {
                             steps {
+                                clearCoverageFiles()
                                 bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${RUN_PYTHON_VERSIONS} -- " +
                                         "-m docker " +
                                         "-o log_cli=True"
@@ -492,8 +498,6 @@ pipeline {
             }
             steps {
                 script {
-                    cleanWs()
-
                     def coverage_files = ""
 
                     for (coverage_stash in coverage_stashes) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -486,36 +486,5 @@ pipeline {
                 }
             }
         }
-        stage('Publish coverage') {
-            options {
-                skipDefaultCheckout()
-            }
-            agent {
-                docker {
-                    label SW_NODE
-                    image WIN_DOCKER_IMAGE
-                }
-            }
-            steps {
-                script {
-                    def coverage_files = ""
-
-                    for (coverage_stash in coverage_stashes) {
-                        unstash coverage_stash
-                        coverage_files += " " + coverage_stash
-                    }
-                    // Archive coverage before combining it
-                    archiveArtifacts artifacts: '*'
-
-                    bat "py -3.9 -m pip install pytest==7.0.1 pytest-cov==2.12.1"
-                    bat "py -3.9 -m coverage combine ${coverage_files}"
-                    // Archive coverage combined
-                    archiveArtifacts artifacts: '*'
-                    bat "py -3.9 -m coverage xml --include='*/ingenialink/*'"
-                }
-                recordCoverage(tools: [[parser: 'COBERTURA', pattern: 'coverage.xml']])
-                archiveArtifacts artifacts: '*.xml'
-            }
-        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,26 +182,30 @@ pipeline {
                                 bat "XCOPY ${env.WORKSPACE} C:\\Users\\ContainerAdministrator\\ingenialink_python /s /i /y /e /h"
                             }
                         }
-                        stage('Type checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
-                            }
-                        }
-                        stage('Format checking') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
-                            }
-                        }
+                        // stage('Type checking') {
+                        //     steps {
+                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e type"
+                        //     }
+                        // }
+                        // stage('Format checking') {
+                        //     steps {
+                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e format"
+                        //     }
+                        // }
                         stage('Build') {
                             steps {
                                 script {
                                     def pythonVersions = ALL_PYTHON_VERSIONS.split(',')
                                     pythonVersions.each { version ->
-                                        bat """
-                                            cd C:\\Users\\ContainerAdministrator\\ingenialink_python
-                                            py -${version} -m tox -e build
-                                            robocopy dist ${env.WORKSPACE}\\dist *.whl /XO /NFL /NDL /NJH /NJS
-                                        """
+                                        def result = bat(returnStatus: true, script: """
+                                                cd C:\\Users\\ContainerAdministrator\\ingenialink_python
+                                                py -${version} -m tox -e build
+                                                robocopy dist ${env.WORKSPACE}\\dist *.whl /XO /NFL /NDL /NJH /NJS
+                                            """)
+                                        if (result > 7) {
+                                            error "Robocopy failed with exit code ${result}"
+                                        }
+
                                     }
                                 }
                             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('cicd-lib@0.12') _
+@Library('cicd-lib@0.14') _
 
 def SW_NODE = "windows-slave"
 def ECAT_NODE = "ecat-test"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,29 +216,29 @@ pipeline {
                                 stash includes: "dist\\*", name: 'wheels'
                             }
                         }
-                        stage('Generate documentation') {
-                            steps {
-                                bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
-                                bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
-                                stash includes: 'docs.zip', name: 'docs'
-                            }
-                        }
+                        // stage('Generate documentation') {
+                        //     steps {
+                        //         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e docs"
+                        //         bat '''"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256'''
+                        //         stash includes: 'docs.zip', name: 'docs'
+                        //     }
+                        // }
                     }
                 }
-                stage('Publish documentation') {
-                    when {
-                        beforeAgent true
-                        branch BRANCH_NAME_MASTER
-                    }
-                    agent {
-                        label 'worker'
-                    }
-                    steps {
-                        unstash 'docs'
-                        unzip zipFile: 'docs.zip', dir: '.'
-                        publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
-                    }
-                }
+                // stage('Publish documentation') {
+                //     when {
+                //         beforeAgent true
+                //         branch BRANCH_NAME_MASTER
+                //     }
+                //     agent {
+                //         label 'worker'
+                //     }
+                //     steps {
+                //         unstash 'docs'
+                //         unzip zipFile: 'docs.zip', dir: '.'
+                //         publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
+                //     }
+                // }
                 stage('Publish wheels') {
                     agent {
                         docker {

--- a/Manifest.in
+++ b/Manifest.in
@@ -1,2 +1,3 @@
+recursive-include ingenialink *.py
 recursive-include ingenialink/cython_files *.pxd *.pyx *.cpp *.pyd
 recursive-include ingenialink *.pyd

--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -22,6 +22,12 @@ from .ethernet.network import EthernetNetwork
 from .ethernet.servo import EthernetServo
 from .network import NetDevEvt, NetProt, NetState, Network
 
+try:
+    from ._version import __version__  # noqa: F401
+except ModuleNotFoundError:
+    __version__ = "development"
+
+
 __all__ = [
     "NetProt",
     "NetDevEvt",
@@ -79,6 +85,3 @@ def __getattr__(name: str) -> Any:
         )
         return globals()[_DEPRECATED[name]]
     raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
-
-
-__version__ = "7.4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 ]
 
 [build-system]
-requires = ["setuptools>=75.6.0", "setuptools_scm[toml]>=8", "wheel==0.42.0", "Cython==3.0.11"]
+requires = ["setuptools==75.6.0", "setuptools_scm[toml]>=8", "wheel==0.42.0", "Cython==3.0.11"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,55 @@
+[project]
+dynamic = ["version", "urls"]
+
+name = "ingenialink"
+description = "IngeniaLink Communications Library"
+authors = [
+  { name = "Novanta", email = "support@ingeniamc.com" }
+]
+readme = { file = "README.rst", content-type = "text/x-rst" }
+
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Cython",
+  "Topic :: Communications",
+  "Topic :: Software Development :: Libraries"
+]
+
+requires-python = ">=3.9"
+dependencies = [
+    "canopen==2.2.0",
+    "python-can==4.4.2",
+    "ingenialogger>=0.2.1",
+    "ping3==4.0.3",
+    "pysoem>=1.1.11, <1.2.0",
+    "numpy>=1.26.0",
+    "scipy==1.12.0",
+    "bitarray==2.9.2",
+    "multiping==1.1.2",
+]
+
 [build-system]
-requires = ["setuptools>=42", "wheel==0.42.0", "Cython==3.0.11"]
+requires = ["setuptools>=75.6.0", "setuptools_scm[toml]>=8", "wheel==0.42.0", "Cython==3.0.11"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+version_scheme = "only-version"
+local_scheme = "node-and-date"
+write_to = "ingenialink/_version.py"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["ingenialink", "virtual_drive"]
+
+[tool.setuptools.package-data]
+ingenialink = ["py.typed", "*.pyd"]
+virtual_drive = ["py.typed", "resources/*"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,7 @@
 line-length = 100
 target-version = "py39"
 preview = true
-exclude = ["tests/setups/tests_setup.py"]
+exclude = ["tests/setups/tests_setup.py", "ingenialink/_version.py"]
 
 [lint]
 pydocstyle.convention = "google"

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
 import platform
 import re
-
+from Cython.Build import cythonize
 import setuptools
-from setuptools.command.build_ext import build_ext as _build_ext
-from setuptools.command.sdist import sdist as _sdist
 
 _version = re.search(r"__version__\s+=\s+\"(.*)\"", open("ingenialink/__init__.py").read()).group(1)
 
@@ -11,9 +9,10 @@ _version = re.search(r"__version__\s+=\s+\"(.*)\"", open("ingenialink/__init__.p
 def get_docs_url():
     return f"https://distext.ingeniamc.com/doc/ingenialink-python/{_version}"
 
+ext_modules = []
 
 if platform.system() == "Windows":
-    extensions = [
+    ext_modules.append(
         setuptools.Extension(
             "ingenialink.get_adapters_addresses",
             ["ingenialink/cython_files/get_adapters_addresses.pyx"],
@@ -23,89 +22,13 @@ if platform.system() == "Windows":
             ],  # treat all files as C++: https://learn.microsoft.com/en-us/cpp/build/reference/tc-tp-tc-tp-specify-source-file-type?view=msvc-170
             libraries=["Iphlpapi"],
         )
-    ]
-else:
-    extensions = []
-
-
-class BuildExtCommand(_build_ext):
-    """Cythonize cython modules."""
-
-    def initialize_options(self):
-        """Set default options."""
-        super().initialize_options()
-        self.inplace = 1
-
-    def run(self):
-        """Cythonize the extensions."""
-        # Ensure cythonize is run before building extensions
-        from Cython.Build import cythonize
-
-        # embedsignature: https://github.com/cython/cython/wiki/enhancements-compilerdirectives
-        cythonize(extensions, compiler_directives={"language_level": "3", "embedsignature": True})
-        super().run()
-
-
-class CustomSdistCommand(_sdist):
-    """Ensure that cython modules are cythonized before running sdist."""
-
-    def run(self):
-        """Cythonize the extensions before running sdist."""
-        self.run_command("build_ext")
-        super().run()
-
+    )
 
 setuptools.setup(
-    name="ingenialink",
-    version=_version,
-    packages=setuptools.find_packages(exclude=["tests*", "examples*"]),
-    include_package_data=True,
-    package_data={
-        "ingenialink": ["py.typed", "*.pyd"],
-        "virtual_drive": ["py.typed", "resources/*"],
-    },
-    description="IngeniaLink Communications Library",
-    long_description=open("README.rst").read(),
-    long_description_content_type="text/x-rst",
-    author="Novanta",
-    author_email="support@ingeniamc.com",
     url="https://www.ingeniamc.com",
     project_urls={
         "Documentation": get_docs_url(),
         "Source": "https://github.com/ingeniamc/ingenialink-python",
     },
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Cython",
-        "Topic :: Communications",
-        "Topic :: Software Development :: Libraries",
-    ],
-    install_requires=[
-        "canopen==2.2.0",
-        "python-can==4.4.2",
-        "ingenialogger>=0.2.1",
-        "ping3==4.0.3",
-        "pysoem>=1.1.11, <1.2.0",
-        "numpy>=1.26.0",
-        "scipy==1.12.0",
-        "bitarray==2.9.2",
-        "multiping==1.1.2",
-    ],
-    extras_require={
-        "dev": ["tox==4.12.1"],
-    },
-    setup_requires=["cython==3.0.11"],
-    python_requires=">=3.9",
-    ext_modules=extensions,
-    cmdclass={
-        "build_ext": BuildExtCommand,
-        "sdist": CustomSdistCommand,
-    },
+    ext_modules=cythonize(ext_modules, compiler_directives={'language_level': "3"}),
 )

--- a/tox.ini
+++ b/tox.ini
@@ -65,9 +65,9 @@ description = build wheels
 skip_install = true
 deps =
     wheel==0.42.0
-    twine==6.0.1
+    twine==6.1.0
     cython==3.0.11
-    build==1.2.2
+    build==1.2.2.post1
     setuptools==75.6.0
 commands =
     python -m build

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,8 @@ skip_install = true
 deps =
     ruff==0.9.2
 commands =
-    ruff format --check --exclude ingenialink/_version.py {posargs:ingenialink tests virtual_drive}
-    ruff check --exclude ingenialink/_version.py {posargs:ingenialink tests virtual_drive}
+    ruff format --check {posargs:ingenialink tests virtual_drive}
+    ruff check {posargs:ingenialink tests virtual_drive}
 
 [testenv:type]
 description = run type checks

--- a/tox.ini
+++ b/tox.ini
@@ -67,10 +67,11 @@ deps =
     wheel==0.42.0
     twine==6.0.1
     cython==3.0.11
+    build==1.2.2
     setuptools >= 42; python_version >= '3.12'
 basepython = {env:TOX_PYTHON_VERSION:py39}
 commands =
-    python -I setup.py {posargs:build sdist --dist-dir={env:TOX_DIST_DIR:dist} bdist_wheel --dist-dir={env:TOX_DIST_DIR:dist}}
+    python -m build
     twine check {env:TOX_DIST_DIR:dist}/*
 
 [run]

--- a/tox.ini
+++ b/tox.ini
@@ -21,17 +21,6 @@ deps =
 commands =
     python -I -m pytest {posargs:tests} --import-mode=importlib --cov={envsitepackagesdir}/ingenialink --junitxml=pytest_reports/junit-{envname}.xml --junit-prefix={envname}
 
-
-[testenv:coverage]
-description = combine and export coverage report
-skip_install = true
-deps =
-    pytest==7.0.1
-    pytest-cov==2.12.1
-commands =
-    python -I -m coverage combine {posargs}
-    python -I -m coverage xml --include='*/ingenialink/*'
-
 [testenv:format]
 description = check format
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ deps =
     ruff==0.9.2
 commands =
     ruff format --check --exclude ingenialink/_version.py {posargs:ingenialink tests virtual_drive}
-    ruff check {posargs:ingenialink tests virtual_drive}
+    ruff check --exclude ingenialink/_version.py {posargs:ingenialink tests virtual_drive}
 
 [testenv:type]
 description = run type checks

--- a/tox.ini
+++ b/tox.ini
@@ -63,17 +63,15 @@ commands =
 [testenv:build]
 description = build wheels
 skip_install = true
-env_dir = {toxworkdir}/{env:TOX_BUILD_ENV_DIR:build}
 deps =
     wheel==0.42.0
     twine==6.0.1
     cython==3.0.11
     build==1.2.2
     setuptools==75.6.0
-basepython = {env:TOX_PYTHON_VERSION:py39}
 commands =
     python -m build
-    twine check {env:TOX_DIST_DIR:dist}/*
+    twine check dist/*
 
 [run]
 relative_files=True

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ skip_install = true
 deps =
     ruff==0.9.2
 commands =
-    ruff format --check {posargs:ingenialink tests virtual_drive}
+    ruff format --check --exclude ingenialink/_version.py {posargs:ingenialink tests virtual_drive}
     ruff check {posargs:ingenialink tests virtual_drive}
 
 [testenv:type]


### PR DESCRIPTION
### Description

Moved build system to `pyproject.toml` and introduced uploading of development wheels to internal pypi.

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Moved build system to `pyproject.toml`
- [X] Introduced setuptools scm dynamic wheel versioning -> uploading development wheels to internal pypi.
- [X] Removed Jenkins stages that were checking the git commit hash
- [X] Simplified tox build stage by removing environment variables that were controlling _dist_ and _build_ directories for each different wheel
- [X] Changed Jenkins build stage to always build the wheels for all python versions instead of just for the selected python versions for the Jenkins job 
       -> it is safer to build all wheels since they contain cython code and development wheels may be used for different python versions than the one selected for the Jenkins job run.
- [X] Added linux wheel support


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Tested that the wheel is uploaded to internal pypi. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
