### PR TITLE
Ingk 1167 fix jenkins for python 3 9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,15 +177,19 @@ pipeline {
                         RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                     } else {
                         if (env.PYTHON_VERSIONS == "MIN_MAX") {
-                          RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
+                            RUN_PYTHON_VERSIONS = "${PYTHON_VERSION_MIN},${PYTHON_VERSION_MAX}"
                         } else if (env.PYTHON_VERSIONS == "MIN") {
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         } else if (env.PYTHON_VERSIONS == "MAX") {
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
-                          RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        } else { // Branch-indexing
-                          RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                        } else { // Branch-indexing/timer
+                            if (env.BRANCH_NAME == 'develop') {
+                                RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
+                            } else {
+                                RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
+                            }
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,10 @@ def createVirtualEnvironments(boolean installWheel = true, String workingDir = n
     runPython("pip install poetry==2.1.3", DEFAULT_PYTHON_VERSION)
     def versions = pythonVersionList?.trim() ? pythonVersionList : RUN_PYTHON_VERSIONS
     def pythonVersions = versions.split(',')
+    // Ensure DEFAULT_PYTHON_VERSION is included if not already present
+    if (!pythonVersions.contains(DEFAULT_PYTHON_VERSION)) {
+        pythonVersions = pythonVersions + [DEFAULT_PYTHON_VERSION]
+    }
     pythonVersions.each { version ->
         def venvName = ".venv${version}"
         def cdCmd = workingDir ? "cd ${workingDir}" : ""
@@ -182,9 +186,6 @@ pipeline {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         } else if (env.PYTHON_VERSIONS == "MAX") {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
-                            // Change the default python version so that virtual environments will match
-                            // the selected python version
-                            DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
                             RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                         } else { // Branch-indexing

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ def runTestHW(markers, setup_name, extra_args = "") {
 }
 
 /* Build develop everyday 3 times starting at 19:00 UTC (21:00 Barcelona Time), running all tests */
-CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 19,21,23 * * *''' : ""
+CRON_SETTINGS = BRANCH_NAME == "develop" ? '''0 19,21,23 * * * % PYTHON_VERSIONS=All''' : ""
 
 pipeline {
     agent none
@@ -187,12 +187,8 @@ pipeline {
                             DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
                             RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                        } else { // Branch-indexing/timer
-                            if (env.BRANCH_NAME == 'develop') {
-                                RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
-                            } else {
-                                RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
-                            }
+                        } else { // Branch-indexing
+                            RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         }
                     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -182,6 +182,9 @@ pipeline {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MIN
                         } else if (env.PYTHON_VERSIONS == "MAX") {
                             RUN_PYTHON_VERSIONS = PYTHON_VERSION_MAX
+                            // Change the default python version so that virtual environments will match
+                            // the selected python version
+                            DEFAULT_PYTHON_VERSION = PYTHON_VERSION_MAX
                         } else if (env.PYTHON_VERSIONS == "All") {
                             RUN_PYTHON_VERSIONS = ALL_PYTHON_VERSIONS
                         } else { // Branch-indexing/timer


### PR DESCRIPTION
### Description

Jenkins fixes for different python versions.

Right now all the docker environment activations are supposed to run with the default python version, which is the minimum one. However, since the python version can be selected, the maximum one may run, leading to an error:
http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingenialink-python/job/develop/702/  

### Type of change

Please add a description and delete options that are not relevant.

- [X] Always include default version when creating the virtual environments
- [X] Add run all python versions to nightly builds


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).