### PR TITLE
INGK-1154 Create linux environments in custom workspace

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
                                 }
                                 stage('Build wheels') {
                                     environment {
-                                        SETUPTOOLS_SCM_PRETEND_VERSION = getVersionForPR()
+                                        SETUPTOOLS_SCM_PRETEND_VERSION = getPythonVersionForPr()
                                     }
                                     steps {
                                         script {
@@ -341,7 +341,7 @@ pipeline {
                                 }
                                 stage('Build wheels') {
                                     environment {
-                                        SETUPTOOLS_SCM_PRETEND_VERSION = getVersionForPR()
+                                        SETUPTOOLS_SCM_PRETEND_VERSION = getPythonVersionForPr()
                                     }
                                     steps {
                                         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('cicd-lib@0.14') _
+@Library('cicd-lib@0.15') _
 
 def SW_NODE = "windows-slave"
 def ECAT_NODE = "ecat-test"
@@ -30,20 +30,6 @@ START_WIRESHARK_TIMEOUT_S = 10.0
 
 wheel_stashes = []
 coverage_stashes = []
-
-def getVersionForPR() {
-    if (!env.CHANGE_ID) {
-        return ""
-    }
-    def latest_tag = ''
-    if (isUnix()) {
-        sh "git config --global --add safe.directory '*'"
-        latest_tag = sh(returnStdout: true, script: 'git describe --tags --abbrev=0').trim()
-    } else {
-        latest_tag = powershell(returnStdout: true, script: 'git describe --tags --abbrev=0').trim()
-    }
-    return "${latest_tag}+PR${env.CHANGE_ID}B${env.BUILD_NUMBER}"
-}
 
 def reassignFilePermissions() {
     if (isUnix()) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -261,7 +261,7 @@ pipeline {
                                 stage('Make a static type analysis') {
                                     steps {
                                         bat """
-                                            cd ${DOCKER_TMP_PATH}
+                                            cd ${WIN_DOCKER_TMP_PATH}
                                             call .venv${DEFAULT_PYTHON_VERSION}/Scripts/activate
                                             poetry run poe type
                                         """
@@ -270,7 +270,7 @@ pipeline {
                                 stage('Check formatting') {
                                     steps {
                                         bat """
-                                            cd ${DOCKER_TMP_PATH}
+                                            cd ${WIN_DOCKER_TMP_PATH}
                                             call .venv${DEFAULT_PYTHON_VERSION}/Scripts/activate
                                             poetry run poe format
                                         """
@@ -289,7 +289,7 @@ pipeline {
                                 stage('Generate documentation') {
                                     steps {
                                         bat """
-                                            cd ${DOCKER_TMP_PATH}
+                                            cd ${WIN_DOCKER_TMP_PATH}
                                             call .venv${DEFAULT_PYTHON_VERSION}/Scripts/activate
                                             poetry run poe docs
                                             "C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256
@@ -610,10 +610,10 @@ pipeline {
                     for (stash_name in wheel_stashes) {
                         unstash stash_name
                     }
-                    bat "XCOPY ${env.WORKSPACE} ${DOCKER_TMP_PATH} /s /i /y /e /h"
-                    createVirtualEnvironments(true, DOCKER_TMP_PATH, DEFAULT_PYTHON_VERSION)
+                    bat "XCOPY ${env.WORKSPACE} ${WIN_DOCKER_TMP_PATH} /s /i /y /e /h"
+                    createVirtualEnvironments(true, WIN_DOCKER_TMP_PATH, DEFAULT_PYTHON_VERSION)
                     bat """
-                        cd ${DOCKER_TMP_PATH}
+                        cd ${WIN_DOCKER_TMP_PATH}
                         call .venv${DEFAULT_PYTHON_VERSION}/Scripts/activate
                         poetry run poe cov-combine --${coverage_files}
                         poetry run poe cov-report


### PR DESCRIPTION
### Description

To prevent "No space left on device" errors during the Linux stage, virtual environments are now created in a custom directory. This ensures that all data is automatically cleaned up when the Docker image is unmounted, avoiding residual storage issues.

Additionally, test result reporting has been updated to include results for all Python versions.

### Type of change

Please add a description and delete options that are not relevant.

- Create virtual environments in a custom directory.
- Update test result reporting.

### Tests
- [x] Run tests.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
