### PR TITLE
INGK-1153 FoE fails and returns a boot state not reached

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -627,7 +627,6 @@ class EthercatNetwork(Network):
             ValueError: If the salve ID value is invalid.
             ILError: If no slaves could be found in the network.
             ILError: If the slave ID couldn't be found in the network.
-            ILFirmwareLoadError: If no slave is detected.
             ILFirmwareLoadError: If the FoE write operation is not successful.
         """
         if not isinstance(boot_in_app, bool):

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -651,21 +651,31 @@ class EthercatNetwork(Network):
             raise ILError(f"Slave {slave_id} was not found.")
 
         slave = self._ecat_master.slaves[slave_id - 1]
+        error_messages: list[str] = []
         for iteration in range(self.__MAX_FOE_TRIES):
             if not boot_in_app:
                 self._force_boot_mode(slave)
-            self._switch_to_boot_state(slave)
-
+            if not self._switch_to_boot_state(slave):
+                error_message = f"Attempt {iteration + 1}: The slave cannot reach the Boot state."
+                logger.info(error_message)
+                error_messages.append(error_message)
+                continue
             foe_write_result = self._write_foe(slave, fw_file, password)
             if foe_write_result > 0:
                 break
+            error_message = (
+                f"Attempt {iteration + 1}: "
+                f"{self.__get_foe_error_message(error_code=foe_write_result)}"
+            )
+            logger.info(f"FoE write failed: {error_message}")
+            error_messages.append(error_message)
             self.__init_nodes()
         else:
-            error_message = (
-                "The firmware file could not be loaded correctly."
-                f" {EthercatNetwork.__get_foe_error_message(error_code=foe_write_result)}"
+            combined_errors = "\n".join(error_messages)
+            raise ILFirmwareLoadError(
+                f"The firmware file could not be loaded correctly after {self.__MAX_FOE_TRIES}"
+                f" attempts. Errors:\n{combined_errors}"
             )
-            raise ILFirmwareLoadError(error_message)
         start_time = time.time()
         recovered = False
         while time.time() < (start_time + self.__FOE_RECOVERY_TIMEOUT_S) and not recovered:
@@ -684,16 +694,17 @@ class EthercatNetwork(Network):
         if not is_master_running_before_loading_firmware:
             self.close_ecat_master(release_reference=False)
 
-    def _switch_to_boot_state(self, slave: "CdefSlave") -> None:
+    def _switch_to_boot_state(self, slave: "CdefSlave") -> bool:
         """Transitions the slave to the boot state.
 
-        Raises:
-            ILFirmwareLoadError: if the drive cannot reach the boot state.
+        Returns:
+            True if the slave reached the boot state, False otherwise.
         """
         slave.state = pysoem.BOOT_STATE
         slave.write_state()
-        if slave.state_check(pysoem.BOOT_STATE, ECAT_STATE_CHANGE_TIMEOUT_US) != pysoem.BOOT_STATE:
-            raise ILFirmwareLoadError("The drive cannot reach the boot state.")
+        return bool(
+            slave.state_check(pysoem.BOOT_STATE, ECAT_STATE_CHANGE_TIMEOUT_US) == pysoem.BOOT_STATE
+        )
 
     def _force_boot_mode(self, slave: "CdefSlave") -> None:
         """COMOCO drives need to be forced to boot mode.

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -665,7 +665,7 @@ class EthercatNetwork(Network):
                 break
             error_message = (
                 f"Attempt {iteration + 1}: "
-                f"{self.__get_foe_error_message(error_code=foe_write_result)}"
+                f"{self.__get_foe_error_message(error_code=foe_write_result)}."
             )
             logger.info(f"FoE write failed: {error_message}")
             error_messages.append(error_message)

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -53,15 +53,15 @@ def test_raise_exception_if_not_winpcap():
         release_network_reference(net)
 
 
