### PR TITLE
MOT3-5242 Avoid CIA registers in virtual drive dictionary

### DIFF
--- a/ingenialink/virtual/dictionary.py
+++ b/ingenialink/virtual/dictionary.py
@@ -49,7 +49,7 @@ class VirtualDictionaryV2(VirtualDictionary, EthernetDictionaryV2):
             return None
 
         if self.dict_interface == "CAN" and (
-            register.attrib["cat_id"] == "CIA402" or register.attrib["id"].startswith("CIA402_")
+            register.attrib["cat_id"] == "CIA402" or register.attrib["id"].startswith("CIA")
         ):
             return None
 

--- a/tests/canopen/test_canopen_dictionary_v2.py
+++ b/tests/canopen/test_canopen_dictionary_v2.py
@@ -45,8 +45,9 @@ def test_read_dictionary_registers():
             "DRV_AXIS_NUMBER",
             "COMMS_ETH_IP",
             "COMMS_ETH_NET_MASK",
+            "CIA301_DRV_ID_DEVICE_TYPE",
         ],
-        1: ["COMMU_ANGLE_SENSOR"],
+        1: ["COMMU_ANGLE_SENSOR", "CIA402_DRV_STATE_CONTROL"],
     }
 
     canopen_dict = CanopenDictionaryV2(tests.resources.canopen.TEST_DICT_CAN)
@@ -87,6 +88,7 @@ def test_read_dictionary_categories():
         "COMMUTATION",
         "REPORTING",
         "MONITORING",
+        "CIA402",
     ]
 
     canopen_dict = CanopenDictionaryV2(tests.resources.canopen.TEST_DICT_CAN)

--- a/tests/resources/canopen/test_dict_can.xdf
+++ b/tests/resources/canopen/test_dict_can.xdf
@@ -73,6 +73,16 @@
             <Enum value="8">Incremental encoder 2</Enum>
           </Enumerations>
         </Register>
+        <Register access="rw" address_type="NVM_NONE" address="0x604000"  dtype="u16" id="CIA402_DRV_STATE_CONTROL" units="-" subnode="1"  desc="" cat_id="CIA402">
+            <Labels>
+                <Label lang="en_US">Control Word</Label>
+            </Labels>
+        </Register>
+        <Register access="r" address_type="NVM_NONE" address="0x100000"  dtype="u32" id="CIA301_DRV_ID_DEVICE_TYPE" units="-" subnode="0" cyclic="CONFIG" desc="This object shall provide information about the device type. The object describes the type of the logical device and its functionality." cat_id="IDENTIFICATION">
+            <Labels>
+                <Label lang="en_US">Device type</Label>
+            </Labels>
+        </Register>
       </Registers>
     </Device>
     <Errors>

--- a/tests/virtual/test_virtual_dictionary.py
+++ b/tests/virtual/test_virtual_dictionary.py
@@ -27,3 +27,16 @@ def test_read_xdf_register_canopen(reg_id, subnode, address):
     ethernet_dict = VirtualDictionaryV2(dictionary_path)
 
     assert ethernet_dict.registers(subnode)[reg_id].address == address
+
+
+@pytest.mark.no_connection
+def test_no_cia_registers_in_dictionary():
+    dictionary_path = tests.resources.canopen.TEST_DICT_CAN
+
+    virtual_dict = VirtualDictionaryV2(dictionary_path)
+
+    assert "CIA402" not in virtual_dict.categories.category_ids
+
+    for subnode in virtual_dict.subnodes:
+        for register in virtual_dict.registers(subnode):
+            assert not register.startswith("CIA")


### PR DESCRIPTION
### Description

The CIA301 registers in the virtual drive are causing read failures (the converted address is invalid).

Remove all CIA301 register references from the virtual drive dictionary to prevent these errors.

### Type of change

Please add a description and delete options that are not relevant.

- [ ] Change 1 (description)
- [ ] Change 2 (description)


### Tests
- [ ] Add new unit tests if it applies.

Please describe the manual tests that you ran to verify your changes if it applies. 

### Documentation

Please update the documentation.

- [ ] Update docstrings of every function, method or class that change.
- [ ] Build documentation locally to verify changes.
- [ ] Add the changes at the `[Unreleased]` section of the [CHANGELOG](CHANGELOG.md).