### PR TITLE
Ingk 1161 callback function for complete access

### DIFF
--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -11,6 +11,7 @@ from ingenialink.constants import (
 )
 from ingenialink.dictionary import (
     CanOpenObject,
+    CanOpenObjectType,
     Dictionary,
     DictionarySafetyModule,
     DictionaryV2,
@@ -82,36 +83,78 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
 
     Args:
         dictionary_path: Path to the Ingenia dictionary.
-
     """
+
+    @cached_property
+    def _monitoring_disturbance_objects(self) -> list["CanOpenObject"]:
+        monitoring_obj = CanOpenObject(
+            uid="MON_DATA",
+            idx=0x58B2,
+            object_type=CanOpenObjectType.RECORD,
+            registers=[
+                CanopenRegister(
+                    identifier="MON_DATA_SUBINDEX_0",
+                    units="none",
+                    idx=0x58B2,
+                    subidx=0x00,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.U8,
+                    access=RegAccess.RW,
+                    subnode=0,
+                    labels={"en_US": "SubIndex 000"},
+                    cat_id="MONITORING",
+                ),
+                CanopenRegister(
+                    identifier="MON_DATA_VALUE",
+                    units="none",
+                    idx=0x58B2,
+                    subidx=0x01,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.BYTE_ARRAY_512,
+                    access=RegAccess.RO,
+                    subnode=0,
+                    labels={"en_US": "Monitoring data"},
+                    cat_id="MONITORING",
+                ),
+            ],
+        )
+        disturbance_obj = CanOpenObject(
+            uid="DIST_DATA",
+            idx=0x58B4,
+            object_type=CanOpenObjectType.RECORD,
+            registers=[
+                CanopenRegister(
+                    identifier="DIST_DATA_SUBINDEX_0",
+                    units="none",
+                    idx=0x58B4,
+                    subidx=0x00,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.U8,
+                    access=RegAccess.RW,
+                    subnode=0,
+                    labels={"en_US": "SubIndex 000"},
+                    cat_id="MONITORING",
+                ),
+                CanopenRegister(
+                    identifier="DIST_DATA_VALUE",
+                    units="none",
+                    idx=0x58B4,
+                    subidx=0x01,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.BYTE_ARRAY_512,
+                    access=RegAccess.WO,
+                    subnode=0,
+                    labels={"en_US": "Disturbance data"},
+                    cat_id="MONITORING",
+                ),
+            ],
+        )
+        return [monitoring_obj, disturbance_obj]
 
     @cached_property
     def _monitoring_disturbance_registers(self) -> list[CanopenRegister]:
         return [
-            CanopenRegister(
-                identifier="MON_DATA_VALUE",
-                units="none",
-                idx=0x58B2,
-                subidx=0x00,
-                pdo_access=RegCyclicType.CONFIG,
-                dtype=RegDtype.BYTE_ARRAY_512,
-                access=RegAccess.RO,
-                subnode=0,
-                labels={"en_US": "Monitoring data"},
-                cat_id="MONITORING",
-            ),
-            CanopenRegister(
-                identifier="DIST_DATA_VALUE",
-                units="none",
-                idx=0x58B4,
-                subidx=0x00,
-                pdo_access=RegCyclicType.CONFIG,
-                dtype=RegDtype.BYTE_ARRAY_512,
-                access=RegAccess.WO,
-                subnode=0,
-                labels={"en_US": "Disturbance data"},
-                cat_id="MONITORING",
-            ),
+            register for obj in self._monitoring_disturbance_objects for register in obj.registers
         ]
 
     @cached_property

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -193,6 +193,24 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
             )
             return None
 
+    def _add_canopen_object(self, canopen_object: "CanOpenObject") -> None:
+        """Adds Canopen object into the items list.
+
+        Args:
+            canopen_object: Canopen object to add.
+        """
+        axis = canopen_object.registers[0].subnode
+        if axis not in self.items:
+            self.items[axis] = {}
+        self.items[axis][canopen_object.uid] = canopen_object
+
+    def _append_missing_registers(self):
+        super()._append_missing_registers()
+
+        if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
+            for obj in self._monitoring_disturbance_objects:
+                self._add_canopen_object(obj)
+
 
 class CanopenDictionaryV3(CanopenDictionary, DictionaryV3):
     """Contains all registers and information of a CANopen dictionary.

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -204,7 +204,7 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
             self.items[axis] = {}
         self.items[axis][canopen_object.uid] = canopen_object
 
-    def _append_missing_registers(self):
+    def _append_missing_registers(self) -> None:
         super()._append_missing_registers()
 
         if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -88,27 +88,15 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
     @cached_property
     def _monitoring_disturbance_objects(self) -> list["CanOpenObject"]:
         monitoring_obj = CanOpenObject(
-            uid="MON_DATA",
+            uid="MON_DATA_VALUE",
             idx=0x58B2,
             object_type=CanOpenObjectType.RECORD,
             registers=[
                 CanopenRegister(
-                    identifier="MON_DATA_SUBINDEX_0",
-                    units="none",
-                    idx=0x58B2,
-                    subidx=0x00,
-                    pdo_access=RegCyclicType.CONFIG,
-                    dtype=RegDtype.U8,
-                    access=RegAccess.RW,
-                    subnode=0,
-                    labels={"en_US": "SubIndex 000"},
-                    cat_id="MONITORING",
-                ),
-                CanopenRegister(
                     identifier="MON_DATA_VALUE",
                     units="none",
                     idx=0x58B2,
-                    subidx=0x01,
+                    subidx=0x00,
                     pdo_access=RegCyclicType.CONFIG,
                     dtype=RegDtype.BYTE_ARRAY_512,
                     access=RegAccess.RO,
@@ -119,27 +107,15 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
             ],
         )
         disturbance_obj = CanOpenObject(
-            uid="DIST_DATA",
+            uid="DIST_DATA_VALUE",
             idx=0x58B4,
             object_type=CanOpenObjectType.RECORD,
             registers=[
                 CanopenRegister(
-                    identifier="DIST_DATA_SUBINDEX_0",
-                    units="none",
-                    idx=0x58B4,
-                    subidx=0x00,
-                    pdo_access=RegCyclicType.CONFIG,
-                    dtype=RegDtype.U8,
-                    access=RegAccess.RW,
-                    subnode=0,
-                    labels={"en_US": "SubIndex 000"},
-                    cat_id="MONITORING",
-                ),
-                CanopenRegister(
                     identifier="DIST_DATA_VALUE",
                     units="none",
                     idx=0x58B4,
-                    subidx=0x01,
+                    subidx=0x00,
                     pdo_access=RegCyclicType.CONFIG,
                     dtype=RegDtype.BYTE_ARRAY_512,
                     access=RegAccess.WO,

--- a/ingenialink/canopen/dictionary.py
+++ b/ingenialink/canopen/dictionary.py
@@ -207,7 +207,7 @@ class CanopenDictionaryV2(CanopenDictionary, DictionaryV2):
     def _append_missing_registers(self) -> None:
         super()._append_missing_registers()
 
-        if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
+        if self._DictionaryV2__MON_DIST_STATUS_REGISTER in self._registers[0]:  # type: ignore[attr-defined]
             for obj in self._monitoring_disturbance_objects:
                 self._add_canopen_object(obj)
 

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1626,6 +1626,10 @@ class DictionaryV2(Dictionary):
         return None
 
     @property
+    def _monitoring_disturbance_objects(self) -> list["CanOpenObject"]:
+        raise NotImplementedError
+
+    @property
     @abstractmethod
     def _monitoring_disturbance_registers(
         self,
@@ -1876,6 +1880,17 @@ class DictionaryV2(Dictionary):
             self.categories._categories[category] = {"en_US": category.capitalize()}
         self._registers[subnode][identifier] = register
 
+    def _add_canopen_object(self, canopen_object: "CanOpenObject") -> None:
+        """Adds Canopen object into the items list.
+
+        Args:
+            canopen_object: Canopen object to add.
+        """
+        axis = canopen_object.registers[0].subnode
+        if axis not in self.items:
+            self.items[axis] = {}
+        self.items[axis][canopen_object.uid] = canopen_object
+
     def _append_missing_registers(
         self,
     ) -> None:
@@ -1887,3 +1902,7 @@ class DictionaryV2(Dictionary):
         if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
             for register in self._monitoring_disturbance_registers:
                 self._add_register_list(register)
+
+            if self.interface in [Interface.CAN, Interface.ECAT]:
+                for obj in self._monitoring_disturbance_objects:
+                    self._add_canopen_object(obj)

--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -1880,17 +1880,6 @@ class DictionaryV2(Dictionary):
             self.categories._categories[category] = {"en_US": category.capitalize()}
         self._registers[subnode][identifier] = register
 
-    def _add_canopen_object(self, canopen_object: "CanOpenObject") -> None:
-        """Adds Canopen object into the items list.
-
-        Args:
-            canopen_object: Canopen object to add.
-        """
-        axis = canopen_object.registers[0].subnode
-        if axis not in self.items:
-            self.items[axis] = {}
-        self.items[axis][canopen_object.uid] = canopen_object
-
     def _append_missing_registers(
         self,
     ) -> None:
@@ -1902,7 +1891,3 @@ class DictionaryV2(Dictionary):
         if self.__MON_DIST_STATUS_REGISTER in self._registers[0]:
             for register in self._monitoring_disturbance_registers:
                 self._add_register_list(register)
-
-            if self.interface in [Interface.CAN, Interface.ECAT]:
-                for obj in self._monitoring_disturbance_objects:
-                    self._add_canopen_object(obj)

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -192,7 +192,7 @@ class DriveContextManager:
         else:
             self._objects_changed[register.subnode][obj.uid].append(register.identifier)
         self._update_reset_pdo_mapping_flags(uid=register.identifier)
-        logger.debug(f"{id(self)}: Object {obj.uid=} changed using complete access to {value}.")
+        logger.debug(f"{id(self)}: Object {obj.uid} changed using complete access to {value!r}.")
 
     def _store_register_data(self) -> None:
         """Saves the value of all registers."""
@@ -200,16 +200,13 @@ class DriveContextManager:
         for axis in axes:
             self._original_register_values[axis] = {}
             for uid, register in self.drive.dictionary.registers(subnode=axis).items():
-                if register.identifier in self._do_not_restore_registers:
+                if uid in self._do_not_restore_registers:
                     continue
                 if register.access in [RegAccess.WO, RegAccess.RO]:
                     continue
                 # These registers will be restored by resetting the PDO mapping
                 # or with complete access
-                if (
-                    _PDO_RPDO_MAP_REGISTER_UID in register.identifier
-                    or _PDO_TPDO_MAP_REGISTER_UID in register.identifier
-                ):
+                if _PDO_RPDO_MAP_REGISTER_UID in uid or _PDO_TPDO_MAP_REGISTER_UID in uid:
                     continue
 
                 try:

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -42,6 +42,7 @@ class DriveContextManager:
             complete_access_objects: list of objects that should be read using complete access.
                 Objects containing "ETG_COMMS_RPDO_" and "ETG_COMMS_TPDO_" are always read using
                 complete access.
+                Also disturbance data objects should be read using complete access.
                 Defaults to None.
         """
         self.drive = servo
@@ -62,6 +63,7 @@ class DriveContextManager:
         self._complete_access_objects: set[str] = (
             set(complete_access_objects) if isinstance(complete_access_objects, list) else set()
         )
+        self._complete_access_objects.update([servo.DIST_DATA])
 
         self._original_register_values: dict[int, dict[str, Union[int, float, str, bytes]]] = {}
 

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -8,7 +8,7 @@ from ingenialink.enums.register import RegAccess
 from ingenialink.exceptions import ILEcatStateError, ILIOError
 from ingenialink.pdo import PDOServo
 from ingenialink.register import Register
-from ingenialink.servo import Servo
+from ingenialink.servo import RegisterAccessOperation, Servo
 
 logger = get_logger(__name__)
 
@@ -157,7 +157,7 @@ class DriveContextManager:
         servo: Servo,  # noqa: ARG002
         register: Register,
         value: Union[int, float, str, bytes],
-        operation: str,
+        operation: RegisterAccessOperation,
     ) -> None:
         """Callback for registers changed using complete access.
 
@@ -165,7 +165,7 @@ class DriveContextManager:
             servo: servo.
             register: register.
             value: changed value.
-            operation: 'read' or 'write' depending on the operation performed.
+            operation: read or write depending on the operation performed.
 
         Raises:
             ValueError: if the register identifier is None.
@@ -174,7 +174,7 @@ class DriveContextManager:
             RuntimeError: if the register has been changed using complete access, but the
                 object original value was not stored.
         """
-        if operation == "read":
+        if operation is RegisterAccessOperation.READ:
             return
         if register.access in [RegAccess.WO, RegAccess.RO]:
             return

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -174,6 +174,8 @@ class DriveContextManager:
         """
         if operation == "read":
             return
+        if register.access in [RegAccess.WO, RegAccess.RO]:
+            return
 
         if register.identifier is None:
             raise ValueError("Register identifier cannot be None in complete access.")

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -79,7 +79,7 @@ class DriveContextManager:
         self._registers_changed: OrderedDict[tuple[int, str], Union[int, float, str, bytes]] = (
             OrderedDict()
         )
-        # Key: axis, value
+        # Key: axis, (object uid, [register uids])
         self._objects_changed: OrderedDict[int, dict[str, list[str]]] = OrderedDict()
 
         # If registers that contain the prefixes defined in _PDO_MAP_REGISTERS_UID

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from typing import Optional, Union, cast
+from typing import TYPE_CHECKING, Optional, Union, cast
 
 from ingenialogger import get_logger
 
@@ -9,6 +9,10 @@ from ingenialink.exceptions import ILEcatStateError, ILIOError
 from ingenialink.pdo import PDOServo
 from ingenialink.register import Register
 from ingenialink.servo import RegisterAccessOperation, Servo
+
+if TYPE_CHECKING:
+    from ingenialink.canopen.register import CanopenRegister
+    from ingenialink.ethercat.register import EthercatRegister
 
 logger = get_logger(__name__)
 
@@ -155,7 +159,7 @@ class DriveContextManager:
     def _complete_access_callback(
         self,
         servo: Servo,  # noqa: ARG002
-        register: Register,
+        register: Union["CanopenRegister", "EthercatRegister"],
         value: Union[int, float, str, bytes],
         operation: RegisterAccessOperation,
     ) -> None:
@@ -169,7 +173,6 @@ class DriveContextManager:
 
         Raises:
             ValueError: if the register identifier is None.
-            ValueError: if the register does not have idx attribute to retrieve main object.
             ValueError: if the servo dictionary is not a CanopenDictionary instance.
             RuntimeError: if the register has been changed using complete access, but the
                 object original value was not stored.
@@ -181,8 +184,6 @@ class DriveContextManager:
 
         if register.identifier is None:
             raise ValueError("Register identifier cannot be None in complete access.")
-        if not hasattr(register, "idx"):
-            raise ValueError("Register does not have idx attribute to retrieve main object.")
         if not isinstance(servo.dictionary, CanopenDictionary):
             raise ValueError("Servo dictionary is not a CanopenDictionary instance.")
 

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -17,6 +17,12 @@ logger = get_logger(__name__)
 _PDO_RPDO_MAP_REGISTER_UID = "ETG_COMMS_RPDO_"
 _PDO_TPDO_MAP_REGISTER_UID = "ETG_COMMS_TPDO_"
 
+# Monitoring and disturbance objects
+# In CANopen dictionaries, the uid is "MON_DATA_VALUE" and "DIST_DATA_VALUE"
+# In EtherCAT dictionaries, the uid is "MON_DATA" and "DIST_DATA"
+_MON_DATA_OBJECT_UID = "MON_DATA"
+_DIST_DATA_OBJECT_UID = "DIST_DATA"
+
 
 class DriveContextManager:
     """Context used to make modifications in the drive.
@@ -42,7 +48,8 @@ class DriveContextManager:
             complete_access_objects: list of objects that should be read using complete access.
                 Objects containing "ETG_COMMS_RPDO_" and "ETG_COMMS_TPDO_" are always read using
                 complete access.
-                Also disturbance data objects should be read using complete access.
+            Also, monitoring and disturbance data objects ("MON_DATA" and "DIST_DATA")
+                should be read using complete access.
                 Defaults to None.
         """
         self.drive = servo
@@ -63,7 +70,6 @@ class DriveContextManager:
         self._complete_access_objects: set[str] = (
             set(complete_access_objects) if isinstance(complete_access_objects, list) else set()
         )
-        self._complete_access_objects.update(["MON_DATA", "DIST_DATA"])
 
         self._original_register_values: dict[int, dict[str, Union[int, float, str, bytes]]] = {}
 
@@ -237,6 +243,8 @@ class DriveContextManager:
                 if (
                     (_PDO_RPDO_MAP_REGISTER_UID not in uid)
                     and (_PDO_TPDO_MAP_REGISTER_UID not in uid)
+                    and (_MON_DATA_OBJECT_UID not in uid)
+                    and (_DIST_DATA_OBJECT_UID not in uid)
                     and (uid not in self._complete_access_objects)
                 ):
                     continue

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -152,7 +152,7 @@ class DriveContextManager:
         self._registers_changed[dict_key] = current_value
         logger.debug(f"{id(self)}: {uid=} changed from {previous_value!r} to {current_value!r}")
 
-    def _complete_access_register_update_callback(
+    def _complete_access_callback(
         self,
         servo: Servo,  # noqa: ARG002
         register: Register,
@@ -335,15 +335,11 @@ class DriveContextManager:
         self._store_register_data()
         self._store_objects_data()
         self.drive.register_update_subscribe(self._register_update_callback)
-        self.drive.register_update_complete_access_subscribe(
-            self._complete_access_register_update_callback
-        )
+        self.drive.register_update_complete_access_subscribe(self._complete_access_callback)
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore [no-untyped-def]
         """Unsubscribes from register updates and restores the drive values."""
         self.drive.register_update_unsubscribe(self._register_update_callback)
-        self.drive.register_update_complete_access_unsubscribe(
-            self._complete_access_register_update_callback
-        )
+        self.drive.register_update_complete_access_unsubscribe(self._complete_access_callback)
         self._restore_register_data()
         self._restore_objects_data()

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -63,6 +63,8 @@ class DriveContextManager:
             servo.STORE_MOCO_ALL_REGISTERS,
             servo.RESTORE_COCO_ALL,
             servo.RESTORE_MOCO_ALL_REGISTERS,
+            # Mac address should not be restored, in certain FW versions the reading of MAC
+            # address provides different values each time
             "COMMS_ETH_MAC",
         ])
 

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -108,14 +108,14 @@ class DriveContextManager:
                 f"{id(self)}: {uid=} has been changed, will reset rpdo mapping on context exit"
             )
             self._reset_rpdo_mapping = True
-            return True
         elif _PDO_TPDO_MAP_REGISTER_UID in uid:
             logger.debug(
                 f"{id(self)}: {uid=} has been changed, will reset tpdo mapping on context exit"
             )
             self._reset_tpdo_mapping = True
-            return True
-        return False
+        else:
+            return False
+        return True
 
     def _register_update_callback(
         self,

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -63,7 +63,7 @@ class DriveContextManager:
         self._complete_access_objects: set[str] = (
             set(complete_access_objects) if isinstance(complete_access_objects, list) else set()
         )
-        self._complete_access_objects.update([servo.DIST_DATA])
+        self._complete_access_objects.update(["MON_DATA", "DIST_DATA"])
 
         self._original_register_values: dict[int, dict[str, Union[int, float, str, bytes]]] = {}
 

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -97,20 +97,20 @@ class DriveContextManager:
 
         # Reset the whole rpdo/tpdo mapping if needed
         if _PDO_RPDO_MAP_REGISTER_UID in uid:
-            logger.info(
+            logger.debug(
                 f"{id(self)}: {uid=} has been changed, will reset rpdo mapping on context exit"
             )
             self._reset_rpdo_mapping = True
             return
         if _PDO_TPDO_MAP_REGISTER_UID in uid:
-            logger.info(
+            logger.debug(
                 f"{id(self)}: {uid=} has been changed, will reset tpdo mapping on context exit"
             )
             self._reset_tpdo_mapping = True
             return
 
         self._registers_changed[dict_key] = value
-        logger.info(f"{id(self)}: {uid=} changed from {previous_value!r} to {value!r}")
+        logger.debug(f"{id(self)}: {uid=} changed from {previous_value!r} to {value!r}")
 
     def _store_register_data(self) -> None:
         """Saves the value of all registers."""
@@ -189,8 +189,10 @@ class DriveContextManager:
         """Subscribes to register update callbacks and saves the drive values."""
         self._store_register_data()
         self.drive.register_update_subscribe(self._register_update_callback)
+        self.drive.register_update_complete_access_subscribe(self._register_update_callback)
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore [no-untyped-def]
         """Unsubscribes from register updates and restores the drive values."""
         self.drive.register_update_unsubscribe(self._register_update_callback)
+        self.drive.register_update_complete_access_unsubscribe(self._register_update_callback)
         self._restore_register_data()

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -159,7 +159,7 @@ class DriveContextManager:
         value: Union[int, float, str, bytes],
         operation: str,
     ) -> None:
-        """Completes the access register update callback.
+        """Callback for registers changed using complete access.
 
         Args:
             servo: servo.

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -156,7 +156,9 @@ class DriveContextManager:
         registers_to_restore = [self._registers_changed]
         # Drive must be in pre-operational state to reset the PDO mapping
         # https://novantamotion.atlassian.net/browse/INGK-1160
-        if self._reset_tpdo_mapping or self._reset_rpdo_mapping:
+        if isinstance(self.drive, PDOServo) and (
+            self._reset_tpdo_mapping or self._reset_rpdo_mapping
+        ):
             try:
                 self.drive.check_servo_is_in_preoperational_state()
                 if self._reset_tpdo_mapping:
@@ -196,9 +198,6 @@ class DriveContextManager:
                     )
                     self.drive.write(uid, restore_value, subnode=axis)
                 restored_registers[axis].append(uid)
-
-        if not isinstance(self.drive, PDOServo):
-            return
 
     def __enter__(self) -> None:
         """Subscribes to register update callbacks and saves the drive values."""

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-# PDO map registers
+# PDO registers
 _PDO_RPDO_MAP_REGISTER_UID = "ETG_COMMS_RPDO_"
 _PDO_TPDO_MAP_REGISTER_UID = "ETG_COMMS_TPDO_"
 

--- a/ingenialink/ethercat/dictionary.py
+++ b/ingenialink/ethercat/dictionary.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from functools import cached_property
-from typing import Optional
+from typing import Optional, cast
 from xml.etree import ElementTree
 
 import ingenialogger
@@ -47,32 +47,77 @@ class EthercatDictionaryV2(EthercatDictionary, DictionaryV2):
     """
 
     @cached_property
+    def _monitoring_disturbance_objects(self) -> list["CanOpenObject"]:
+        monitoring_obj = CanOpenObject(
+            uid="MON_DATA",
+            idx=0x58B2,
+            object_type=CanOpenObjectType.RECORD,
+            registers=[
+                EthercatRegister(
+                    identifier="MON_DATA_SUBINDEX_0",
+                    units="none",
+                    idx=0x58B2,
+                    subidx=0x00,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.U8,
+                    access=RegAccess.RW,
+                    subnode=0,
+                    labels={"en_US": "SubIndex 000"},
+                    cat_id="MONITORING",
+                ),
+                EthercatRegister(
+                    identifier="MON_DATA_VALUE",
+                    units="none",
+                    idx=0x58B2,
+                    subidx=0x01,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.BYTE_ARRAY_512,
+                    access=RegAccess.RO,
+                    subnode=0,
+                    labels={"en_US": "Monitoring data"},
+                    cat_id="MONITORING",
+                ),
+            ],
+        )
+        disturbance_obj = CanOpenObject(
+            uid="DIST_DATA",
+            idx=0x58B4,
+            object_type=CanOpenObjectType.RECORD,
+            registers=[
+                EthercatRegister(
+                    identifier="DIST_DATA_SUBINDEX_0",
+                    units="none",
+                    idx=0x58B4,
+                    subidx=0x00,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.U8,
+                    access=RegAccess.RW,
+                    subnode=0,
+                    labels={"en_US": "SubIndex 000"},
+                    cat_id="MONITORING",
+                ),
+                EthercatRegister(
+                    identifier="DIST_DATA_VALUE",
+                    units="none",
+                    idx=0x58B4,
+                    subidx=0x01,
+                    pdo_access=RegCyclicType.CONFIG,
+                    dtype=RegDtype.BYTE_ARRAY_512,
+                    access=RegAccess.WO,
+                    subnode=0,
+                    labels={"en_US": "Disturbance data"},
+                    cat_id="MONITORING",
+                ),
+            ],
+        )
+        return [monitoring_obj, disturbance_obj]
+
+    @cached_property
     def _monitoring_disturbance_registers(self) -> list[EthercatRegister]:
         return [
-            EthercatRegister(
-                identifier="MON_DATA_VALUE",
-                units="none",
-                subnode=0,
-                idx=0x58B2,
-                subidx=0x01,
-                pdo_access=RegCyclicType.CONFIG,
-                dtype=RegDtype.BYTE_ARRAY_512,
-                access=RegAccess.RO,
-                labels={"en_US": "Monitoring data"},
-                cat_id="MONITORING",
-            ),
-            EthercatRegister(
-                identifier="DIST_DATA_VALUE",
-                units="none",
-                subnode=0,
-                idx=0x58B4,
-                subidx=0x01,
-                pdo_access=RegCyclicType.CONFIG,
-                dtype=RegDtype.BYTE_ARRAY_512,
-                access=RegAccess.WO,
-                labels={"en_US": "Disturbance data"},
-                cat_id="MONITORING",
-            ),
+            cast("EthercatRegister", register)
+            for obj in self._monitoring_disturbance_objects
+            for register in obj.registers
         ]
 
     @cached_property

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -1,5 +1,5 @@
 from functools import cached_property
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 from xml.etree import ElementTree
 
 import ingenialogger
@@ -15,6 +15,10 @@ from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.ethernet.register import EthernetRegister
 from ingenialink.register import MonDistV3
+
+if TYPE_CHECKING:
+    from ingenialink.dictionary import CanOpenObject
+
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -38,6 +42,10 @@ class EthernetDictionaryV2(EthernetDictionary, DictionaryV2):
         dictionary_path: Path to the Ingenia dictionary.
 
     """
+
+    @property
+    def _monitoring_disturbance_objects(self) -> list["CanOpenObject"]:
+        raise NotImplementedError("CanOpen objects are not implemented for this device.")
 
     @cached_property
     def _monitoring_disturbance_registers(self) -> list[EthernetRegister]:

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -314,7 +314,7 @@ class Servo:
             Callable[[Servo, Register, Union[int, float, str, bytes]], None]
         ] = []
         self.__register_update_complete_access_observers: list[
-            Callable[[Servo, Register, Union[int, float, str, bytes]], None]
+            Callable[[Servo, Register, Union[int, float, str, bytes], str], None]
         ] = []
         if servo_status_listener:
             self.start_status_listener()
@@ -1370,7 +1370,7 @@ class Servo:
         else:
             _reg = self._get_reg(reg, subnode)
         self._write_raw(_reg, data, complete_access=True)
-        self._notify_register_update_complete_access(_reg, data)
+        self._notify_register_update_complete_access(_reg, data, operation="write")
 
     def read_complete_access(
         self,
@@ -1405,7 +1405,7 @@ class Servo:
             )
 
         value = self._read_raw(_reg, buffer_size=buffer_size, complete_access=True)
-        self._notify_register_update_complete_access(_reg, value)
+        self._notify_register_update_complete_access(_reg, value, operation="read")
         return value
 
     def read_bitfields(
@@ -1503,7 +1503,7 @@ class Servo:
         self.__register_update_observers.remove(callback)
 
     def register_update_complete_access_subscribe(
-        self, callback: Callable[["Servo", Register, Union[int, float, str, bytes]], None]
+        self, callback: Callable[["Servo", Register, Union[int, float, str, bytes], str], None]
     ) -> None:
         """Subscribe to complete access register updates.
 
@@ -1515,7 +1515,7 @@ class Servo:
         self.__register_update_complete_access_observers.append(callback)
 
     def register_update_complete_access_unsubscribe(
-        self, callback: Callable[["Servo", Register, Union[int, float, str, bytes]], None]
+        self, callback: Callable[["Servo", Register, Union[int, float, str, bytes], str], None]
     ) -> None:
         """Unsubscribe to complete access register updates.
 
@@ -1541,7 +1541,9 @@ class Servo:
                 data,
             )
 
-    def _notify_register_update_complete_access(self, reg: Register, data: bytes) -> None:
+    def _notify_register_update_complete_access(
+        self, reg: Register, data: bytes, operation: str
+    ) -> None:
         """Notify a complete access register update to the observers.
 
         The updated value is stored in the register's storage attribute.
@@ -1549,6 +1551,7 @@ class Servo:
         Args:
             reg: Updated register.
             data: Updated value.
+            operation: 'read' or 'write' depending on the operation performed.
 
         """
         for callback in self.__register_update_complete_access_observers:
@@ -1556,6 +1559,7 @@ class Servo:
                 self,
                 reg,
                 data,
+                operation,
             )
 
     def replace_dictionary(self, dictionary: str) -> None:

--- a/ingenialink/utils/_utils.py
+++ b/ingenialink/utils/_utils.py
@@ -40,6 +40,7 @@ dtype_length_bits: dict[RegDtype, int] = {
     RegDtype.S64: 64,
     RegDtype.FLOAT: 32,
     RegDtype.BOOL: 1,
+    RegDtype.BYTE_ARRAY_512: 512 * 8,
 }
 
 VALID_BIT_REGISTER_VALUES = [0, 1, True, False]

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b5"
+version = "0.1.5+pr48b8"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b5-py3-none-any.whl", hash = "sha256:f1fa587cdd296dc1bfd96871b012b29dfb7c3f1d35d53d8afb406965d34fd7e9"},
+    {file = "summit_testing_framework-0.1.5+pr48b8-py3-none-any.whl", hash = "sha256:5c0c2f00c75c0418d12528a577ff432374cf1ad6c9e16d1a6ccd04136042c021"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "c21934099ab12495ad70555fc0d4d3aebb832e17ea78f03911a8dbed40eb2b77"
+content-hash = "f2ea683959689a6d12162c9cfc80bdca3aa3a40c9486a0ab1b35976ef1db3cf4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b8"
+version = "0.1.5+pr48b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b8-py3-none-any.whl", hash = "sha256:5c0c2f00c75c0418d12528a577ff432374cf1ad6c9e16d1a6ccd04136042c021"},
+    {file = "summit_testing_framework-0.1.5+pr48b1-py3-none-any.whl", hash = "sha256:b195c58a512f3ee08b368e9336eb3804e5e6b68ff7a7cb4bb2c87b6b4291502c"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f2ea683959689a6d12162c9cfc80bdca3aa3a40c9486a0ab1b35976ef1db3cf4"
+content-hash = "d80a42593c81dc630bd63ee012f9a6b2a4e2b8446070a06ff299e3a55031b183"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b1"
+version = "0.1.5+pr48b2"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b1-py3-none-any.whl", hash = "sha256:b195c58a512f3ee08b368e9336eb3804e5e6b68ff7a7cb4bb2c87b6b4291502c"},
+    {file = "summit_testing_framework-0.1.5+pr48b2-py3-none-any.whl", hash = "sha256:f6e4d71a40fd00a50afe5d0c83a7fa9601ca239d4ab62f75f5469593684452ce"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "d80a42593c81dc630bd63ee012f9a6b2a4e2b8446070a06ff299e3a55031b183"
+content-hash = "f4c5e12007cfd2f44d1c676db2b4aee85bb36b444e44739b732eb84e4aecf6c3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr44b14"
+version = "0.1.5+pr48b1"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr44b14-py3-none-any.whl", hash = "sha256:d307ea3feceb705c8c9d1270d4c0f5df890f5a817ae35aeb5d87ed569608535f"},
+    {file = "summit_testing_framework-0.1.5+pr48b1-py3-none-any.whl", hash = "sha256:b195c58a512f3ee08b368e9336eb3804e5e6b68ff7a7cb4bb2c87b6b4291502c"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "c707ccedf9bc27c1d0254cc9399d22409e275dde0954c40ce051a441a4cce127"
+content-hash = "d80a42593c81dc630bd63ee012f9a6b2a4e2b8446070a06ff299e3a55031b183"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b1"
+version = "0.1.5+pr48b12"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b1-py3-none-any.whl", hash = "sha256:b195c58a512f3ee08b368e9336eb3804e5e6b68ff7a7cb4bb2c87b6b4291502c"},
+    {file = "summit_testing_framework-0.1.5+pr48b12-py3-none-any.whl", hash = "sha256:d0b99976a49a1947532fa2e4078ac79fdd5bee24e2241475095e323cf9b17849"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "d80a42593c81dc630bd63ee012f9a6b2a4e2b8446070a06ff299e3a55031b183"
+content-hash = "92be68c9e4613405ad9278e91d0663374a54e47b2d701a031267946f574c2fde"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b12"
+version = "0.1.5+pr48b17"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b12-py3-none-any.whl", hash = "sha256:d0b99976a49a1947532fa2e4078ac79fdd5bee24e2241475095e323cf9b17849"},
+    {file = "summit_testing_framework-0.1.5+pr48b17-py3-none-any.whl", hash = "sha256:80fc0f13d0880334379873ad37d4ce0855a42e210346f627a955306ad268c043"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "92be68c9e4613405ad9278e91d0663374a54e47b2d701a031267946f574c2fde"
+content-hash = "2222d36b2551d4a1a1cda0214e4f2f343acaa4981c98d242543dc89c715e00f4"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b3"
+version = "0.1.5+pr48b4"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b3-py3-none-any.whl", hash = "sha256:2e7bead17d9b852e39e248151fd54c6c080cdc0fefc7b95cfa7cb36a35b1a032"},
+    {file = "summit_testing_framework-0.1.5+pr48b4-py3-none-any.whl", hash = "sha256:1af244584dd2c770f31b0e60dd6f37a6fae56cc45f290fa7aaa5d418d1780d78"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "001a3b2f6199e6d88ad98d02c2da76315099990918b319a80332343137bc0a57"
+content-hash = "8c373185bd094414c67dd34622d7422928731fae37d93b8bd53aa944540950cc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b2"
+version = "0.1.5+pr48b3"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b2-py3-none-any.whl", hash = "sha256:f6e4d71a40fd00a50afe5d0c83a7fa9601ca239d4ab62f75f5469593684452ce"},
+    {file = "summit_testing_framework-0.1.5+pr48b3-py3-none-any.whl", hash = "sha256:2e7bead17d9b852e39e248151fd54c6c080cdc0fefc7b95cfa7cb36a35b1a032"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "f4c5e12007cfd2f44d1c676db2b4aee85bb36b444e44739b732eb84e4aecf6c3"
+content-hash = "001a3b2f6199e6d88ad98d02c2da76315099990918b319a80332343137bc0a57"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3622,13 +3622,13 @@ test = ["pytest"]
 
 [[package]]
 name = "summit-testing-framework"
-version = "0.1.5+pr48b4"
+version = "0.1.5+pr48b5"
 description = "Testing framework for Novanta drives"
 optional = false
 python-versions = ">=3.9"
 groups = ["tests"]
 files = [
-    {file = "summit_testing_framework-0.1.5+pr48b4-py3-none-any.whl", hash = "sha256:1af244584dd2c770f31b0e60dd6f37a6fae56cc45f290fa7aaa5d418d1780d78"},
+    {file = "summit_testing_framework-0.1.5+pr48b5-py3-none-any.whl", hash = "sha256:f1fa587cdd296dc1bfd96871b012b29dfb7c3f1d35d53d8afb406965d34fd7e9"},
 ]
 
 [package.dependencies]
@@ -4283,4 +4283,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "8c373185bd094414c67dd34622d7422928731fae37d93b8bd53aa944540950cc"
+content-hash = "c21934099ab12495ad70555fc0d4d3aebb832e17ea78f03911a8dbed40eb2b77"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b8"
+summit-testing-framework = "==0.1.5+pr48b1"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr44b14"
+summit-testing-framework = "==0.1.5+pr48b1"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b2"
+summit-testing-framework = "==0.1.5+pr48b3"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b1"
+summit-testing-framework = "==0.1.5+pr48b2"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b12"
+summit-testing-framework = "==0.1.5+pr48b17"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b3"
+summit-testing-framework = "==0.1.5+pr48b4"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b4"
+summit-testing-framework = "==0.1.5+pr48b5"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b5"
+summit-testing-framework = "==0.1.5+pr48b8"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ pytest-cov = "==2.12.1"
 pytest-mock = "==3.6.1"
 pytest-console-scripts = "==1.4.1"
 twisted = "==24.11.0"
-summit-testing-framework = "==0.1.5+pr48b1"
+summit-testing-framework = "==0.1.5+pr48b12"
 
 # -----------------------------------------------------------------------
 #                                   TASKS

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -1,6 +1,16 @@
+from typing import TYPE_CHECKING
+
 import pytest
 
 from ingenialink.drive_context_manager import DriveContextManager
+from ingenialink.pdo import RPDOMap, TPDOMap
+
+if TYPE_CHECKING:
+    from summit_testing_framework.setups.descriptors import DriveEcatSetup
+    from summit_testing_framework.setups.environment_control import DriveEnvironmentController
+
+    from ingenialink.ethercat.network import EthercatNetwork
+    from ingenialink.ethercat.servo import EthercatServo
 
 _USER_OVER_VOLTAGE_UID = "DRV_PROT_USER_OVER_VOLT"
 _USER_UNDER_VOLTAGE_UID = "DRV_PROT_USER_UNDER_VOLT"
@@ -117,3 +127,42 @@ def test_drive_context_manager_with_do_not_restore_registers(setup_manager):
         assert _read_user_over_voltage_uid(servo) == new_reg_value
 
     assert _read_user_over_voltage_uid(servo) == new_reg_value
+
+
+@pytest.mark.ethercat
+def test_drive_context_manager_restores_complete_access_registers(
+    setup_manager: tuple["EthercatServo", "EthercatNetwork", str, "DriveEnvironmentController"],
+    setup_descriptor: "DriveEcatSetup",
+) -> None:
+    servo, _, _, _ = setup_manager
+    context = DriveContextManager(servo)
+
+    rpdo_map = RPDOMap()
+    tpdo_map = TPDOMap()
+
+    tpdo_registers = ["CL_POS_FBK_VALUE", "CL_VEL_FBK_VALUE"]
+    rpdo_registers = ["CL_POS_SET_POINT_VALUE", "CL_VEL_SET_POINT_VALUE"]
+
+    for tpdo_register in tpdo_registers:
+        register = servo.dictionary.get_register(tpdo_register)
+        tpdo_map.add_registers(register)
+    for rpdo_register in rpdo_registers:
+        register = servo.dictionary.get_register(rpdo_register)
+        rpdo_map.add_registers(register)
+
+    previous_etg_comms_rpdo_assign_1 = servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1)
+    previous_etg_comms_tpdo_assign_1 = servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1)
+
+    with context:
+        servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
+        servo.map_pdos(slave_index=setup_descriptor.slave)
+
+        assert (
+            servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1) != previous_etg_comms_rpdo_assign_1
+        )
+        assert (
+            servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1) != previous_etg_comms_tpdo_assign_1
+        )
+
+    assert servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1) == previous_etg_comms_rpdo_assign_1
+    assert servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1) == previous_etg_comms_tpdo_assign_1

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -158,11 +158,11 @@ def test_drive_context_manager_restores_complete_access_registers(
         servo.map_pdos(slave_index=setup_descriptor.slave)
 
         assert (
-            servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1) != previous_etg_comms_rpdo_assign_1
+            servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=0) != previous_etg_comms_rpdo_assign_1
         )
         assert (
-            servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1) != previous_etg_comms_tpdo_assign_1
+            servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=0) != previous_etg_comms_tpdo_assign_1
         )
 
-    assert servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1) == previous_etg_comms_rpdo_assign_1
-    assert servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1) == previous_etg_comms_tpdo_assign_1
+    assert servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=0) == previous_etg_comms_rpdo_assign_1
+    assert servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=0) == previous_etg_comms_tpdo_assign_1

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -159,7 +159,8 @@ def test_drive_context_manager_restores_complete_access_registers(
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
         servo.map_pdos(slave_index=setup_descriptor.slave)
 
-        assert context._registers_changed == {}
+        assert (0, "ETG_COMMS_RPDO_ASSIGN_TOTAL") in context._registers_changed
+        assert (0, "ETG_COMMS_TPDO_ASSIGN_TOTAL") in context._registers_changed
         assert len(context._objects_changed[0]) == 4
         assert "ETG_COMMS_RPDO_ASSIGN" in context._objects_changed[0]
         assert "ETG_COMMS_TPDO_ASSIGN" in context._objects_changed[0]

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -150,8 +150,8 @@ def test_drive_context_manager_restores_complete_access_registers(
         register = servo.dictionary.get_register(rpdo_register)
         rpdo_map.add_registers(register)
 
-    previous_etg_comms_rpdo_assign_1 = servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=1)
-    previous_etg_comms_tpdo_assign_1 = servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=1)
+    previous_etg_comms_rpdo_assign_1 = servo.read(servo.ETG_COMMS_RPDO_ASSIGN_1, subnode=0)
+    previous_etg_comms_tpdo_assign_1 = servo.read(servo.ETG_COMMS_TPDO_ASSIGN_1, subnode=0)
 
     with context:
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -155,14 +155,15 @@ def test_drive_context_manager_restores_complete_access_registers(
 
     with context:
         assert context._registers_changed == {}
-        assert context._objects_changed == {}
+        assert context._objects_changed == set()
         servo.set_pdo_map_to_slave([rpdo_map], [tpdo_map])
         servo.map_pdos(slave_index=setup_descriptor.slave)
 
         assert (0, "ETG_COMMS_RPDO_ASSIGN_TOTAL") in context._registers_changed
         assert (0, "ETG_COMMS_TPDO_ASSIGN_TOTAL") in context._registers_changed
-        assert len(context._objects_changed[0]) == 4
-        assert "ETG_COMMS_RPDO_ASSIGN" in context._objects_changed[0]
-        assert "ETG_COMMS_TPDO_ASSIGN" in context._objects_changed[0]
-        assert "ETG_COMMS_RPDO_MAP1" in context._objects_changed[0]
-        assert "ETG_COMMS_TPDO_MAP1" in context._objects_changed[0]
+        assert len(context._objects_changed) == 4
+        objects_uids = [obj.uid for obj in context._objects_changed]
+        assert "ETG_COMMS_RPDO_ASSIGN" in objects_uids
+        assert "ETG_COMMS_TPDO_ASSIGN" in objects_uids
+        assert "ETG_COMMS_RPDO_MAP1" in objects_uids
+        assert "ETG_COMMS_TPDO_MAP1" in objects_uids


### PR DESCRIPTION
### Description

Add callback function for complete access read/write.

Tested with https://github.com/ingeniamc/ingeniamotion/pull/433 and summit-testing-framework new wheel including the INGK changes introduced by this PR.

### Type of change

Please add a description and delete options that are not relevant.

- [X] Added callback function for complete access read/write.
- [X] Modified drive context manager to subscribe to complete access regitser updates.
- [X] Added monitoring and disturbance CANopen objects for v2 dictionaries.
- [X] Fixed `dtype_length_bits` to include `RegDtype.BYTE_ARRAY_512`.


### Tests
- [X] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).