-@pytest.mark.ethercat
-def test_load_firmware_file_not_found_error(setup_descriptor):
-    net = EthercatNetwork(setup_descriptor.ifname)
+@pytest.mark.no_connection
+def test_load_firmware_file_not_found_error():
+    net = EthercatNetwork("fake_interface")
     with pytest.raises(FileNotFoundError):
         net.load_firmware("ethercat.sfu", True)
     net.close_ecat_master()
 
 
-@pytest.mark.ethercat
+@pytest.mark.no_connection
 def test_load_firmware_no_slave_detected_error(mocked_network_for_firmware_loading):
     net, _ = mocked_network_for_firmware_loading
     slave_id = 23
@@ -72,7 +72,7 @@ def test_load_firmware_no_slave_detected_error(mocked_network_for_firmware_loadi
         net.load_firmware("dummy_file.lfu", False, slave_id=slave_id)
 
 
-@pytest.mark.ethercat
+@pytest.mark.no_connection
 def test_load_firmware_boot_state_failure(mocker, mocked_network_for_firmware_loading):
     net, _ = mocked_network_for_firmware_loading
     mocker.patch.object(net, "_switch_to_boot_state", side_effect=[True, False])
@@ -86,7 +86,7 @@ def test_load_firmware_boot_state_failure(mocker, mocked_network_for_firmware_lo
         net.load_firmware("dummy_file.sfu", False, slave_id=1)
 
 
-@pytest.mark.ethercat
+@pytest.mark.no_connection
 def test_load_firmware_foe_write_failure(mocker, mocked_network_for_firmware_loading):
     net, _ = mocked_network_for_firmware_loading
     mocker.patch("os.path.isfile", return_value=True)
@@ -100,7 +100,7 @@ def test_load_firmware_foe_write_failure(mocker, mocked_network_for_firmware_loa
         net.load_firmware("dummy_file.sfu", False, slave_id=1)
 
 
-@pytest.mark.ethercat
+@pytest.mark.no_connection
 def test_load_firmware_success_after_retry(mocker, mocked_network_for_firmware_loading):
     net, slave = mocked_network_for_firmware_loading
     mocker.patch.object(net, "_switch_to_boot_state", side_effect=[False, True])
@@ -110,11 +110,11 @@ def test_load_firmware_success_after_retry(mocker, mocked_network_for_firmware_l
     net.load_firmware("dummy_file.sfu", False, slave_id=1)
 
 
-@pytest.mark.ethercat
-def test_wrong_interface_name_error(setup_descriptor):
-    net = EthercatNetwork("not existing ifname")
+@pytest.mark.no_connection
+def test_wrong_interface_name_error():
+    net = EthercatNetwork("fake_interface")
     slave_id = 1
-    dictionary = setup_descriptor.dictionary
+    dictionary = "fake_dictionary.xdf"
     with pytest.raises(ConnectionError):
         net.connect_to_slave(slave_id, dictionary)
     net.close_ecat_master()

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -62,16 +62,14 @@ def test_load_firmware_file_not_found_error(setup_descriptor):
 
 
 @pytest.mark.ethercat
-def test_load_firmware_no_slave_detected_error(mocker, setup_descriptor):
-    net = EthercatNetwork(setup_descriptor.ifname)
-    mocker.patch("os.path.isfile", return_value=True)
+def test_load_firmware_no_slave_detected_error(mocked_network_for_firmware_loading):
+    net, _ = mocked_network_for_firmware_loading
     slave_id = 23
     with pytest.raises(
         ILError,
         match=f"Slave {slave_id} was not found.",
     ):
         net.load_firmware("dummy_file.lfu", False, slave_id=slave_id)
-    net.close_ecat_master()
 
 
 @pytest.mark.ethercat


### PR DESCRIPTION
### Description

This PR enhances the robustness of the firmware loading process over EtherCAT by:

- Adding retry logic when switching a slave to boot state fails.
- Capturing and reporting detailed error messages for each attempt.
- Raising a comprehensive ILFirmwareLoadError if both attempts fail.
- Improving test coverage for these scenarios using mocks.

### Type of change

- Update the load_firmware method.
- Add tests.

### Tests
- [ ] Add new unit tests if it applies.
- [x] Run tests.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
