### PR TITLE
adding new features for csv config class

### DIFF
--- a/ingenialink/csv_configuration_file.py
+++ b/ingenialink/csv_configuration_file.py
@@ -3,7 +3,6 @@ import csv
 from dataclasses import dataclass
 from typing import Optional, cast
 
-from ingenialink import table
 from ingenialink.configuration_file import ConfigTable, TableElement
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.table import Table
@@ -177,10 +176,7 @@ class CSVConfigurationFile:
         value_key = (f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}")
 
         # ConfigTable identifies the table logically (dictionary id + axis)
-        config_table = ConfigTable(
-            uid=table._Table__dict_table.id,  # same identifier used elsewhere
-            subnode=table._Table__dict_table.axis or 0,
-        )
+        config_table = ConfigTable(uid=table.uid, subnode=table.axis)
 
         current_address: Optional[int] = None
         bytes_length, _ = dtype_value[value_reg.dtype]
@@ -210,9 +206,7 @@ class CSVConfigurationFile:
                 value_str = row.value[2:] if row.value.startswith("0x") else row.value
                 raw_be = bytes.fromhex(value_str)
             except ValueError as exc:
-                raise ValueError(
-                    f"Invalid value data in CSV row {row.csv_row}: {exc}"
-                ) from exc
+                raise ValueError(f"Invalid value data in CSV row {row.csv_row}: {exc}") from exc
 
             # CSV stores big-endian hex; table expects raw little-endian bytes
             raw_le = raw_be[:bytes_length][::-1]

--- a/ingenialink/csv_configuration_file.py
+++ b/ingenialink/csv_configuration_file.py
@@ -3,6 +3,8 @@ import csv
 from dataclasses import dataclass
 from typing import Optional, cast
 
+from ingenialink import table
+from ingenialink.configuration_file import ConfigTable, TableElement
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.table import Table
 from ingenialink.utils._utils import dtype_value
@@ -152,64 +154,75 @@ class CSVConfigurationFile:
             for row in self.__data:
                 writer.writerow(row.csv_row)
 
-    def compare_with_table(self, table: Table) -> list[str]:
-        """Compare the CSV configuration contents with a table.
+    def extract_config_table(self, table: Table) -> ConfigTable:
+        """Extract a table encoded in the CSV write sequence and return it as a ConfigTable.
+
+        The method scans the CSV rows looking for index-register and value-register
+        writes corresponding to the given table. Each index/value pair is converted
+        into a TableElement using raw bytes as stored in the CSV.
+
+        Args:
+            table: Target Table definition (index/value registers are used as keys).
 
         Returns:
