### PR TITLE
INGK-1164 Upload all wheels

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -458,7 +458,7 @@ pipeline {
                         }
                         stage('Publish Novanta PyPi') {
                             steps {
-                                publishNovantaPyPi('dist/*-win_amd64.whl')
+                                publishNovantaPyPi('dist/*')
                             }
                         }
                         stage('Publish PyPi') {


### PR DESCRIPTION
### Description

There is a bug in the pypiserver v2.3 that does not allow the linux wheel to be uploaded. The issue is solved in the latest pypiserver version (v2.4).  

### Type of change

- Upload all the generated wheels.


### Tests

- Updated the pypi server to 2.4.0
- Uploaded all the wheels successfully.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).