### PR TITLE
INGK-1181 Export values using big endian format

### DIFF
--- a/ingenialink/csv_configuration_file.py
+++ b/ingenialink/csv_configuration_file.py
@@ -3,6 +3,7 @@ import csv
 from dataclasses import dataclass
 
 from ingenialink.ethercat.register import EthercatRegister
+from ingenialink.utils._utils import dtype_value
 
 
 @dataclass
@@ -27,12 +28,31 @@ class RegisterRow:
         """
         index = f"0x{register.idx:04X}"
         subindex = f"0x{register.subidx:02X}"
-        value = f"0x{storage.hex().upper()}"
+        value = cls.__format_value_for_csv(register, storage)
         return cls(index, subindex, value)
 
     def to_bytes(self) -> bytes:
         """Return the row data as UTF-8 encoded bytes for the CRC calculation."""
         return ",".join(self.csv_row).encode()
+
+    @staticmethod
+    def __format_value_for_csv(reg: EthercatRegister, value: bytes) -> str:
+        """Format a value to be stored in a CSV configuration file.
+
+        Args:
+            reg: The register of the value.
+            value: The value to be formatted.
+
+        Returns:
+            The formatted value.
+        """
+        # Trim read data to avoid reading garbage
+        # To be fixed in INGK-1176
+        bytes_length, _ = dtype_value[reg.dtype]
+        value = value[:bytes_length]
+        # Convert from little endian to big endian
+        value = value[::-1]
+        return f"0x{value.hex().upper()}"
 
     @property
     def csv_row(self) -> list[str]:

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -9,7 +9,6 @@ from ingenialink import Servo
 from ingenialink.csv_configuration_file import CSVConfigurationFile
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.ethercat.dictionary import EthercatDictionary
-from ingenialink.utils._utils import dtype_value
 
 try:
     import pysoem
@@ -516,10 +515,6 @@ class EthercatServo(PDOServo):
                     continue
                 try:
                     storage = self._read_raw(configuration_register)
-                    # Trim read data to avoid reading garbage
-                    # To be fixed in INGK-1176
-                    bytes_length, _ = dtype_value[configuration_register.dtype]
-                    storage = storage[:bytes_length]
                     csv_configuration_file.add_register(configuration_register, storage)
                 except (ILError, NotImplementedError) as e:
                     logger.error(

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -1,4 +1,5 @@
 import csv
+import struct
 from pathlib import Path
 
 import pytest
@@ -14,9 +15,9 @@ def test_register_row_formatting():
     row = RegisterRow.from_register(reg, b"\x00\x00\xa0A")
     assert row.index == "0x2025"
     assert row.subindex == "0x00"
-    assert row.value == "0x0000A041"
-    assert row.csv_row == ["0x2025", "0x00", "0x0000A041"]
-    assert row.to_bytes() == b"0x2025,0x00,0x0000A041"
+    assert row.value == "0x41A00000"
+    assert row.csv_row == ["0x2025", "0x00", "0x41A00000"]
+    assert row.to_bytes() == b"0x2025,0x00,0x41A00000"
 
 
 @pytest.mark.no_connection
@@ -34,5 +35,17 @@ def test_csv_configuration_file(tmp_path: Path):
         crc_line = next(reader)
         data_rows = list(reader)
     assert header == ["v1"]
-    assert crc_line == ["0xD1BA"]
-    assert data_rows == [["0x2025", "0x00", "0x0000A041"], ["0x209A", "0x00", "0x0000803F"]]
+    assert crc_line == ["0x31E8"]
+    assert data_rows == [["0x2025", "0x00", "0x41A00000"], ["0x209A", "0x00", "0x3F800000"]]
+
+
+@pytest.mark.no_connection
+def test_format_value_for_csv():
+    reg = EthercatRegister(0x2025, 0x00, RegDtype.U32, RegAccess.RW)
+    register_float_value = 20.0
+    raw_value_little_endian = struct.pack("f", register_float_value)
+    garbage_bytes = b"\xff\xff"
+    raw_register_bytes = raw_value_little_endian + garbage_bytes
+    row = RegisterRow.from_register(reg, raw_register_bytes)
+    expected_value_big_endian = struct.pack(">f", register_float_value)
+    assert row.value == f"0x{expected_value_big_endian.hex().upper()}"


### PR DESCRIPTION
### Description

Export values to CSV using big-endian format.

### Type of change

- Add the __format_value_for_csv method.
- Add test.

### Tests
- [x] Add new unit tests if it applies.

### Documentation

Please update the documentation.

- [x] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).