### PR TITLE
INGK-1144 Investigate _parse_dns_suffix error

### DIFF
--- a/ingenialink/cython_files/get_adapters_addresses.pyx
+++ b/ingenialink/cython_files/get_adapters_addresses.pyx
@@ -514,3 +514,22 @@ def get_adapters_addresses(
     for adapter_family in adapter_families:
         adapters.extend(_get_adapters_addresses_by_family(adapter_family, scan_flags))
     return adapters
+
+def get_adapter(ifname: str, adapter_family: AdapterFamily = AdapterFamily.UNSPEC, scan_flags: list[ScanFlags] | ScanFlags = [ScanFlags.INCLUDE_PREFIX, ScanFlags.INCLUDE_ALL_INTERFACES]) -> CyAdapter | None:
+    """Retrieves the address of a specific adapter by its name.
+
+    Args:
+        ifname: The name of the adapter to retrieve.
+            Should match the AdapterName field in the CyAdapter structure, ex:
+                AdapterName='{129BCE68-6859-4A78-B17E-6A80054E9F98}'
+        adapter_family: The address family to filter by (default is UNSPEC).
+        scan_flags: Flags to control the scanning behavior (default includes prefix).
+
+    Returns:
+        The adapter information or None if not found.
+    """
+    adapters = get_adapters_addresses(adapter_families=adapter_family, scan_flags=scan_flags)
+    for adapter in adapters:
+        if adapter.AdapterName == ifname:
+            return adapter
+    return None

--- a/ingenialink/cython_files/get_adapters_addresses.pyx
+++ b/ingenialink/cython_files/get_adapters_addresses.pyx
@@ -23,7 +23,9 @@ from libc.stdlib cimport malloc, free
 import dataclasses
 import cython
 from libc.string cimport strlen
+from libc.stddef cimport wchar_t
 from libc.stdint cimport uint16_t, uint32_t, uint8_t, int32_t, uint64_t
+from cpython.unicode cimport PyUnicode_FromWideChar
 import logging
 
 _MAX_TRIES = 3
@@ -193,9 +195,7 @@ cdef _pwchar_to_str(WCHAR* wide_str, bint safe_parse=True):
     
     cdef int length = 0
     try:
-        while wide_str[length] != 0:
-            length += 1
-        return (<char *>wide_str)[:length * 2].decode('utf-16le')
+       return PyUnicode_FromWideChar(<wchar_t*>wide_str, -1)
     except Exception as e:
         if safe_parse:
             logger.warning(f"Exception in _pwchar_to_str: {e}")

--- a/ingenialink/cython_files/get_adapters_addresses.pyx
+++ b/ingenialink/cython_files/get_adapters_addresses.pyx
@@ -27,6 +27,15 @@ from libc.stddef cimport wchar_t
 from libc.stdint cimport uint16_t, uint32_t, uint8_t, int32_t, uint64_t
 from cpython.unicode cimport PyUnicode_FromWideChar
 import logging
+from libc.signal cimport signal, SIGSEGV
+from libc.stdlib cimport exit
+from libc.signal cimport signal, SIGSEGV
+from libc.setjmp cimport jmp_buf, setjmp, longjmp
+
+
+from libc.stdlib cimport malloc, free
+from libc.string cimport memset
+
 
 _MAX_TRIES = 3
 _WORKING_BUFFER_SIZE = 15000
@@ -189,13 +198,36 @@ class CyAdapter:
     Dhcpv6Iaid: int
     FirstDnsSuffix: list[CyFirstDnsSuffix]
 
-cdef _pwchar_to_str(WCHAR* wide_str, bint safe_parse=True):
+cdef jmp_buf jump_buffer
+
+cdef void segfault_handler(int sig) noexcept nogil:
+    """Signal handler for SIGSEGV"""
+    if sig == SIGSEGV:
+        with gil:
+            logger.warning("Segmentation fault detected - jumping back to setjmp point")
+    # Jump back to the setjmp point instead of returning to the faulting instruction
+    longjmp(jump_buffer, 1)
+
+cdef str _pwchar_to_str(WCHAR* wide_str, bint safe_parse=True):
     if wide_str is NULL:
         return None
+
+    # Register signal handler
+    signal(SIGSEGV, segfault_handler)
     
-    cdef int length = 0
+    cdef:
+        int jump_result
+        int length = 0
+        str result
     try:
-       return PyUnicode_FromWideChar(<wchar_t*>wide_str, -1)
+        jump_result = setjmp(jump_buffer) # Set jump point
+        if jump_result != 0: # Jumped here from the signal handler - segfault occurred
+            raise RuntimeError("Segmentation fault occurred")
+        result = PyUnicode_FromWideChar(<wchar_t*>wide_str, -1)
+        if result is None:
+            logger.warning("Failed to convert wide string to Python string")
+            raise RuntimeError("Failed to convert wide string to Python string")
+        return result
     except Exception as e:
         if safe_parse:
             logger.warning(f"Exception in _pwchar_to_str: {e}")

--- a/ingenialink/cython_files/get_adapters_addresses.pyx
+++ b/ingenialink/cython_files/get_adapters_addresses.pyx
@@ -131,7 +131,7 @@ class CyFirstPrefix:
 @cython.cclass
 @dataclasses.dataclass
 class CyFirstDnsSuffix:
-    String: list[str]
+    String: str
 
 @cython.cclass
 @dataclasses.dataclass
@@ -285,11 +285,11 @@ cdef list[CyFirstDnsSuffix] _parse_dns_suffix(IP_ADAPTER_DNS_SUFFIX* data):
     parsed_data = []
 
     while current_data:
-        parsed_data.append(
-            CyFirstDnsSuffix(
-                String=[current_data.String[i].decode("utf-8") for i in range(MAX_DNS_SUFFIX_STRING_LENGTH) if current_data.String[i] is not None]
+        dns_suffix_string = _pwchar_to_str(current_data.String)
+        if dns_suffix_string: 
+            parsed_data.append(
+                CyFirstDnsSuffix(String=dns_suffix_string)
             )
-        )
         current_data = current_data.Next
     return parsed_data
 


### PR DESCRIPTION
### Description

Fixed `_parse_dns_suffix` parser. 

Changes have been tested adding the following function to `get_adapters_addresses.pyx`:

```
cpdef list[CyFirstDnsSuffix] _test_parse_dns_suffix_with_mock_data():
    cdef IP_ADAPTER_DNS_SUFFIX* node1 = <IP_ADAPTER_DNS_SUFFIX*> malloc(sizeof(IP_ADAPTER_DNS_SUFFIX))
    cdef IP_ADAPTER_DNS_SUFFIX* node2 = <IP_ADAPTER_DNS_SUFFIX*> malloc(sizeof(IP_ADAPTER_DNS_SUFFIX))
    cdef IP_ADAPTER_DNS_SUFFIX* node3 = <IP_ADAPTER_DNS_SUFFIX*> malloc(sizeof(IP_ADAPTER_DNS_SUFFIX))
    
    if not node1 or not node2 or not node3:
        if node1: free(node1)
        if node2: free(node2)
        if node3: free(node3)
        raise MemoryError("Failed to allocate test DNS suffix nodes")
    
    test_strings = [
        "company.local".encode('utf-16le'),
        "example.com".encode('utf-16le'),
        "backup.domain.net".encode('utf-16le')
    ]
    
    cdef bytes str_bytes
    cdef int i, str_len
    
    str_bytes = test_strings[0]
    str_len = min(len(str_bytes) // 2, MAX_DNS_SUFFIX_STRING_LENGTH - 1) 
    for i in range(str_len):
        node1.String[i] = (<uint16_t*>(<char*>str_bytes))[i]
    node1.String[str_len] = 0  
    node1.Next = node2
    
    str_bytes = test_strings[1]
    str_len = min(len(str_bytes) // 2, MAX_DNS_SUFFIX_STRING_LENGTH - 1)
    for i in range(str_len):
        node2.String[i] = (<uint16_t*>(<char*>str_bytes))[i]
    node2.String[str_len] = 0
    node2.Next = node3
    
    str_bytes = test_strings[2]
    str_len = min(len(str_bytes) // 2, MAX_DNS_SUFFIX_STRING_LENGTH - 1)
    for i in range(str_len):
        node3.String[i] = (<uint16_t*>(<char*>str_bytes))[i]
    node3.String[str_len] = 0
    node3.Next = NULL
    
    result = _parse_dns_suffix(node1)
    
    free(node1)
    free(node2)
    free(node3)
    
    return result
```

The following script returns the expected output:
```
import ingenialink.get_adapters_addresses as adapters

result = adapters._test_parse_dns_suffix_with_mock_data()
print(result)
```

Output:
```
[CyFirstDnsSuffix(String='company.local'), CyFirstDnsSuffix(String='example.com'), CyFirstDnsSuffix(String='backup.domain.net')]
```

Fixes # (issue)

### Type of change

Please add a description and delete options that are not relevant.

- [X] Fixed `_parse_dns_suffix` parser
- [X] Added `safe_parse` option to all adapter parsing functions -> if parsing fails, it will fallback to a default value instead that raising an error
- [X] Added `get_adapter` method -> retrieves a certain adapter using its ifname

### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [X] Set fix version field in the Jira issue.