-            A list of mismatch or error messages. The list is empty when the
-            CSV contents match the current table values.
+            ConfigTable populated with the extracted table elements.
+
+        Raises:
+            ValueError: If malformed rows are encountered.
         """
-        mismatches: list[str] = []
         index_reg = cast("EthercatRegister", table.index_register)
         value_reg = cast("EthercatRegister", table.value_register)
-        current_address: Optional[int] = None
 
+        index_key = (f"0x{index_reg.idx:04X}", f"0x{index_reg.subidx:02X}")
+        value_key = (f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}")
+
+        # ConfigTable identifies the table logically (dictionary id + axis)
+        config_table = ConfigTable(
+            uid=table._Table__dict_table.id,  # same identifier used elsewhere
+            subnode=table._Table__dict_table.axis or 0,
+        )
+
+        current_address: Optional[int] = None
         bytes_length, _ = dtype_value[value_reg.dtype]
-        index_reg_key = f"0x{index_reg.idx:04X}", f"0x{index_reg.subidx:02X}"
-        value_reg_key = f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}"
 
         for row in self.__data:
-            if (row.index, row.subindex) == index_reg_key:
+            # --- Index register write ---
+            if (row.index, row.subindex) == index_key:
                 try:
-                    current_address = (
-                        int(row.value[2:], 16) if row.value.startswith("0x") else int(row.value, 16)
-                    )
+                    value_str = row.value[2:] if row.value.startswith("0x") else row.value
+                    current_address = int(value_str, 16)
                 except ValueError as exc:
-                    mismatches.append(f"Invalid index value for row {row.csv_row}: {exc}")
-                    current_address = None
+                    raise ValueError(
+                        f"Invalid index value in CSV row {row.csv_row}: {exc}"
+                    ) from exc
                 continue
-
-            if (row.index, row.subindex) != value_reg_key:
+            # --- Value register write ---
+            if (row.index, row.subindex) != value_key:
                 continue
 
             if current_address is None:
-                mismatches.append("CSV value row found before an index row for the target table.")
-                continue
+                raise ValueError(
+                    "Value register row found before index register row while "
+                    "extracting table from CSV."
+                )
 
             try:
-                expected_raw = bytes.fromhex(
-                    row.value[2:] if row.value.startswith("0x") else row.value
-                )
+                value_str = row.value[2:] if row.value.startswith("0x") else row.value
+                raw_be = bytes.fromhex(value_str)
             except ValueError as exc:
-                mismatches.append(f"Invalid value for CSV row {row.csv_row}: {exc}")
-                continue
+                raise ValueError(
+                    f"Invalid value data in CSV row {row.csv_row}: {exc}"
+                ) from exc
 
-            try:
-                drive_raw = table.get_value_raw(current_address)
-            except Exception as exc:
-                mismatches.append(
-                    f"Table {value_reg.identifier} address {current_address} -- {exc}"
-                )
-                continue
+            # CSV stores big-endian hex; table expects raw little-endian bytes
+            raw_le = raw_be[:bytes_length][::-1]
 
-            actual_raw = drive_raw[:bytes_length][::-1]
-            if actual_raw != expected_raw:
-                mismatches.append(
-                    f"Table {value_reg.identifier} address {current_address} --- "
-                    f"Expected: 0x{expected_raw.hex().upper()} Found: 0x{actual_raw.hex().upper()}"
-                )
+            element = TableElement(address=current_address, data=raw_le)
+            config_table.elements.append(element)
 
-        return mismatches
+            current_address = None  # enforce index/value pairing
+
+        return config_table
 
     def __calculate_crc(self, row: RegisterRow) -> None:
         """Calculate the CRC for a given row and update the internal CRC state.

--- a/ingenialink/csv_configuration_file.py
+++ b/ingenialink/csv_configuration_file.py
@@ -1,6 +1,7 @@
 import binascii
 import csv
 from dataclasses import dataclass
+from typing import Optional, cast
 
 from ingenialink.ethercat.register import EthercatRegister
 from ingenialink.table import Table
@@ -81,6 +82,37 @@ class CSVConfigurationFile:
         self.__data: list[RegisterRow] = []
         self.__crc = 0x0000
 
