### PR TITLE
Ingk 1260 add configurationfile from dictionary defaults and override values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Create config files from DictionaryV3 defaults
+- Override configuration file values with values form another configuration file
+- Allow to upload configurations from configuration file class
+
 ### Fixed
 - Fix issues of servo status listener of ethercat drives when the drive is on operational state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Added
 - Create config files from DictionaryV3 defaults
-- Override configuration file values with values form another configuration file
+- Override configuration file values with values from another configuration file
 - Allow to upload configurations from configuration file class
 
 ### Fixed

--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -674,11 +674,11 @@ class ConfigurationFile(XMLBase, ABC):
                 the register default is missing.
         """
         xcf_instance = cls.create_empty_configuration(
-            dictionary.interface,
-            dictionary.part_number,
-            dictionary.product_code,
-            dictionary.revision_number,
-            dictionary.firmware_version,
+            interface=dictionary.interface,
+            part_number=dictionary.part_number,
+            product_code=dictionary.product_code,
+            revision_number=dictionary.revision_number,
+            firmware_version=dictionary.firmware_version,
         )
         for register in dictionary.all_registers():
             # Only NVM/NVM_CFG registers with RW access are stored in a configuration file

--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -10,7 +10,14 @@ import numpy as np
 from typing_extensions import Literal
 
 from ingenialink import RegAccess, RegDtype
-from ingenialink.dictionary import ACCESS_XDF_OPTIONS, DTYPE_XDF_OPTIONS, Interface, XMLBase
+from ingenialink.dictionary import (
+    ACCESS_XDF_OPTIONS,
+    DTYPE_XDF_OPTIONS,
+    DictionaryV3,
+    Interface,
+    XMLBase,
+)
+from ingenialink.enums.register import RegAddressType
 from ingenialink.exceptions import ILConfigurationFileParseError
 from ingenialink.register import Register
 
@@ -646,3 +653,93 @@ class ConfigurationFile(XMLBase, ABC):
             True if contains target subnode registers, else False
         """
         return subnode in self.__subnodes
+
+    @classmethod
+    def from_dictionary_defaults(cls, dictionary: DictionaryV3) -> "ConfigurationFile":
+        """Create a ConfigurationFile populated with default values from an XDF3 dictionary.
+
+        Iterates all registers in the dictionary, filters to those that are writable
+        (RW) and stored in NVM (NVM_CFG or NVM address type), and populates each with
+        its declared default value.
+
+        Args:
+            dictionary: XDF3 dictionary to read defaults from.
+
+        Returns:
+            ConfigurationFile with all valid registers set to their default values.
+
+        Raises:
+            ValueError: If a qualifying register has no default value or a bytes default
+                (DOMAIN dtype), which indicates the dictionary is not a valid XDF3 or
+                the register default is missing.
+        """
+        xcf_instance = cls.create_empty_configuration(
+            dictionary.interface,
+            dictionary.part_number,
+            dictionary.product_code,
+            dictionary.revision_number,
+            dictionary.firmware_version,
+        )
+        for register in dictionary.all_registers():
+            # Only NVM/NVM_CFG registers with RW access are stored in a configuration file
+            if register.access != RegAccess.RW or register.address_type not in (
+                RegAddressType.NVM_CFG,
+                RegAddressType.NVM,
+            ):
+                continue
+            default = register.default
+            # A None or bytes default indicates the XDF3 is missing the default declaration,
+            # which is not allowed in a valid V3 dictionary
+            if default is None or isinstance(default, bytes):
+                raise ValueError(
+                    f"Register {register.identifier!r} has no valid default value. "
+                    "from_dictionary_defaults requires an XDF3 dictionary where all "
+                    "NVM/NVM_CFG RW registers have a declared default value."
+                )
+            xcf_instance.add_register(register, default)
+        return xcf_instance
+
+    def override_values(self, other: "ConfigurationFile") -> None:
+        """Overlay another ConfigurationFile's values onto this one.
+
+        For each register and table in ``other``:
+
+        - If a matching entry (same subnode and uid) exists in ``self``, it is replaced.
+        - If no match is found, the entry is appended to ``self`` and a warning is logged.
+
+        Args:
+            other: ConfigurationFile whose values will be applied on top of ``self``.
+        """
+        # Build an index of existing registers keyed by (subnode, uid) for O(1) lookup
+        existing_reg_idx: dict[tuple[int, str], int] = {
+            (reg.subnode, reg.uid): i for i, reg in enumerate(self.registers)
+        }
+        for new_reg in other.registers:
+            key = (new_reg.subnode, new_reg.uid)
+            if key in existing_reg_idx:
+                # Replace the existing register with the overriding value
+                self.registers[existing_reg_idx[key]] = new_reg
+            else:
+                # Register is new (not present in base config) — add it but warn the caller
+                logger.warning(
+                    f"Register {new_reg.uid!r} (subnode {new_reg.subnode}) from the override "
+                    "configuration was not found in the target; it will be added."
+                )
+                self.add_config_register(new_reg)
+
+        # Same logic for tables, indexed by (subnode, uid)
+        existing_table_idx: dict[tuple[int, str], int] = {
+            (t.subnode, t.uid): i for i, t in enumerate(self.tables)
+        }
+        for new_table in other.tables:
+            key = (new_table.subnode, new_table.uid)
+            if key in existing_table_idx:
+                # Replace the existing table with the overriding content
+                self.tables[existing_table_idx[key]] = new_table
+            else:
+                # Table is new — add it but warn the caller
+                logger.warning(
+                    f"Table {new_table.uid!r} (subnode {new_table.subnode}) from the override "
+                    "configuration was not found in the target; it will be added."
+                )
+                self.add_config_table(new_table)

