### PR TITLE
Ingk 1203 fix set network reference not set if connecting to servo and master is closed

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -497,6 +497,8 @@ class EthercatNetwork(Network):
             raise ValueError("Invalid slave ID value")
         if not self.__is_master_running:
             self._start_master()
+            if self not in ETHERCAT_NETWORK_REFERENCES:
+                set_network_reference(network=self)
         if slave_id not in self.__last_init_nodes:
             self.__init_nodes()
         if len(self.__last_init_nodes) == 0:

--- a/tests/ethercat/test_ethercat_network.py
+++ b/tests/ethercat/test_ethercat_network.py
@@ -356,6 +356,37 @@ def test_master_reference_is_kept_after_scan(setup_descriptor):
 
 
 @pytest.mark.ethercat
+def test_network_reference_is_added_back_if_servo_connected_after_close(setup_descriptor):
+    previous_networks = ETHERCAT_NETWORK_REFERENCES.copy()
+    net = EthercatNetwork(setup_descriptor.ifname, gil_release_config=GilReleaseConfig.always())
+    assert len(ETHERCAT_NETWORK_REFERENCES) == len(previous_networks) + 1
+    assert net in ETHERCAT_NETWORK_REFERENCES
+
+    assert len(net.servos) == 0
+    servo = net.connect_to_slave(
+        setup_descriptor.slave,
+        setup_descriptor.dictionary.as_posix(),
+    )
+    assert len(net.servos) == 1
+
+    net.disconnect_from_slave(servo)
+    assert len(net.servos) == 0
+    assert len(ETHERCAT_NETWORK_REFERENCES) == len(previous_networks)
+
+    # Connect again to a servo, the network reference should be added back
+    servo = net.connect_to_slave(
+        setup_descriptor.slave,
+        setup_descriptor.dictionary.as_posix(),
+    )
+    assert len(net.servos) == 1
+
+    assert len(ETHERCAT_NETWORK_REFERENCES) == len(previous_networks) + 1
+    assert net in ETHERCAT_NETWORK_REFERENCES
+
+    net.disconnect_from_slave(servo)
+
+
+@pytest.mark.ethercat
 def test_network_is_not_released_if_gil_operation_ongoing(mocker, setup_descriptor):
     blocking_time = 5
 


### PR DESCRIPTION
### Description

When `disconnect_from_slave` is called in an `EtherCAT` network, if the servo was the last one, the master is closed.

If the master is closed, the reference of the network is released. If a servo was reconnected again, the master would start, but the reference of the network was not added back.

### Type of change

Please add a description and delete options that are not relevant.

- [X] Add back network reference if already released when reconnecting to a servo.


### Tests
- [X] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [X] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).