### PR TITLE
Update CHANGELOG with unreleased fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+### Fixed
+- Fix issues of servo status listener of ethercat drives when the drive is on operational state
+
 ## [7.6.0] - 2026-03-20
 ### Added
 - Add support for tables for XDF and XCF and CSV export. XCF version has been updated to 2.2
@@ -10,7 +14,6 @@
 
 ### Fixed
 - Fix sdo timeout rollback issue during store and firmware loading operations.
-- Fix issues of servo status listener of ethercat drives when the drive is on operational state
 
 ## [7.5.2] - 2025-11-24
 ### Added


### PR DESCRIPTION
the changelog was automatically merged aftered after the release, but that issue is not actually included in that release

https://github.com/ingeniamc/ingenialink-python/pull/760/changes#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13

Fixing it by creating a new unrelased section