--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -662,6 +662,9 @@ class ConfigurationFile(XMLBase, ABC):
         (RW) and stored in NVM (NVM_CFG or NVM address type), and populates each with
         its declared default value.
 
+        Tables are not included in the generated ConfigurationFile, as they have no default
+        values declared in the dictionary.
+
         Args:
             dictionary: XDF3 dictionary to read defaults from.
 
@@ -697,6 +700,7 @@ class ConfigurationFile(XMLBase, ABC):
                     "NVM/NVM_CFG RW registers have a declared default value."
                 )
             xcf_instance.add_register(register, default)
+
         return xcf_instance
 
     def override_values(self, other: "ConfigurationFile") -> None:
@@ -705,7 +709,10 @@ class ConfigurationFile(XMLBase, ABC):
         For each register and table in ``other``:
 
         - If a matching entry (same subnode and uid) exists in ``self``, it is replaced.
-        - If no match is found, the entry is appended to ``self`` and a warning is logged.
+        - If no match is found the entry is appended to ``self``. For registers a warning
+          is logged (unexpected mismatch). For tables a debug message is logged instead,
+          because tables have no default values in the dictionary and are therefore never
+          present in a ``ConfigurationFile`` built with :meth:`from_dictionary_defaults`.
 
         Args:
             other: ConfigurationFile whose values will be applied on top of ``self``.
@@ -737,9 +744,9 @@ class ConfigurationFile(XMLBase, ABC):
                 # Replace the existing table with the overriding content
                 self.tables[existing_table_idx[key]] = new_table
             else:
