### PR TITLE
INGK-1163 do not run all python versions on develop index scans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,8 +173,6 @@ pipeline {
                 script {
                     if (env.BRANCH_NAME == 'master') {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                    } else if (env.BRANCH_NAME == 'develop') {
-                        RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                     } else if (env.BRANCH_NAME.startsWith('release/')) {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                     } else {


### PR DESCRIPTION
### Description

Nightlies already trigger builds with all versions of python. Testing stages take 60 minutes of each machine time, which is very valuable during the day.

Develop builds that are triggered by scans should take the same as PR builds (15 min),

This pattern is already implemented on IM

Fixes INGK-1163

### Type of change

Please add a description and delete options that are not relevant.

- [x] Do not force all python versions on develop branch

### Tests
N/A

Please describe the tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).

### Code formatting and linting

- [ ] Use the ruff package to format the code: `ruff format ingenialink tests virtual_drive`.
- [ ] Use the ruff package to lint the code: `ruff check ingenialink tests virtual_drive`.

### Others

- [ ] Set fix version field in the Jira issue.
