### PR TITLE
Allow save_to_xcf to save a config file without registers

### DIFF
--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -585,22 +585,17 @@ class ConfigurationFile(XMLBase, ABC):
 
         Args:
             xcf_path: config file target path
-
-        Raises:
-            ValueError: the configuration has no registers
-
         """
-        if not self.registers:
-            raise ValueError("registers is empty")
         tree = ElementTree.Element(self.__ROOT_ELEMENT)
         header = ElementTree.SubElement(tree, self.__HEADER_ELEMENT)
         body = ElementTree.SubElement(tree, self.__BODY_ELEMENT)
         version = ElementTree.SubElement(header, self.__VERSION_ELEMENT)
         version.text = self.version
         device = self.device.to_xcf()
-        registers_element = ElementTree.SubElement(device, self.__REGISTERS_ELEMENT)
-        for register in self.registers:
-            registers_element.append(register.to_xcf())
+        if self.registers:
+            registers_element = ElementTree.SubElement(device, self.__REGISTERS_ELEMENT)
+            for register in self.registers:
+                registers_element.append(register.to_xcf())
 
         # Add tables if present
         if self.tables:

--- a/ingenialink/configuration_file.py
+++ b/ingenialink/configuration_file.py
@@ -592,10 +592,9 @@ class ConfigurationFile(XMLBase, ABC):
         version = ElementTree.SubElement(header, self.__VERSION_ELEMENT)
         version.text = self.version
         device = self.device.to_xcf()
-        if self.registers:
-            registers_element = ElementTree.SubElement(device, self.__REGISTERS_ELEMENT)
-            for register in self.registers:
-                registers_element.append(register.to_xcf())
+        registers_element = ElementTree.SubElement(device, self.__REGISTERS_ELEMENT)
+        for register in self.registers:
+            registers_element.append(register.to_xcf())
 
         # Add tables if present
         if self.tables:

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -63,10 +63,11 @@ def test_from_register():
     assert conf_file.registers[0].storage == 5.5
 
 
-def test_to_xcf_fail_no_device():
-    with pytest.raises(ValueError):
-        conf = ConfigurationFile.create_empty_configuration(Interface.CAN, "a", 0, 0, "0.0.0")
-        conf.save_to_xcf("test_path")
+def test_to_xcf_allows_empty_configuration(tmp_path):
+    conf = ConfigurationFile.create_empty_configuration(Interface.CAN, "a", 0, 0, "0.0.0")
+    xcf_path = tmp_path / "test_path.xcf"
+    conf.save_to_xcf(str(xcf_path))
+    assert xcf_path.exists()
 
 
 @pytest.mark.parametrize("missing_attr", RegisterXCFElementFactory.DEFAULT_ATTRIBUTES.keys())

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -65,7 +65,7 @@ def test_from_register():
 
 def test_to_xcf_allows_empty_configuration(tmp_path):
     conf = ConfigurationFile.create_empty_configuration(Interface.CAN, "a", 0, 0, "0.0.0")
-    xcf_path = tmp_path / "test_path.xcf"
+    xcf_path = tmp_path / "test_empty_config_file.xcf"
     conf.save_to_xcf(str(xcf_path))
     assert xcf_path.exists()
 


### PR DESCRIPTION
[Doc]

Remove the register check in save_to_xcf in order to allow saving the config file without registers.