-                # Table is new — add it but warn the caller
-                logger.warning(
-                    f"Table {new_table.uid!r} (subnode {new_table.subnode}) from the override "
-                    "configuration was not found in the target; it will be added."
+                # Table did not exist in base config — Probably from a older xcf
+                # or one that was created from a dictionary defaults (that does not include them)
+                logger.debug(
+                    f"Table {new_table.uid!r} (subnode {new_table.subnode}) not in target; adding."
                 )
                 self.add_config_table(new_table)

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -640,12 +640,15 @@ class Servo:
             return convert_dtype_to_bytes(config_register.storage, target_register.dtype)
 
     def load_configuration(
-        self, config_file: str, subnode: Optional[int] = None, strict: bool = False
+        self,
+        config_file: Union[str, ConfigurationFile],
+        subnode: Optional[int] = None,
+        strict: bool = False,
     ) -> None:
         """Write current dictionary storage to the servo drive.
 
         Args:
-            config_file: Path to the dictionary.
+            config_file: Path to the configuration file, or a ConfigurationFile instance.
             subnode: Subnode of the axis.
             strict: Whether to raise an exception if any error occurs during the loading
             configuration process. If false, all errors will only be ignored.
@@ -661,7 +664,11 @@ class Servo:
         """
         if subnode is not None and (not isinstance(subnode, int) or subnode < 0):
             raise ValueError("Invalid subnode")
-        xcf_instance = ConfigurationFile.load_from_xcf(config_file)
+        # Accept either a pre-built ConfigurationFile object or a path to an XCF file
+        if isinstance(config_file, ConfigurationFile):
+            xcf_instance = config_file
+        else:
+            xcf_instance = ConfigurationFile.load_from_xcf(config_file)
 
         if subnode == 0 and not xcf_instance.contains_node(subnode):
             raise ValueError(f"Cannot load {config_file} to subnode {subnode}")

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -1,3 +1,4 @@
+import logging
 from typing import ClassVar
 from xml.etree import ElementTree
 
@@ -12,6 +13,8 @@ from ingenialink.configuration_file import (
     TableElement,
 )
 from ingenialink.dictionary import Interface
+from ingenialink.enums.register import RegAddressType
+from ingenialink.ethercat.dictionary import EthercatDictionaryV3
 from ingenialink.register import Register
 
 
@@ -207,3 +210,138 @@ def test_register_to_xcf_writes_data_as_hex():
     assert element.get("storage") == "1234"
     # data must be hex string matching the bytes
     assert element.get("data") == "aabbcc"
+
+
+class TestFromDictionaryDefaults:
+    """Tests for ConfigurationFile.from_dictionary_defaults.
+
+    Uses tests.resources.TEST_DICT_ECAT_EOE_v3 (EthercatDictionaryV3) which
+    contains exactly 6 registers: 3 qualifying (RW + NVM/NVM_CFG) with defaults,
+    2 read-only, and 1 RW non-NVM register.
+
+    Qualifying registers in that file:
+        CIA301_COMMS_RPDO1_MAP   (U8,  default=1)
+        CIA301_COMMS_RPDO1_MAP_1 (U32, default=268451936)
+        COMMU_ANGLE_SENSOR       (U16, default=4)
+    """
+
+    def test_from_dictionary_defaults(self):
+        """Only RW+NVM registers are included, with their XDF3 defaults and device metadata."""
+        dictionary = EthercatDictionaryV3(tests.resources.TEST_DICT_ECAT_EOE_v3, Interface.ECAT)
+
+        conf = ConfigurationFile.from_dictionary_defaults(dictionary)
+
+        # Only the 3 qualifying registers are present — RO and non-NVM registers are excluded
+        assert len(conf.registers) == 3
+        assert {r.uid for r in conf.registers} == {
+            "CIA301_COMMS_RPDO1_MAP",
+            "CIA301_COMMS_RPDO1_MAP_1",
+            "COMMU_ANGLE_SENSOR",
+        }
+
+        # Each register carries its declared XDF3 default value
+        reg_map = {r.uid: r.storage for r in conf.registers}
+        assert reg_map["CIA301_COMMS_RPDO1_MAP"] == 1
+        assert reg_map["CIA301_COMMS_RPDO1_MAP_1"] == 268451936
+        assert reg_map["COMMU_ANGLE_SENSOR"] == 4
+
+        # Non-qualifying registers from the dictionary must not appear in the result
+        excluded_uids = {
+            r.identifier
+            for r in dictionary.all_registers()
+            if r.access != RegAccess.RW
+            or r.address_type not in (RegAddressType.NVM_CFG, RegAddressType.NVM)
+        }
+        assert not ({r.uid for r in conf.registers} & excluded_uids)
+
+        # Device metadata is copied from the dictionary
+        assert conf.device.interface == Interface.ECAT
+        assert conf.device.part_number == dictionary.part_number
+        assert conf.device.product_code == dictionary.product_code
+        assert conf.device.revision_number == dictionary.revision_number
+        assert conf.device.firmware_version == dictionary.firmware_version
+
+
+class TestOverrideValues:
+    """Tests for ConfigurationFile.override_values."""
+
+    def test_replaces_matching_register(self):
+        """A register matching by (subnode, uid) has its value replaced."""
+        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base.add_config_register(
+            ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=10)
+        )
+
+        override = ConfigurationFile.create_empty_configuration(
+            Interface.ETH, None, None, None, None
+        )
+        override.add_config_register(
+            ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=99)
+        )
+
+        base.override_values(override)
+
+        assert len(base.registers) == 1
+        assert base.registers[0].storage == 99
+
+    def test_adds_non_matching_register_with_warning(self, caplog):
+        """A register not present in base is added, and a warning is logged."""
+        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base.add_config_register(
+            ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=1)
+        )
+
+        override = ConfigurationFile.create_empty_configuration(
+            Interface.ETH, None, None, None, None
+        )
+        override.add_config_register(
+            ConfigRegister(
+                "REG_NEW", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=77
+            )
+        )
+
+        with caplog.at_level(logging.WARNING):
+            base.override_values(override)
+
+        assert len(base.registers) == 2
+        assert base.registers[1].uid == "REG_NEW"
+        assert any("REG_NEW" in record.message for record in caplog.records)
+
+    def test_replaces_matching_table(self):
+        """A table matching by (subnode, uid) has its content replaced."""
+        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
+        base.add_config_table(
+            ConfigTable(uid="TABLE_A", subnode=0, elements=[TableElement(0, b"\x01")])
+        )
+
+        override = ConfigurationFile.create_empty_configuration(
+            Interface.ETH, None, None, None, None
+        )
+        override.add_config_table(
+            ConfigTable(uid="TABLE_A", subnode=0, elements=[TableElement(0, b"\xff")])
+        )
+
+        base.override_values(override)
+
+        assert len(base.tables) == 1
+        assert base.tables[0].elements[0].data == b"\xff"
+
+    def test_adds_non_matching_table_with_warning(self, caplog):
+        """A table not present in base is added, and a warning is logged."""
+        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
+
+        override = ConfigurationFile.create_empty_configuration(
+            Interface.ETH, None, None, None, None
+        )
+        override.add_config_table(
+            ConfigTable(uid="TABLE_NEW", subnode=0, elements=[TableElement(0, b"\xab")])
+        )
+
+        with caplog.at_level(logging.WARNING):
+            base.override_values(override)
+
+        assert len(base.tables) == 1
+        assert base.tables[0].uid == "TABLE_NEW"
+        assert any("TABLE_NEW" in record.message for record in caplog.records)

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -268,16 +268,22 @@ class TestOverrideValues:
     def test_replaces_matching_register(self):
         """A register matching by (subnode, uid) has its value replaced."""
         base = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         base.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=10)
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         override.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=99)
@@ -291,16 +297,22 @@ class TestOverrideValues:
     def test_adds_non_matching_register_with_warning(self, caplog):
         """A register not present in base is added, and a warning is logged."""
         base = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         base.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=1)
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         override.add_config_register(
             ConfigRegister(
@@ -318,8 +330,11 @@ class TestOverrideValues:
     def test_replaces_matching_table(self):
         """A table matching by (subnode, uid) has its content replaced."""
         base = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
         base.add_config_table(
@@ -327,8 +342,11 @@ class TestOverrideValues:
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         override.add_config_table(
             ConfigTable(uid="TABLE_A", subnode=0, elements=[TableElement(0, b"\xff")])
@@ -342,14 +360,20 @@ class TestOverrideValues:
     def test_adds_non_matching_table_with_warning(self, caplog):
         """A table not present in base is added, and a warning is logged."""
         base = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
 
         override = ConfigurationFile.create_empty_configuration(
-            interface=Interface.ETH, part_number=None, product_code=None,
-            revision_number=None, firmware_version=None,
+            interface=Interface.ETH,
+            part_number=None,
+            product_code=None,
+            revision_number=None,
+            firmware_version=None,
         )
         override.add_config_table(
             ConfigTable(uid="TABLE_NEW", subnode=0, elements=[TableElement(0, b"\xab")])

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -267,13 +267,17 @@ class TestOverrideValues:
 
     def test_replaces_matching_register(self):
         """A register matching by (subnode, uid) has its value replaced."""
-        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base = ConfigurationFile.create_empty_configuration(
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
+        )
         base.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=10)
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            Interface.ETH, None, None, None, None
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
         )
         override.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=99)
@@ -286,13 +290,17 @@ class TestOverrideValues:
 
     def test_adds_non_matching_register_with_warning(self, caplog):
         """A register not present in base is added, and a warning is logged."""
-        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base = ConfigurationFile.create_empty_configuration(
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
+        )
         base.add_config_register(
             ConfigRegister("REG_A", subnode=1, dtype=RegDtype.U16, access=RegAccess.RW, storage=1)
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            Interface.ETH, None, None, None, None
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
         )
         override.add_config_register(
             ConfigRegister(
@@ -309,14 +317,18 @@ class TestOverrideValues:
 
     def test_replaces_matching_table(self):
         """A table matching by (subnode, uid) has its content replaced."""
-        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base = ConfigurationFile.create_empty_configuration(
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
+        )
         base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
         base.add_config_table(
             ConfigTable(uid="TABLE_A", subnode=0, elements=[TableElement(0, b"\x01")])
         )
 
         override = ConfigurationFile.create_empty_configuration(
-            Interface.ETH, None, None, None, None
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
         )
         override.add_config_table(
             ConfigTable(uid="TABLE_A", subnode=0, elements=[TableElement(0, b"\xff")])
@@ -329,11 +341,15 @@ class TestOverrideValues:
 
     def test_adds_non_matching_table_with_warning(self, caplog):
         """A table not present in base is added, and a warning is logged."""
-        base = ConfigurationFile.create_empty_configuration(Interface.ETH, None, None, None, None)
+        base = ConfigurationFile.create_empty_configuration(
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
+        )
         base.add_register(Register(RegDtype.U16, RegAccess.RW, "REG", subnode=0), 0)
 
         override = ConfigurationFile.create_empty_configuration(
-            Interface.ETH, None, None, None, None
+            interface=Interface.ETH, part_number=None, product_code=None,
+            revision_number=None, firmware_version=None,
         )
         override.add_config_table(
             ConfigTable(uid="TABLE_NEW", subnode=0, elements=[TableElement(0, b"\xab")])

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -357,8 +357,8 @@ class TestOverrideValues:
         assert len(base.tables) == 1
         assert base.tables[0].elements[0].data == b"\xff"
 
-    def test_adds_non_matching_table_with_warning(self, caplog):
-        """A table not present in base is added, and a warning is logged."""
+    def test_adds_non_matching_table_with_debug_log(self, caplog):
+        """A table not present in base is added, and a debug message is logged."""
         base = ConfigurationFile.create_empty_configuration(
             interface=Interface.ETH,
             part_number=None,
@@ -379,9 +379,12 @@ class TestOverrideValues:
             ConfigTable(uid="TABLE_NEW", subnode=0, elements=[TableElement(0, b"\xab")])
         )
 
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.DEBUG):
             base.override_values(override)
 
         assert len(base.tables) == 1
         assert base.tables[0].uid == "TABLE_NEW"
-        assert any("TABLE_NEW" in record.message for record in caplog.records)
+        assert any(
+            "TABLE_NEW" in record.message and record.levelno == logging.DEBUG
+            for record in caplog.records
+        )

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -217,7 +217,7 @@ def test_load_configuration_strict(mocker, virtual_drive_custom_dict):  # noqa: 
     )
 
 
-def test_load_configuration_accepts_configuration_file_object(virtual_drive_custom_dict):  # noqa: F811
+def test_load_configuration_accepts_configuration_file_object(virtual_drive_custom_dict):
     """load_configuration accepts a ConfigurationFile instance directly (no file path needed)."""
     dictionary = virtual_drive_resources.VIRTUAL_DRIVE_V2_XDF
     _, _, servo = virtual_drive_custom_dict(dictionary, Interface.ETH)
@@ -229,12 +229,9 @@ def test_load_configuration_accepts_configuration_file_object(virtual_drive_cust
     # Should not raise - the ConfigurationFile object is accepted directly
     servo.load_configuration(conf)
 
-    # Verify the register was written: read it back and compare
+    # Verify the registers were written: read them back and compare
     for config_register in conf.registers:
-        try:
-            value = servo.read(config_register.uid, subnode=config_register.subnode)
-        except Exception:
-            continue
+        value = servo.read(config_register.uid, subnode=config_register.subnode)
         if config_register.dtype == RegDtype.FLOAT:
             assert value == pytest.approx(config_register.storage, 0.0001)
         else:

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -217,7 +217,30 @@ def test_load_configuration_strict(mocker, virtual_drive_custom_dict):  # noqa: 
     )
 
 
-@pytest.mark.canopen
+def test_load_configuration_accepts_configuration_file_object(virtual_drive_custom_dict):  # noqa: F811
+    """load_configuration accepts a ConfigurationFile instance directly (no file path needed)."""
+    dictionary = virtual_drive_resources.VIRTUAL_DRIVE_V2_XDF
+    _, _, servo = virtual_drive_custom_dict(dictionary, Interface.ETH)
+
+    # Build a ConfigurationFile from the test xcf file
+    test_file = tests.resources.TEST_CONFIG_FILE
+    conf = ConfigurationFile.load_from_xcf(test_file)
+
+    # Should not raise - the ConfigurationFile object is accepted directly
+    servo.load_configuration(conf)
+
+    # Verify the register was written: read it back and compare
+    for config_register in conf.registers:
+        try:
+            value = servo.read(config_register.uid, subnode=config_register.subnode)
+        except Exception:
+            continue
+        if config_register.dtype == RegDtype.FLOAT:
+            assert value == pytest.approx(config_register.storage, 0.0001)
+        else:
+            assert value == config_register.storage
+
+
 @pytest.mark.ethernet
 @pytest.mark.ethercat
 def test_load_configuration_file_not_found(servo) -> None:


### PR DESCRIPTION
### Description

Adds three new capabilities to support the setup-manager configuration restore flow:

1. `ConfigurationFile.from_dictionary_defaults(dictionary)` — builds an XCF from the NVM/NVM_CFG RW register defaults declared in a `DictionaryV3`.
2. `ConfigurationFile.override_values(other)` — merges a second `ConfigurationFile` into this one, replacing matching registers/tables by `(subnode, uid)` and adding non-matching ones (with a warning).
3. `Servo.load_configuration()` now accepts either a file path (`str`) or a pre-built `ConfigurationFile` object.

### Type of change

- [x] New feature — `ConfigurationFile.from_dictionary_defaults()`
- [x] New feature — `ConfigurationFile.override_values()`
- [x] Enhancement — `Servo.load_configuration()` accepts `Union[str, ConfigurationFile]`

### Tests

- [x] `TestFromDictionaryDefaults` — end-to-end test using a real `EthercatDictionaryV3`, verifies count, values, and metadata
- [x] `TestOverrideValues` — 4 tests covering register/table replace and add-with-warning paths
- [x] `test_load_configuration_accepts_configuration_file_object` — virtual drive smoke test

### Documentation

- [x] Docstrings updated on all new/changed methods
- [x] CHANGELOG `[Unreleased]` section updated