### PR TITLE
INGK-1183 Revert changes

### DIFF
--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -9,7 +9,6 @@ from ingenialink import Servo
 from ingenialink.csv_configuration_file import CSVConfigurationFile
 from ingenialink.emcy import EmergencyMessage
 from ingenialink.ethercat.dictionary import EthercatDictionary
-from ingenialink.register import Register
 
 try:
     import pysoem
@@ -97,8 +96,6 @@ class EthercatServo(PDOServo):
     # Default PDO maps to assign if not specified
     DEFAULT_RPDO_MAP = "ETG_COMMS_RPDO_MAP1"
     DEFAULT_TPDO_MAP = "ETG_COMMS_TPDO_MAP1"
-
-    __EXCLUDED_REGISTERS_FROM_CONFIG_FILE = frozenset({"COMMS_ETH_MAC"})
 
     def __init__(
         self,
@@ -526,8 +523,3 @@ class EthercatServo(PDOServo):
                         e,
                     )
         csv_configuration_file.write_to_file()
-
-    def _is_register_valid_for_configuration_file(self, register: Register) -> bool:
-        if not super()._is_register_valid_for_configuration_file(register):
-            return False
-        return register.identifier not in self.__EXCLUDED_REGISTERS_FROM_CONFIG_FILE

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -165,16 +165,6 @@ def test_save_configuration(servo, net):
     _clean(filename)
 
 
-@pytest.mark.ethercat
-def test_excluded_ethercat_registers_from_configuration_file(servo):
-    for configuration_registers in servo._registers_to_save_in_configuration_file(None).values():
-        for configuration_register in configuration_registers:
-            assert (
-                configuration_register
-                not in servo._EthercatServo__EXCLUDED_REGISTERS_FROM_CONFIG_FILE
-            )
-
-
 @pytest.mark.no_connection
 def test_check_configuration(virtual_drive):
     server, servo = virtual_drive


### PR DESCRIPTION
### Description

 Some registers were excluded from the CSV configuration due to differences in access types in firmware versions earlier than 2.8.1.

While CSV configuration files can still be generated using firmware versions below 2.8.1, they will be rejected by the device. To successfully upload and apply the configuration, firmware version 2.8.1 or higher is required.

### Type of change

- Revert changes.


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).