+    @classmethod
+    def load_from_csv(cls, filename: str) -> "CSVConfigurationFile":
+        """Load a CSV configuration file.
+
+        Args:
+            filename: The path to the CSV file.
+
+        Returns:
+            A CSVConfigurationFile instance loaded from the file.
+
+        Raises:
+            ValueError: If the CSV format is invalid.
+        """
+        instance = cls(filename)
+        with open(filename, newline="") as file:
+            reader = csv.reader(file)
+            rows = list(reader)
+        if not rows or rows[0] != ["v1"]:
+            raise ValueError("Invalid CSV format: missing or incorrect version")
+        crc_str = rows[1][0]
+        try:
+            instance.__crc = int(crc_str, 16)
+        except ValueError:
+            raise ValueError(f"Invalid CRC format: {crc_str}")
+        for row in rows[2:]:
+            if len(row) != 3:
+                raise ValueError(f"Invalid row format: {row}")
+            index, subindex, value = row
+            instance.__data.append(RegisterRow(index, subindex, value))
+        return instance
+
     def add_register(self, register: EthercatRegister, storage: bytes) -> None:
         """Add a register to the CSV configuration.
 
@@ -119,6 +151,65 @@ class CSVConfigurationFile:
             writer.writerow([f"0x{self.__crc:04X}"])
             for row in self.__data:
                 writer.writerow(row.csv_row)
+
+    def compare_with_table(self, table: Table) -> list[str]:
+        """Compare the CSV configuration contents with a table.
+
+        Returns:
+            A list of mismatch or error messages. The list is empty when the
+            CSV contents match the current table values.
+        """
+        mismatches: list[str] = []
+        index_reg = cast("EthercatRegister", table.index_register)
+        value_reg = cast("EthercatRegister", table.value_register)
+        current_address: Optional[int] = None
+
+        bytes_length, _ = dtype_value[value_reg.dtype]
+        index_reg_key = f"0x{index_reg.idx:04X}", f"0x{index_reg.subidx:02X}"
+        value_reg_key = f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}"
+
+        for row in self.__data:
+            if (row.index, row.subindex) == index_reg_key:
+                try:
+                    current_address = (
+                        int(row.value[2:], 16) if row.value.startswith("0x") else int(row.value, 16)
+                    )
+                except ValueError as exc:
+                    mismatches.append(f"Invalid index value for row {row.csv_row}: {exc}")
+                    current_address = None
+                continue
+
+            if (row.index, row.subindex) != value_reg_key:
+                continue
+
+            if current_address is None:
+                mismatches.append("CSV value row found before an index row for the target table.")
+                continue
+
+            try:
+                expected_raw = bytes.fromhex(
+                    row.value[2:] if row.value.startswith("0x") else row.value
+                )
+            except ValueError as exc:
+                mismatches.append(f"Invalid value for CSV row {row.csv_row}: {exc}")
+                continue
+
+            try:
+                drive_raw = table.get_value_raw(current_address)
+            except Exception as exc:
+                mismatches.append(
+                    f"Table {value_reg.identifier} address {current_address} -- {exc}"
+                )
+                continue
+
+            actual_raw = drive_raw[:bytes_length][::-1]
+            if actual_raw != expected_raw:
+                mismatches.append(
+                    f"Table {value_reg.identifier} address {current_address} --- "
+                    f"Expected: 0x{expected_raw.hex().upper()} Found: 0x{actual_raw.hex().upper()}"
+                )
+
+        return mismatches
 
     def __calculate_crc(self, row: RegisterRow) -> None:
         """Calculate the CRC for a given row and update the internal CRC state.

--- a/ingenialink/csv_configuration_file.py
+++ b/ingenialink/csv_configuration_file.py
@@ -99,7 +99,7 @@ class CSVConfigurationFile:
         with open(filename, newline="") as file:
             reader = csv.reader(file)
             rows = list(reader)
-        if not rows or rows[0] != ["v1"]:
+        if not rows or rows[0] != [cls.__VERSION]:
             raise ValueError("Invalid CSV format: missing or incorrect version")
         crc_str = rows[1][0]
         try:

--- a/ingenialink/table.py
+++ b/ingenialink/table.py
@@ -61,6 +61,16 @@ class Table:
         """Value register used to read/write table values."""
         return self.__value_register
 
