### PR TITLE
INGK-1134 Update setuptools

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ def runTestHW(markers, setup_name, tox_skip_install = false, extra_args = "") {
             def pythonVersions = RUN_PYTHON_VERSIONS.split(',')
             pythonVersions.each { version ->
                 def wheelFile = getWheelPath(tox_skip_install, version)
-                withEnv(["INGENIALINK_WHEEL_PATH=${wheelFile}", "TOX_SKIP_INSTALL=${tox_skip_install.toString()}", "WIRESHARK_SCOPE=${params.WIRESHARK_LOGGING_SCOPE}", "CLEAR_WIRESHARK_LOG_IF_SUCCESSFUL=${CLEAR_SUCCESSFUL_WIRESHARK_LOGS}", "START_WIRESHARK_TIMEOUT_S=${START_WIRESHARK_TIMEOUT_S}"]) {
+                withEnv(["INGENIALINK_WHEEL_PATH=${wheelFile}", "TOX_SKIP_INSTALL=${tox_skip_install.toString()}", "WIRESHARK_SCOPE=${params.WIRESHARK_LOGGING_SCOPE}", "CLEAR_WIRESHARK_LOG_IF_SUCCESSFUL=${params.CLEAR_SUCCESSFUL_WIRESHARK_LOGS}", "START_WIRESHARK_TIMEOUT_S=${START_WIRESHARK_TIMEOUT_S}"]) {
                     try {
                         def setupArg = setup_name ? "--setup ${setup_name} " : ""
                         bat "py -${DEFAULT_PYTHON_VERSION} -m tox -e ${version} -- " +

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ deps =
     wheel==0.42.0
     twine==6.0.1
     cython==3.0.11
-    setuptools >= 42; python_version >= '3.12'
+    setuptools==75.6.0
 basepython = {env:TOX_PYTHON_VERSION:py39}
 commands =
     python -I setup.py {posargs:build sdist --dist-dir={env:TOX_DIST_DIR:dist} bdist_wheel --dist-dir={env:TOX_DIST_DIR:dist}}


### PR DESCRIPTION
### Description

The generated wheels could not be uploaded to PyPI due to a metadata error. Update setuptools to avoid this error.

### Type of change

- Update setuptools for wheel generation.

### Tests
Test:
- Generate wheels using setuptools.
- Upload to internal PyPI successfully.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
