### PR TITLE
Fix drive context manager pre-op error

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3540,13 +3540,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.4+pr30b62"
+version = "0.1.4+gabbc726"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.4+pr30b62-py3-none-any.whl", hash = "sha256:e3e88f2d5eeb22120468fa19a47759ec8eda1e802ae38a1bfc3d470d174a75fa"},
+    {file = "summit_testing_framework-0.1.4+gabbc726-py3-none-any.whl", hash = "sha256:9077b59b5aee5727c6f3ca4e9f3a7911e97a8528f414da9a65c136aa4e31f14b"},
 ]
 
 [package.dependencies]
@@ -4199,4 +4199,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "842e1cbb282b48fb476e661c9468e0079aadc9d53dfa5b5214f9b302cb7fa0f7"
+content-hash = "ab9cd6e3ac6f72b7c3e16360e7190d8bfceffd1b697fa31f8096898835938713"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.4+pr30b62"
+summit-testing-framework = "==0.1.4+gabbc726"
 
 # -----------------------------------------------------------------------
 #                                   TASKS


### PR DESCRIPTION
### Description

If the drive is not in preop state, PDOs cannot be written, which would cause drive context manager restore method to fail.

This is a temporary fix to avoid the tests to fail. It will be reworked in https://novantamotion.atlassian.net/browse/INGK-1160.

### Type of change

Please add a description and delete options that are not relevant.

- [X] Do not restore pdo maps if the drive is not in preop state.


### Tests
- [ ] Add new unit tests if it applies.
- [X] Run tests.

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [X] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [X] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
