### PR TITLE
fix: prevent use-after-close crash in recover_from_disconnection

### DIFF
--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -1099,17 +1099,27 @@ class EthercatNetwork(EthercatNetworkBase):
         if self._ecat_master.state == pysoem.PREOP_STATE and all_servos_have_refs:
             return True
 
-        # Clean start the master to try to recover the CoE communication.
-        # This is needed to avoid the master state machine to be stuck in a wrong
-        # state after a disconnection.
-        self._lock.acquire()
+        # Acquire all servo locks to wait for any in-flight SDO operations to
+        # complete before closing the master. This prevents use-after-close crashes
+        # when sdo_read/sdo_write is running with release_gil=True.
+        ecat_servos = [s for s in self.servos if isinstance(s, EthercatServo)]
+        for s in ecat_servos:
+            s._lock.acquire()
         try:
-            self._ecat_master.close()
-            self._ecat_master.open(self.interface_name)
-        finally:
-            self._lock.release()
+            # Clean start the master to try to recover the CoE communication.
+            # This is needed to avoid the master state machine to be stuck in a wrong
+            # state after a disconnection.
+            self._lock.acquire()
+            try:
+                self._ecat_master.close()
+                self._ecat_master.open(self.interface_name)
+            finally:
+                self._lock.release()
 
-        self.__init_nodes()
+            self.__init_nodes()
+        finally:
+            for s in ecat_servos:
+                s._lock.release()
         if not self.servos:
             log_message = (
                 "The CoE communication cannot be recovered. No slaves where detected in the network"


### PR DESCRIPTION
## Context

pysoem [PR #191](https://github.com/bnjmnp/pysoem/pull/191) introduced an `OperationCounter` at the C level to prevent `close()` from running while SDO operations are in-flight. This fix is merged to pysoem `master` but **not yet released** — v1.1.13 (the version we use) does not include it.

Until a new pysoem release is available, calling `close()` concurrently with an in-flight `sdo_read(release_gil=True)` causes an access violation. This PR adds equivalent protection at the Python lock level in ingenialink.

## Problem

When a MonitoringThread is performing SDO operations (`sdo_read`/`sdo_write` with `release_gil=True`) during an EtherCAT cable disconnection, `recover_from_disconnection()` calls `_ecat_master.close()` while the C-level SDO operation is still in progress, causing an **access violation (segfault)**.

### Race condition

Two independent locks are involved:
- `servo._lock` — protects SDO read/write operations
- `network._lock` — protects master-level operations (close, open, config_init)

These locks never interact, so the following race occurs:

| Thread | Action |
|--------|--------|
| MonitoringThread | Acquires `servo._lock` → calls `sdo_read(release_gil=True)` → GIL released, C code running |
| NetStatusListener | Acquires GIL → `recover_from_disconnection()` → acquires `network._lock` → `_ecat_master.close()` → port closed |
| MonitoringThread | C code crashes → **access violation** |

### Crash trace

```
Windows fatal exception: access violation
  File ingenialink/ethercat/servo.py, line 196 in _read_raw
    → self.slave.sdo_read(...)
```

## Fix

This is an additional layer of protection at the ingenialink level, complementing the pysoem `OperationCounter` fix (which will provide the definitive C-level guard once released).

Acquire all servo `_lock`s in `recover_from_disconnection()` **before** closing the master. This ensures:

1. Any in-flight `sdo_read`/`sdo_write` completes (blocked by lock acquisition)
2. No new SDO operations can start while the master is being closed and reopened
3. `__init_nodes()` updates slave references while locks are still held
4. After lock release, pending SDO operations use the new (valid) slave references
