### PR TITLE
INGK-1184 Notify disconnection after teardown is finished

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -415,14 +415,14 @@ class CanopenNetwork(Network):
             servo: Instance of the servo connected.
 
         """
-        # Notify that disconnect_from_slave has been called
-        if servo._disconnect_callback:
-            servo._disconnect_callback(servo)
         self.stop_status_listener()
         servo.stop_status_listener()
         self.servos.remove(servo)
         if not self.servos:
             self._teardown_connection()
+        # Notify that disconnect_from_slave has been called
+        if servo._disconnect_callback:
+            servo._disconnect_callback(servo)
 
     def _setup_connection(self) -> None:
         """Creates a network interface object.

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -546,9 +546,6 @@ class EthercatNetwork(Network):
             servo: Instance of the servo connected.
 
         """
-        # Notify that disconnect_from_slave has been called
-        if servo._disconnect_callback:
-            servo._disconnect_callback(servo)
         if not self._change_nodes_state(servo, pysoem.INIT_STATE):
             logger.warning("Drive can not reach Init state")
         servo.teardown()
@@ -556,6 +553,9 @@ class EthercatNetwork(Network):
         if not self.servos:
             self.stop_status_listener()
             self.close_ecat_master()
+        # Notify that disconnect_from_slave has been called
+        if servo._disconnect_callback:
+            servo._disconnect_callback(servo)
 
     def config_pdo_maps(self) -> None:
         """Configure the PDO maps.

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -306,15 +306,15 @@ class EthernetNetwork(Network):
             servo: Instance of the servo connected.
 
         """
-        # Notify that disconnect_from_slave has been called
-        if servo._disconnect_callback:
-            servo._disconnect_callback(servo)
         self.servos.remove(servo)
         servo.stop_status_listener()
         self.close_socket(servo.socket)
         self._set_servo_state(servo.ip_address, NetState.DISCONNECTED)
         if len(self.servos) == 0:
             self.stop_status_listener()
+        # Notify that disconnect_from_slave has been called
+        if servo._disconnect_callback:
+            servo._disconnect_callback(servo)
 
     @staticmethod
     def close_socket(sock: socket.socket) -> None:


### PR DESCRIPTION
### Description

The disconnection notification is being done too early, causing the callback method to be called before INGK is finished with the connection teardown.

### Type of change

- Notify of the disconnection after the teardown is finished.

### Tests
- [ ] Add new unit tests if it applies.

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).