### PR TITLE
INGK-1149 organize exports and test they are properly exported

### DIFF
--- a/ingenialink/__init__.py
+++ b/ingenialink/__init__.py
@@ -13,14 +13,28 @@ from ingenialink.enums.servo import (
 from ingenialink.poller import Poller
 from ingenialink.servo import Servo
 
-from .canopen.dictionary import CanopenDictionaryV2
+# Canopen
+from .canopen.dictionary import CanopenDictionary, CanopenDictionaryV2, CanopenDictionaryV3
 from .canopen.network import CanBaudrate, CanDevice, CanopenNetwork
 from .canopen.register import CanopenRegister
 from .canopen.servo import CanopenServo
+from .dictionary import Dictionary, DictionaryV2, DictionaryV3
+
+# Ethercat
+from .ethercat.dictionary import EthercatDictionary, EthercatDictionaryV2, EthercatDictionaryV3
 from .ethercat.network import EthercatNetwork, GilReleaseConfig
+from .ethercat.register import EthercatRegister
+from .ethercat.servo import EthercatServo
+
+# Ethernet
+from .ethernet.dictionary import EthernetDictionary, EthernetDictionaryV2, EthernetDictionaryV3
 from .ethernet.network import EthernetNetwork
+from .ethernet.register import EthernetRegister
 from .ethernet.servo import EthernetServo
+
+# Generic
 from .network import NetDevEvt, NetProt, NetState, Network
+from .register import Register
 
 try:
     from ._version import __version__  # noqa: F401
@@ -39,22 +53,37 @@ __all__ = [
     "ServoUnitsPos",
     "ServoUnitsVel",
     "ServoUnitsAcc",
+    "Register",
     "Network",
     "Servo",
+    "Dictionary",
+    "DictionaryV2",
+    "DictionaryV3",
     "RegDtype",
     "RegAccess",
     "RegPhy",
     "EthercatNetwork",
+    "EthercatServo",
+    "EthercatDictionary",
+    "EthercatDictionaryV2",
+    "EthercatDictionaryV3",
+    "EthercatRegister",
     "GilReleaseConfig",
     "EthernetServo",
+    "EthernetDictionary",
+    "EthernetDictionaryV2",
+    "EthernetDictionaryV3",
+    "EthernetRegister",
     "EthernetNetwork",
     "CanopenNetwork",
+    "CanopenDictionary",
+    "CanopenDictionaryV2",
+    "CanopenDictionaryV3",
     "CanDevice",
     "CanBaudrate",
     "CanopenServo",
     "CanopenRegister",
     "Poller",
-    "CanopenDictionaryV2",
 ]
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,19 @@
+def test_exported_comms_symbols():
+    import ingenialink
+
+    expected_attrs = []
+
+    for obj_type in ["Network", "Servo", "Dictionary", "Register", "DictionaryV2", "DictionaryV3"]:
+        expected_attrs.extend(
+            f"{comm_type}{obj_type}"
+            for comm_type in [
+                "Ethercat",
+                "Ethernet",
+                "Canopen",
+                "",  # Generic
+            ]
+        )
+    all_attrs = set(getattr(ingenialink, "__all__", []))
+    for attr in expected_attrs:
+        assert attr in all_attrs, f"{attr} missing from ingenialink.__all__"
+        assert hasattr(ingenialink, attr), f"ingenialink missing {attr} in __init__"


### PR DESCRIPTION
### Description

The exported objects on __init __ were inconsistent across diferent communications.
Added a test that checks this consistency and fixed.
The initial detection of this was that EthercatServo was not exposed, all others were.
Same happens with other objects as I see...

Fixes INGK-1149

### Type of change

Please add a description and delete options that are not relevant.

- [x] Update exported ingenialink symbols


### Tests
- [x] Add a unit test for exported sybmols of each comm type and obj type

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
