### PR TITLE
INGK-1159 fix isdirty attribute when reading a pdo map from drive

### DIFF
--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -403,6 +403,11 @@ class PDOMap:
             item = self.create_item(register)
             self.add_item(item)
 
+    def clear(self) -> None:
+        """Clear all items."""
+        self.__is_dirty = True
+        self.__items.clear()
+
     @property
     def items(self) -> list[PDOMapItem]:
         """List of items.

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -457,6 +457,7 @@ def test_read_tpdo_map_from_slave(servo: EthercatServo, from_uid: bool):
 def test_map_register_items(servo: EthercatServo):
     pdo_map = servo.read_tpdo_map_from_slave("ETG_COMMS_TPDO_MAP1")
 
+    pdo_map.clear()
     item1 = pdo_map.create_item(servo.dictionary.get_register("CL_POS_FBK_VALUE"))
     item2 = pdo_map.create_item(servo.dictionary.get_register("DRV_STATE_STATUS"))
     item3 = pdo_map.create_item(servo.dictionary.get_register("CL_TOR_FBK_VALUE"))


### PR DESCRIPTION
Rolling back a change from a previous PR comment:
https://github.com/ingeniamc/ingenialink-python/pull/625#discussion_r2303936342

This was not for debug. After adding the items it is dirty so it has to be force to the correct state again.

Additionally found that some tests were not being run because did not have a marker