### PR TITLE
INGK-1139 add method to set the pdo map to the slave

### DIFF
--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -1,10 +1,11 @@
 from abc import abstractmethod
-from typing import TYPE_CHECKING, ClassVar, Literal, Optional, TypeVar, Union
+from typing import ClassVar, Literal, Optional, TypeVar, Union
 
 import bitarray
 from typing_extensions import override
 
 from ingenialink.bitfield import BitField
+from ingenialink.canopen.dictionary import CanopenDictionary
 from ingenialink.canopen.register import CanopenRegister
 from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
@@ -15,9 +16,6 @@ from ingenialink.utils._utils import (
     convert_dtype_to_bytes,
     dtype_length_bits,
 )
-
-if TYPE_CHECKING:
-    from ingenialink.canopen.dictionary import CanopenDictionary
 
 BIT_ENDIAN: Literal["little"] = "little"
 bitarray._set_default_endian(BIT_ENDIAN)
@@ -463,21 +461,27 @@ class PDOMap:
 
         return pdo_map
 
-    def write_to_slave(self, slave: "PDOServo") -> None:
+    def write_to_slave(self) -> None:
         """Write the PDOMap to the slave.
 
         WARNING: This operation can not be done if the servo is not in pre-operational state.
 
-        Args:
-            slave: Servo to which the PDOMap will be written.
+        Raises:
+            ValueError: If the slave is not set or the map_register_index is None.
+
         """
         self.__check_servo_is_in_preoperational_state()
-        reg = slave.get_register_by_index_subindex(
+        if self.__slave is None:
+            raise ValueError("To write the PDOMap to the slave, the slave must be set.")
+        if self.map_register_index is None:
+            raise ValueError(
+                "To write the PDOMap to the slave, the map_register_index must be set."
+            )
+
+        reg = self.__slave.dictionary.get_register_by_index_subindex(
             self.map_register_index, subindex=0
         )
-        slave.write_complete_access(
-            reg, self.to_pdo_value()
-        )
+        self.__slave.write_complete_access(reg, self.to_pdo_value())
 
     def set_item_bytes(self, data_bytes: bytes) -> None:
         """Set the items raw data from a byte array.
@@ -594,6 +598,11 @@ class PDOServo(Servo):
         super().__init__(target, dictionary_path, servo_status_listener)
         self._rpdo_maps: list[RPDOMap] = []
         self._tpdo_maps: list[TPDOMap] = []
+
+    @property  # type: ignore[misc]
+    def dictionary(self) -> CanopenDictionary:  # type: ignore[override]
+        """Canopen dictionary."""
+        return self._dictionary  # type: ignore[return-value]
 
     @abstractmethod
     def check_servo_is_in_preoperational_state(self) -> None:

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -463,6 +463,22 @@ class PDOMap:
 
         return pdo_map
 
+    def write_to_slave(self, slave: "PDOServo") -> None:
+        """Write the PDOMap to the slave.
+
+        WARNING: This operation can not be done if the servo is not in pre-operational state.
+
+        Args:
+            slave: Servo to which the PDOMap will be written.
+        """
+        self.__check_servo_is_in_preoperational_state()
+        reg = slave.get_register_by_index_subindex(
+            self.map_register_index, subindex=0
+        )
+        slave.write_complete_access(
+            reg, self.to_pdo_value()
+        )
+
     def set_item_bytes(self, data_bytes: bytes) -> None:
         """Set the items raw data from a byte array.
 


### PR DESCRIPTION
### Description

Added a method to write the full pdo map value for: https://github.com/ingeniamc/ingeniamotion/pull/373
Pending https://novantamotion.atlassian.net/browse/INGK-1140

There's already a private method on servo that does it, but it private and it does it in two complete access writes instead of one, not sure why and is only called when the pdo does not have an index associated

Fixes INGK-1139

### Type of change

Please add a description and delete options that are not relevant.

- [x] Added method to write the pdo map to the slave registers

### Tests
- [x] Validated using https://github.com/ingeniamc/ingeniamotion/pull/373

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
