### PR TITLE
Remove extras flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Use an environment with a certain Python version::
 
 Install all dependencies::
 
-    poetry sync --all-groups --extras virtual_drive
+    poetry sync --all-groups
 
 
 Project Tasks - Poe The Poet plugin


### PR DESCRIPTION
The virtual drive is no longer an optional dependency. Update the README to reflect this.