+    @property
+    def uid(self) -> str:
+        """Unique identifier for the table."""
+        return self.__dict_table.id
+
+    @property
+    def axis(self) -> int:
+        """Axis to which the table belongs."""
+        return self.__dict_table.axis or 0
+
     def get_value(self, index: int) -> REG_VALUE:
         """Reads a value from the table.
 

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -7,6 +7,8 @@ import pytest
 from ingenialink.csv_configuration_file import CSVConfigurationFile, RegisterRow
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
+from ingenialink.servo import Servo
+from ingenialink.table import Table
 
 pytest_plugins = ["tests.test_table"]
 
@@ -50,7 +52,12 @@ def test_format_value_for_csv():
     assert row.value == f"0x{expected_value_big_endian.hex().upper()}"
 
 
-def test_load_from_csv_reads_rows(tmp_path: Path):
+def test_load_from_csv_reads_rows(tmp_path: Path) -> None:
+    """Test that loading from a CSV file reads the rows correctly.
+
+    Args:
+        tmp_path: pytest fixture providing a temporary directory for file operations.
+    """
     file_path = tmp_path / "load_config.csv"
     file_path.write_text("v1\n0x0000\n0x2025,0x00,0x41A00000\n0x209A,0x00,0x3F800000\n")
 
@@ -63,7 +70,12 @@ def test_load_from_csv_reads_rows(tmp_path: Path):
     ]
 
 
-def test_extract_config_table_single_entry(servo_with_table):
+def test_extract_config_table_single_entry(servo_with_table: tuple[Servo, Table]) -> None:
+    """Test that a configuration table can be extracted from the CSV data.
+
+    Args:
+        servo_with_table: pytest fixture providing a servo and a table for testing.
+    """
     _servo, table = servo_with_table
 
     index_reg = table.index_register
@@ -94,7 +106,12 @@ def test_extract_config_table_single_entry(servo_with_table):
     assert element.data == b"\x04\x03\x02\x01"
 
 
-def test_extract_config_table_multiple_entries(servo_with_table):
+def test_extract_config_table_multiple_entries(servo_with_table: tuple[Servo, Table]) -> None:
+    """Test that multiple entries can be extracted into a configuration table.
+
+    Args:
+        servo_with_table: pytest fixture providing a servo and a table for testing.
+    """
     _servo, table = servo_with_table
     index_reg = table.index_register
     value_reg = table.value_register
@@ -115,7 +132,16 @@ def test_extract_config_table_multiple_entries(servo_with_table):
     assert config_table.elements[1].data == b"\xbb\xbb\xbb\xbb"
 
 
-def test_extract_config_table_value_before_index_raises(servo_with_table):
+def test_extract_config_table_value_before_index_raises(
+    servo_with_table: tuple[Servo, Table],
+) -> None:
+    """Test that a ValueError is raised if a value row is encountered before an index row.
+
+    This tests the enforcement of index/value pairing in the CSV configuration extraction logic.
+
+    Args:
+       servo_with_table: pytest fixture providing a servo and a table for testing.
+    """
     _servo, table = servo_with_table
     value_reg = table.value_register
 

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -1,10 +1,37 @@
 import csv
 import struct
+from dataclasses import dataclass
 from pathlib import Path
 
 from ingenialink.csv_configuration_file import CSVConfigurationFile, RegisterRow
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
+
+
+@dataclass(frozen=True)
+class DummyRegister:
+    idx: int
+    subidx: int
+    dtype: RegDtype
+    identifier: str
+
+
+class DummyTable:
+    def __init__(
+        self,
+        index_register: DummyRegister,
+        value_register: DummyRegister,
+        raw_values: dict[int, bytes],
+    ) -> None:
+        self.index_register = index_register
+        self.value_register = value_register
+        self._raw_values = raw_values
+
+    def get_value_raw(self, index: int) -> bytes:
+        try:
+            return self._raw_values[index]
+        except KeyError as exc:
+            raise IndexError(f"Table address {index} not found.") from exc
 
 
 def test_register_row_formatting():
@@ -44,3 +71,48 @@ def test_format_value_for_csv():
     row = RegisterRow.from_register(reg, raw_register_bytes)
     expected_value_big_endian = struct.pack(">f", register_float_value)
     assert row.value == f"0x{expected_value_big_endian.hex().upper()}"
+
+
+def test_load_from_csv_reads_rows(tmp_path: Path):
+    file_path = tmp_path / "load_config.csv"
+    file_path.write_text("v1\n0x0000\n0x2025,0x00,0x41A00000\n0x209A,0x00,0x3F800000\n")
+
+    cfg = CSVConfigurationFile.load_from_csv(str(file_path))
+
+    assert cfg._CSVConfigurationFile__crc == 0x0000
+    assert [row.csv_row for row in cfg._CSVConfigurationFile__data] == [
+        ["0x2025", "0x00", "0x41A00000"],
+        ["0x209A", "0x00", "0x3F800000"],
+    ]
+
+
+def test_compare_with_table_reports_no_mismatches_for_matching_values():
+    csv_cfg = CSVConfigurationFile("unused")
+    csv_cfg._CSVConfigurationFile__data.extend([
+        RegisterRow("0x1000", "0x00", "0x00000001"),
+        RegisterRow("0x1001", "0x00", "0x01020304"),
+    ])
+
+    index_register = DummyRegister(idx=0x1000, subidx=0x00, dtype=RegDtype.U32, identifier="INDEX")
+    value_register = DummyRegister(idx=0x1001, subidx=0x00, dtype=RegDtype.U32, identifier="VALUE")
+    table = DummyTable(index_register, value_register, {1: b"\x04\x03\x02\x01"})
+
+    mismatches = csv_cfg.compare_with_table(table)
+
+    assert mismatches == []
+
+
+def test_compare_with_table_reports_mismatches_for_differing_values():
+    csv_cfg = CSVConfigurationFile("unused")
+    csv_cfg._CSVConfigurationFile__data.extend([
+        RegisterRow("0x1000", "0x00", "0x00000001"),
+        RegisterRow("0x1001", "0x00", "0x01020304"),
+    ])
+
+    index_register = DummyRegister(idx=0x1000, subidx=0x00, dtype=RegDtype.U32, identifier="INDEX")
+    value_register = DummyRegister(idx=0x1001, subidx=0x00, dtype=RegDtype.U32, identifier="VALUE")
+    table = DummyTable(index_register, value_register, {1: b"\x08\x07\x06\x05"})
+
+    mismatches = csv_cfg.compare_with_table(table)
+
+    assert mismatches == ["Table VALUE address 1 --- Expected: 0x01020304 Found: 0x05060708"]

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -8,6 +8,8 @@ from ingenialink.csv_configuration_file import CSVConfigurationFile, RegisterRow
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
 
+pytest_plugins = ["tests.test_table"]
+
 
 def test_register_row_formatting():
     reg = EthercatRegister(0x2025, 0x00, RegDtype.U32, RegAccess.RW)

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -85,8 +85,8 @@ def test_extract_config_table_single_entry(servo_with_table):
 
     config_table = csv_cfg.extract_config_table(table)
 
-    assert config_table.uid == table._Table__dict_table.id
-    assert config_table.subnode == (table._Table__dict_table.axis or 0)
+    assert config_table.uid == table.uid
+    assert config_table.subnode == table.axis
     assert len(config_table.elements) == 1
 
     element = config_table.elements[0]

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -1,37 +1,13 @@
 import csv
 import struct
-from dataclasses import dataclass
 from pathlib import Path
+
+import pytest
 
 from ingenialink.csv_configuration_file import CSVConfigurationFile, RegisterRow
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
-
-
-@dataclass(frozen=True)
-class DummyRegister:
-    idx: int
-    subidx: int
-    dtype: RegDtype
-    identifier: str
-
-
-class DummyTable:
-    def __init__(
-        self,
-        index_register: DummyRegister,
-        value_register: DummyRegister,
-        raw_values: dict[int, bytes],
-    ) -> None:
-        self.index_register = index_register
-        self.value_register = value_register
-        self._raw_values = raw_values
-
-    def get_value_raw(self, index: int) -> bytes:
-        try:
-            return self._raw_values[index]
-        except KeyError as exc:
-            raise IndexError(f"Table address {index} not found.") from exc
+from tests.test_table import servo_with_table
 
 
 def test_register_row_formatting():
@@ -86,33 +62,70 @@ def test_load_from_csv_reads_rows(tmp_path: Path):
     ]
 
 
-def test_compare_with_table_reports_no_mismatches_for_matching_values():
+def test_extract_config_table_single_entry(servo_with_table):
+    _servo, table = servo_with_table
+
+    index_reg = table.index_register
+    value_reg = table.value_register
+
     csv_cfg = CSVConfigurationFile("unused")
     csv_cfg._CSVConfigurationFile__data.extend([
-        RegisterRow("0x1000", "0x00", "0x00000001"),
-        RegisterRow("0x1001", "0x00", "0x01020304"),
+        RegisterRow(
+            f"0x{index_reg.idx:04X}",
+            f"0x{index_reg.subidx:02X}",
+            "0x00000001",
+        ),
+        RegisterRow(
+            f"0x{value_reg.idx:04X}",
+            f"0x{value_reg.subidx:02X}",
+            "0x01020304",
+        ),
     ])
 
-    index_register = DummyRegister(idx=0x1000, subidx=0x00, dtype=RegDtype.U32, identifier="INDEX")
-    value_register = DummyRegister(idx=0x1001, subidx=0x00, dtype=RegDtype.U32, identifier="VALUE")
-    table = DummyTable(index_register, value_register, {1: b"\x04\x03\x02\x01"})
+    config_table = csv_cfg.extract_config_table(table)
 
-    mismatches = csv_cfg.compare_with_table(table)
+    assert config_table.uid == table._Table__dict_table.id
+    assert config_table.subnode == (table._Table__dict_table.axis or 0)
+    assert len(config_table.elements) == 1
 
-    assert mismatches == []
+    element = config_table.elements[0]
+    assert element.address == 1
+    assert element.data == b"\x04\x03\x02\x01"
 
 
-def test_compare_with_table_reports_mismatches_for_differing_values():
+def test_extract_config_table_multiple_entries(servo_with_table):
+    _servo, table = servo_with_table
+    index_reg = table.index_register
+    value_reg = table.value_register
+
     csv_cfg = CSVConfigurationFile("unused")
     csv_cfg._CSVConfigurationFile__data.extend([
-        RegisterRow("0x1000", "0x00", "0x00000001"),
-        RegisterRow("0x1001", "0x00", "0x01020304"),
+        RegisterRow(f"0x{index_reg.idx:04X}", f"0x{index_reg.subidx:02X}", "0x00000000"),
+        RegisterRow(f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}", "0xAAAAAAAA"),
+        RegisterRow(f"0x{index_reg.idx:04X}", f"0x{index_reg.subidx:02X}", "0x00000001"),
+        RegisterRow(f"0x{value_reg.idx:04X}", f"0x{value_reg.subidx:02X}", "0xBBBBBBBB"),
     ])
 
-    index_register = DummyRegister(idx=0x1000, subidx=0x00, dtype=RegDtype.U32, identifier="INDEX")
-    value_register = DummyRegister(idx=0x1001, subidx=0x00, dtype=RegDtype.U32, identifier="VALUE")
-    table = DummyTable(index_register, value_register, {1: b"\x08\x07\x06\x05"})
+    config_table = csv_cfg.extract_config_table(table)
 
-    mismatches = csv_cfg.compare_with_table(table)
+    assert len(config_table.elements) == 2
+    assert [e.address for e in config_table.elements] == [0, 1]
+    assert config_table.elements[0].data == b"\xAA\xAA\xAA\xAA"
+    assert config_table.elements[1].data == b"\xBB\xBB\xBB\xBB"
 
-    assert mismatches == ["Table VALUE address 1 --- Expected: 0x01020304 Found: 0x05060708"]
+
+def test_extract_config_table_value_before_index_raises(servo_with_table):
+    _servo, table = servo_with_table
+    value_reg = table.value_register
+
+    csv_cfg = CSVConfigurationFile("unused")
+    csv_cfg._CSVConfigurationFile__data.append(
+        RegisterRow(
+            f"0x{value_reg.idx:04X}",
+            f"0x{value_reg.subidx:02X}",
+            "0x01020304",
+        )
+    )
+
+    with pytest.raises(ValueError, match="Value register row found before index"):
+        csv_cfg.extract_config_table(table)

--- a/tests/test_csv_configuration_file.py
+++ b/tests/test_csv_configuration_file.py
@@ -7,7 +7,6 @@ import pytest
 from ingenialink.csv_configuration_file import CSVConfigurationFile, RegisterRow
 from ingenialink.enums.register import RegAccess, RegDtype
 from ingenialink.ethercat.register import EthercatRegister
-from tests.test_table import servo_with_table
 
 
 def test_register_row_formatting():
@@ -110,8 +109,8 @@ def test_extract_config_table_multiple_entries(servo_with_table):
 
     assert len(config_table.elements) == 2
     assert [e.address for e in config_table.elements] == [0, 1]
-    assert config_table.elements[0].data == b"\xAA\xAA\xAA\xAA"
-    assert config_table.elements[1].data == b"\xBB\xBB\xBB\xBB"
+    assert config_table.elements[0].data == b"\xaa\xaa\xaa\xaa"
+    assert config_table.elements[1].data == b"\xbb\xbb\xbb\xbb"
 
 
 def test_extract_config_table_value_before_index_raises(servo_with_table):

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -432,14 +432,14 @@ def test_save_configuration_csv_with_tables(real_servo_with_tables, tmp_path: Pa
 
 
 def test_table_compare_with_modified_config_table(
-    servo_with_tables,
+    servo_with_table,
 ) -> None:
     """Verify compare_with_config_table detects mismatches when table data differs.
 
     Args:
