### PR TITLE
INGK-1177 Trim data to avoid corrupted reads

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -9,6 +9,7 @@ from ingenialink import Servo
 from ingenialink.csv_configuration_file import CSVConfigurationFile
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.ethercat.dictionary import EthercatDictionary
+from ingenialink.utils._utils import dtype_value
 
 try:
     import pysoem
@@ -515,6 +516,10 @@ class EthercatServo(PDOServo):
                     continue
                 try:
                     storage = self._read_raw(configuration_register)
+                    # Trim read data to avoid reading garbage
+                    # To be fixed in INGK-1176
+                    bytes_length, _ = dtype_value[configuration_register.dtype]
+                    storage = storage[:bytes_length]
                     csv_configuration_file.add_register(configuration_register, storage)
                 except (ILError, NotImplementedError) as e:
                     logger.error(


### PR DESCRIPTION
### Description

A bug in the SDO read when the GIL is released causes the CSV configuration file to be incorrect.

### Type of change

- Trim data to avoid corrupted reads.


### Tests
- [ ] Add new unit tests if it applies.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).