### PR TITLE
INGM-662 Investigate adapters not appearing if only npcap is selected in adapter configuration

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -6,7 +6,7 @@ import time
 from collections import OrderedDict, defaultdict
 from enum import Enum
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
 
 import ingenialogger
 
@@ -217,7 +217,7 @@ class EthercatNetwork(Network):
         set_network_reference(network=self)
 
     @staticmethod
-    def find_adapters() -> tuple[str, str]:
+    def find_adapters() -> list[tuple[int, str, str]]:
         """Finds all available EtherCAT adapters.
 
         Returns:
@@ -237,7 +237,7 @@ class EthercatNetwork(Network):
             adapters.append((
                 interface_index,
                 interface_guid.group(0),
-                adapter.desc.decode("utf-8"),
+                cast("str", adapter.desc.decode("utf-8")),
             ))
         return adapters
 

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -217,6 +217,15 @@ class EthercatNetwork(Network):
         set_network_reference(network=self)
 
     @staticmethod
+    def pysoem_available() -> bool:
+        """Check if pysoem is available.
+
+        Returns:
+            True if pysoem is available, False otherwise.
+        """
+        return pysoem is not None
+
+    @staticmethod
     def find_adapters() -> list[tuple[int, str, str]]:
         """Finds all available EtherCAT adapters.
 

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -50,11 +50,17 @@ def test_load_firmware_no_slave_detected_error(mocker, read_config, ethercat_net
 
 
 @pytest.mark.ethercat
-def test_find_adapters():
+def test_find_adapters(read_config):
     """Test that find_adapters returns a list of EtherCATNetwork instances."""
-    adapters = EthercatNetwork.find_adapters()
-    assert isinstance(adapters, list)
-    assert len(adapters) > 0
+    adapter_found = False
+    ifname = read_config["ethercat"]["ifname"]
+    for adapter in EthercatNetwork.find_adapters():
+        _, interface_guid, _ = adapter
+        interface_guid = f"\\Device\\NPF{interface_guid}"
+        if interface_guid == ifname:
+            adapter_found = True
+            break
+    assert adapter_found is True
 
 
 @pytest.mark.ethercat

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -50,6 +50,14 @@ def test_load_firmware_no_slave_detected_error(mocker, read_config, ethercat_net
 
 
 @pytest.mark.ethercat
+def test_find_adapters():
+    """Test that find_adapters returns a list of EtherCATNetwork instances."""
+    adapters = EthercatNetwork.find_adapters()
+    assert isinstance(adapters, list)
+    assert len(adapters) > 0
+
+
+@pytest.mark.ethercat
 def test_wrong_interface_name_error(read_config, ethercat_network_teardown):  # noqa: ARG001
     with pytest.raises(ConnectionError):
         net = EthercatNetwork("not existing ifname")

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -56,7 +56,7 @@ def test_find_adapters(read_config):
     ifname = read_config["ethercat"]["ifname"]
     for adapter in EthercatNetwork.find_adapters():
         _, interface_guid, _ = adapter
-        interface_guid = f"\\Device\\NPF{interface_guid}"
+        interface_guid = f"\\Device\\NPF_{interface_guid}"
         if interface_guid == ifname:
             adapter_found = True
             break


### PR DESCRIPTION
### Description

Add pysoem `find_adapters` to scan Ethercat network adapters. 

### Type of change

Please add a description and delete options that are not relevant.

- [X] Use `find_adapters()` from pysoem to scan adapters

### Tests
- [X] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [X] Set fix version field in the Jira issue.