-        servo_with_tables: Fixture providing a servo and table.
+        servo_with_table: Fixture providing a servo and table.
     """
-    _, table = servo_with_tables
+    _, table = servo_with_table
     config_table = table.to_config_table()
     first_element = config_table.elements[0]
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -6,7 +6,7 @@ import pytest
 
 import tests.resources
 from ingenialink import Servo
-from ingenialink.configuration_file import ConfigurationFile
+from ingenialink.configuration_file import ConfigTable, ConfigurationFile, TableElement
 from ingenialink.dictionary import DictionaryTable, Interface
 from ingenialink.exceptions import ILConfigurationError
 from ingenialink.table import Table
@@ -429,3 +429,38 @@ def test_save_configuration_csv_with_tables(real_servo_with_tables, tmp_path: Pa
                 break
         else:
             pytest.fail(f"Index row {idx_row} not found in CSV")
+
+
+def test_table_compare_with_modified_config_table(
+    servo_with_tables,
+) -> None:
+    """Verify compare_with_config_table detects mismatches when table data differs.
+
+    Args:
+        servo_with_tables: Fixture providing a servo and table.
+    """
+    _, table = servo_with_tables
+    config_table = table.to_config_table()
+    first_element = config_table.elements[0]
+
+    mutated_data = bytes(
+        b ^ 0x01 if i == len(first_element.data) - 1 else b
+        for i, b in enumerate(first_element.data)
+    )
+    if mutated_data == first_element.data:
+        mutated_data = bytes(
+            b ^ 0x02 if i == len(first_element.data) - 1 else b
+            for i, b in enumerate(first_element.data)
+        )
+
+    mutated_elements = [
+        TableElement(address=first_element.address, data=mutated_data),
+        *config_table.elements[1:],
+    ]
+    mutated_table = ConfigTable(config_table.uid, config_table.subnode, mutated_elements)
+
+    mismatches = table.compare_with_config_table(mutated_table)
+    assert mismatches, "compare_with_config_table should report mismatches for modified table data"
+    assert len(mismatches) == 1
+    assert f"Table {config_table.uid} address {first_element.address}" in mismatches[0]
+    assert "Expected:" in mismatches[0] and "Found:" in mismatches[0]


### PR DESCRIPTION
**Add CSV configuration file load and extract methods with comprehensive unit tests**

This PR adds comprehensive test coverage and validation capabilities for CSV configuration file handling in EtherCAT devices.

### Changes

**New properties in `Table`:**

- `uid`: returns the `__dict_table.id`
- `axis`: returns the `__dict_table.axis`

**New Methods in `CSVConfigurationFile`:**
- `load_from_csv()`: Load and parse existing CSV configuration files, restoring register data and CRC values
- `extract_config_table()`: Extract a table encoded in the CSV write sequence and return it as a ConfigTable.

**New Test Coverage in test_csv_configuration_file.py:**
- `test_load_from_csv_reads_rows`: Validates CSV file parsing preserves CRC and register rows
- `test_extract_config_table_single_entry`: verifies ConfigTable correctly extracted from csv config
- `test_extract_config_table_multiple_entries`: verifies multiple ConfigTable objects extracted from csv config

**Enhanced Testing in test_table.py:**
- `test_table_compare_with_modified_config_table`: Strengthened assertions to validate:
  - Mismatch presence and count
  - Message format includes table UID, address, and Expected/Found values

### Enables
- Load previously saved CSV configurations for reuse
- Validate configuration consistency between saved files and current device state
- Generate detailed diagnostic reports for configuration discrepancies

Motivation behind these features is https://github.com/CeleraMotion/testing-fw-summit/pull/1 as to fully cover tables/csv tests against a real servo. 