### PR TITLE
Ingk 1122 c def slave is not updated on config init

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -336,6 +336,9 @@ class EthercatNetwork(Network):
         if nodes is not None:
             self.__last_init_nodes = list(range(1, nodes + 1))
 
+        # For every init_nodes, pysoem generates a new CdefSlave object.
+        # Servos that are already "connected" to the network
+        # must update their slave reference
         for servo in self.servos:
             if servo.slave_id in self.__last_init_nodes:
                 servo.update_slave_reference(self._ecat_master.slaves[servo.slave_id - 1])

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -336,6 +336,10 @@ class EthercatNetwork(Network):
         if nodes is not None:
             self.__last_init_nodes = list(range(1, nodes + 1))
 
+        for servo in self.servos:
+            if servo.slave_id in self.__last_init_nodes:
+                servo.update_slave_reference(self._ecat_master.slaves[servo.slave_id - 1])
+
     def connect_to_slave(
         self,
         slave_id: int,

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -452,3 +452,14 @@ class EthercatServo(PDOServo):
     def slave(self) -> "CdefSlave":
         """Ethercat slave."""
         return self.__slave
+
+    def update_slave_reference(self, slave: "CdefSlave") -> None:
+        """Update the slave reference.
+
+        Args:
+            slave: The new slave reference.
+        """
+        self.__slave = slave
+        if self._on_emcy not in self.__slave._emcy_callbacks:
+            # Make sure the emergency callback is added only once
+            self.__slave.add_emergency_callback(self._on_emcy)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,8 @@ import pytest
 from summit_testing_framework import dynamic_loader
 
 from ingenialink.virtual.network import VirtualNetwork
+from tests.ethercat.mock import pysoem_mock_network  # noqa: F401
 from virtual_drive.core import VirtualDrive
-from tests.ethercat.mock import pysoem_mock_network # noqa: F401
 
 pytest_plugins = [
     "summit_testing_framework.pytest_addoptions",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from summit_testing_framework import dynamic_loader
 
 from ingenialink.virtual.network import VirtualNetwork
 from virtual_drive.core import VirtualDrive
+from tests.ethercat.mock import pysoem_mock_network # noqa: F401
 
 pytest_plugins = [
     "summit_testing_framework.pytest_addoptions",

--- a/tests/ethercat/mock.py
+++ b/tests/ethercat/mock.py
@@ -1,12 +1,11 @@
 import pytest
-from pysoem import INIT_STATE
 
 
 class MockSoemSlave:
     def __init__(self, id: int):  # noqa: A002 shadows built-in
         self.id = id
         self._emcy_callbacks = []
-        self.state: int = INIT_STATE
+        self.state: int = 1  # INIT_STATE
 
     def write_state(self):
         pass

--- a/tests/ethercat/mock.py
+++ b/tests/ethercat/mock.py
@@ -3,7 +3,7 @@ from pysoem import INIT_STATE
 
 
 class MockSoemSlave:
-    def __init__(self, id: int):
+    def __init__(self, id: int):  # noqa: A002 shadows built-in
         self.id = id
         self._emcy_callbacks = []
         self.state: int = INIT_STATE
@@ -17,7 +17,7 @@ class MockSoemSlave:
     def add_emergency_callback(self, callback):
         self._emcy_callbacks.append(callback)
 
-    def state_check(self, expected_state: int, timeout=2000):
+    def state_check(self, **_):
         return self.state
 
     def sdo_write(
@@ -36,7 +36,7 @@ class MockSoemMaster:
     def close(self):
         pass
 
-    def config_init(self, usetable=False, *, release_gil=None):
+    def config_init(self, **_):
         self.slaves = [MockSoemSlave(id=1), MockSoemSlave(id=2), MockSoemSlave(id=3)]
 
         return len(self.slaves)

--- a/tests/ethercat/mock.py
+++ b/tests/ethercat/mock.py
@@ -1,0 +1,53 @@
+import pytest
+from pysoem import INIT_STATE
+
+
+class MockSoemSlave:
+    def __init__(self, id: int):
+        self.id = id
+        self._emcy_callbacks = []
+        self.state: int = INIT_STATE
+
+    def write_state(self):
+        pass
+
+    def read_state(self):
+        return self.state
+
+    def add_emergency_callback(self, callback):
+        self._emcy_callbacks.append(callback)
+
+    def state_check(self, expected_state: int, timeout=2000):
+        return self.state
+
+    def sdo_write(
+        self, index: int, subindex: int, data: bytes, ca: bool = False, *, release_gil=None
+    ):
+        pass
+
+
+class MockSoemMaster:
+    def __init__(self):
+        self.slaves = []
+
+    def open(self, ifname, ifname_red=None):
+        pass
+
+    def close(self):
+        pass
+
+    def config_init(self, usetable=False, *, release_gil=None):
+        self.slaves = [MockSoemSlave(id=1), MockSoemSlave(id=2), MockSoemSlave(id=3)]
+
+        return len(self.slaves)
+
+    def read_state(self):
+        pass
+
+    def state_check(self, expected_state: int, timeout: int = 50000):
+        pass
+
+
+@pytest.fixture()
+def pysoem_mock_network(mocker):
+    mocker.patch("pysoem.Master", MockSoemMaster)

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -380,7 +380,7 @@ def test_network_is_not_released_if_gil_operation_ongoing(mocker, setup_descript
     assert len(ETHERCAT_NETWORK_REFERENCES) == len(previous_networks)
 
 
-def test_slave_update_on_config_init(pysoem_mock_network):
+def test_slave_update_on_config_init(pysoem_mock_network):  # noqa: ARG001
     net = EthercatNetwork("dummy_ifname")
 
     servo = net.connect_to_slave(

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -1,5 +1,7 @@
 import contextlib
 
+import tests.resources
+
 with contextlib.suppress(ImportError):
     import pysoem
 import threading
@@ -376,3 +378,26 @@ def test_network_is_not_released_if_gil_operation_ongoing(mocker, setup_descript
     thread_block_lock.join()
     thread_acquire_lock.join()
     assert len(ETHERCAT_NETWORK_REFERENCES) == len(previous_networks)
+
+
+def test_slave_update_on_config_init(pysoem_mock_network):
+    net = EthercatNetwork("dummy_ifname")
+
+    servo = net.connect_to_slave(
+        slave_id=1,
+        dictionary=tests.resources.DEN_NET_E_2_8_0_xdf_v3,
+    )
+
+    assert len(net.servos) == 1
+    assert net.servos[0] == servo
+    original_slave = servo.slave
+    # The slave contains the emergency callbacks
+    assert original_slave._emcy_callbacks[0] == servo._on_emcy
+
+    # Now, a method could __init_nodes, which re-creates the pysoem slaves
+    net._EthercatNetwork__init_nodes()
+    assert len(net.servos) == 1
+    # The slave should be updated
+    assert servo.slave is not original_slave
+    # And the emergency callback retained
+    assert original_slave._emcy_callbacks[0] == servo._on_emcy


### PR DESCRIPTION
### Description
Config Init in soem is though to be an initialization function that is called once during master configuration.
However, there several cases while a "connected" servo is on the network and a config_init is done.

- Stopping PDOS. This one is questionable. I have created INGK-1162 as related.
- Recovering from a disconnection. Not sure if is questionable, can help recover from weird master states.

Either way this produced a situation where the object reference CDefSlave servos were using was outdated. Since the pointer to the object is the same it kind of worked but was wrong. Additionally this cython object holds the callbacks of emergency, so those were definitely missing.

Fixes INGK-1122

### Type of change

Please add a description and delete options that are not relevant.

- [x] Update slave references when config init is called
- [x] Re-add emergency callbacks when the slave reference is updated

### Tests
- [x] Add simple mock of pysoem 
- [x] Added unit test to test that init_nodes re-updates the newly created cdef slaves

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [x] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [x] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [x] Set fix version field in the Jira issue.
