### PR TITLE
Fix jenkins cron

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
         timestamps()
     }
     triggers {
-        cron(CRON_SETTINGS)
+        parameterizedCron(CRON_SETTINGS)
     }
     parameters {
         choice(


### PR DESCRIPTION
### Description

Error introduced in https://github.com/ingeniamc/ingenialink-python/pull/624 when trying to fix develop to work with all python versions. If a parameter is specified in the cron, `parameterizedCron` should be used.

### Type of change

Please add a description and delete options that are not relevant.

- [X] Use `parameterizedCron`


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).