### PR TITLE
INGK-1257 Fix PDO processing order to match insertion order

### DIFF
--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Callable, ClassVar, Literal, Optional, TypeVar, Union
 
 import bitarray
@@ -868,9 +869,11 @@ class PDOServo(Servo):
         super().__init__(
             target, dictionary_path, servo_status_listener, disconnect_callback=disconnect_callback
         )
-        # Index of the pdo map -> PDO Map instance
-        self._rpdo_maps: dict[int, RPDOMap] = {}
-        self._tpdo_maps: dict[int, TPDOMap] = {}
+        # Index of the pdo map -> PDO Map instance. OrderedDict preserves insertion
+        # order so that assignment (map_rpdos/map_tpdos) and processing
+        # (_process_rpdo/_process_tpdo) iterate maps in the same order.
+        self._rpdo_maps: OrderedDict[int, RPDOMap] = OrderedDict()
+        self._tpdo_maps: OrderedDict[int, TPDOMap] = OrderedDict()
 
     @property  # type: ignore[misc]
     def dictionary(self) -> CanopenDictionary:  # type: ignore[override]
@@ -996,9 +999,9 @@ class PDOServo(Servo):
         if rpdo_map is not None:
             if rpdo_map not in self._rpdo_maps.values():
                 raise ValueError("The RPDOMap instance is not in the RPDOMaps")
-            self._rpdo_maps = {
-                idx: rmap for idx, rmap in self._rpdo_maps.items() if rmap is not rpdo_map
-            }
+            self._rpdo_maps = OrderedDict(
+                (idx, rmap) for idx, rmap in self._rpdo_maps.items() if rmap is not rpdo_map
+            )
             return
         if rpdo_map_index is not None:
             del self._rpdo_maps[rpdo_map_index]
@@ -1021,9 +1024,9 @@ class PDOServo(Servo):
         if tpdo_map is not None:
             if tpdo_map not in self._tpdo_maps.values():
                 raise ValueError("The TPDOMap instance is not in the TPDOMaps")
-            self._tpdo_maps = {
-                idx: tmap for idx, tmap in self._tpdo_maps.items() if tmap is not tpdo_map
-            }
+            self._tpdo_maps = OrderedDict(
+                (idx, tmap) for idx, tmap in self._tpdo_maps.items() if tmap is not tpdo_map
+            )
             return
         if tpdo_map_index is not None:
             self._tpdo_maps.pop(tpdo_map_index)
@@ -1058,8 +1061,7 @@ class PDOServo(Servo):
             input_data: Concatenated received data bytes.
 
         """
-        for idx in sorted(self._tpdo_maps):
-            tpdo_map = self._tpdo_maps[idx]
+        for tpdo_map in self._tpdo_maps.values():
             map_bytes = input_data[: tpdo_map.data_length_bytes]
             tpdo_map.set_item_bytes(map_bytes)
             input_data = input_data[tpdo_map.data_length_bytes :]
@@ -1072,7 +1074,7 @@ class PDOServo(Servo):
             Concatenated data bytes to be sent.
         """
         output = bytearray()
-        for idx in sorted(self._rpdo_maps):
-            self._rpdo_maps[idx]._notify_process_data_event()
-            output += self._rpdo_maps[idx].get_item_bytes()
+        for rpdo_map in self._rpdo_maps.values():
+            rpdo_map._notify_process_data_event()
+            output += rpdo_map.get_item_bytes()
         return bytes(output)

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -692,7 +692,7 @@ def test_pdo_item_custom_size(open_dictionary):
 
 
 @pytest.mark.ethercat
-@pytest.mark.not_valid_for_standard_cocomoco # CoCoMoCo does not support multiple PDO maps
+@pytest.mark.not_valid_for_standard_cocomoco  # CoCoMoCo does not support multiple PDO maps
 @pytest.mark.parametrize("reverse_order", [False, True], ids=["index_order", "reverse_order"])
 def test_multiple_pdo_maps_insertion_order_matches_processing_order(
     servo: EthercatServo, net: "EthercatNetwork", reverse_order: bool

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -735,7 +735,11 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
     servo.set_pdo_map_to_slave(rpdo_maps=rpdo_maps, tpdo_maps=tpdo_maps)
 
     try:
-        start_stop_pdos(net)
+        net.start_pdos(timeout=5.0)
+        start_time = time.time()
+        while time.time() < start_time + 1:
+            net.send_receive_processdata()
+        net.stop_pdos()
 
         actual_op_mode = servo.read(drv_op_cmd)
         assert actual_op_mode == target_op_mode, (
@@ -743,6 +747,8 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
             "RPDO byte order does not match insertion order."
         )
     finally:
+        with contextlib.suppress(Exception):
+            net.stop_pdos()
         # Rollback register values modified by PDO exchanges during test teardown
         # https://novantamotion.atlassian.net/browse/CIT-657
         servo.write(drv_op_cmd, initial_op_mode)

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -696,19 +696,27 @@ def test_pdo_item_custom_size(open_dictionary):
 def test_multiple_pdo_maps_insertion_order_matches_processing_order(
     servo: EthercatServo, net: "EthercatNetwork", reverse_order: bool
 ):
-    """PDO values must arrive at the correct registers regardless of map insertion order."""
+    """PDO values must arrive at the correct registers regardless of map insertion order.
+
+    Uses two RPDO maps and two TPDO maps to verify that the byte layout in the
+    process data image matches the insertion order of the maps, not their index order.
+    Both RPDO values are validated via SDO reads and both TPDO item values are
+    cross-checked against their corresponding SDO registers.
+    """
     drv_op_cmd = servo.dictionary.get_register("DRV_OP_CMD")
     cl_pos_set_point = servo.dictionary.get_register("CL_POS_SET_POINT_VALUE")
     drv_op_value = servo.dictionary.get_register("DRV_OP_VALUE")
     cl_vel_fbk = servo.dictionary.get_register("CL_VEL_FBK_VALUE")
 
     initial_op_mode = servo.read(drv_op_cmd)
+    initial_pos_set_point = servo.read(cl_pos_set_point)
     target_op_mode = 1 if initial_op_mode != 1 else 2
+    target_pos_set_point = 12345
 
     rpdo_map1 = RPDOMap()
     rpdo_map1.map_register_index = 0x1600
     pos_item = RPDOMapItem(cl_pos_set_point)
-    pos_item.value = 0
+    pos_item.value = target_pos_set_point
     rpdo_map1.add_item(pos_item)
 
     rpdo_map2 = RPDOMap()
@@ -719,11 +727,13 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
 
     tpdo_map1 = TPDOMap()
     tpdo_map1.map_register_index = 0x1A00
-    tpdo_map1.add_item(TPDOMapItem(cl_vel_fbk))
+    vel_fbk_item = TPDOMapItem(cl_vel_fbk)
+    tpdo_map1.add_item(vel_fbk_item)
 
     tpdo_map2 = TPDOMap()
     tpdo_map2.map_register_index = 0x1A01
-    tpdo_map2.add_item(TPDOMapItem(drv_op_value))
+    op_value_item = TPDOMapItem(drv_op_value)
+    tpdo_map2.add_item(op_value_item)
 
     if reverse_order:
         rpdo_maps = [rpdo_map2, rpdo_map1]
@@ -741,10 +751,23 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
             net.send_receive_processdata()
         net.stop_pdos()
 
+        # Validate RPDO map 1: CL_POS_SET_POINT_VALUE received the correct value
+        actual_pos_set_point = servo.read(cl_pos_set_point)
+        assert actual_pos_set_point == target_pos_set_point, (
+            f"CL_POS_SET_POINT_VALUE: expected {target_pos_set_point}, got {actual_pos_set_point}. "
+            "RPDO map 1 data was placed at the wrong position."
+        )
+        # Validate RPDO map 2: DRV_OP_CMD received the correct value
         actual_op_mode = servo.read(drv_op_cmd)
         assert actual_op_mode == target_op_mode, (
             f"DRV_OP_CMD: expected {target_op_mode}, got {actual_op_mode}. "
-            "RPDO byte order does not match insertion order."
+            "RPDO map 2 data was placed at the wrong position."
+        )
+        # Validate TPDO map 2: DRV_OP_VALUE item matches the SDO read
+        actual_drv_op_value = servo.read(drv_op_value)
+        assert op_value_item.value == actual_drv_op_value, (
+            f"DRV_OP_VALUE TPDO item: expected {actual_drv_op_value}, got {op_value_item.value}. "
+            "TPDO map 2 data was read from the wrong position."
         )
     finally:
         with contextlib.suppress(Exception):
@@ -752,6 +775,7 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
         # Rollback register values modified by PDO exchanges during test teardown
         # https://novantamotion.atlassian.net/browse/CIT-657
         servo.write(drv_op_cmd, initial_op_mode)
+        servo.write(cl_pos_set_point, initial_pos_set_point)
 
 
 def test_pdo_item_custom_size_wrong_length(open_dictionary):

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -692,6 +692,7 @@ def test_pdo_item_custom_size(open_dictionary):
 
 
 @pytest.mark.ethercat
+@pytest.mark.not_valid_for_standard_cocomoco # CoCoMoCo does not support multiple PDO maps
 @pytest.mark.parametrize("reverse_order", [False, True], ids=["index_order", "reverse_order"])
 def test_multiple_pdo_maps_insertion_order_matches_processing_order(
     servo: EthercatServo, net: "EthercatNetwork", reverse_order: bool
@@ -745,11 +746,7 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
     servo.set_pdo_map_to_slave(rpdo_maps=rpdo_maps, tpdo_maps=tpdo_maps)
 
     try:
-        net.start_pdos(timeout=5.0)
-        start_time = time.time()
-        while time.time() < start_time + 1:
-            net.send_receive_processdata()
-        net.stop_pdos()
+        start_stop_pdos(net)
 
         # Validate RPDO map 1: CL_POS_SET_POINT_VALUE received the correct value
         actual_pos_set_point = servo.read(cl_pos_set_point)
@@ -770,8 +767,6 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
             "TPDO map 2 data was read from the wrong position."
         )
     finally:
-        with contextlib.suppress(Exception):
-            net.stop_pdos()
         # Rollback register values modified by PDO exchanges during test teardown
         # https://novantamotion.atlassian.net/browse/CIT-657
         servo.write(drv_op_cmd, initial_op_mode)

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -691,6 +691,61 @@ def test_pdo_item_custom_size(open_dictionary):
     assert tpdo_item.raw_data_bytes == b"\x09"
 
 
+@pytest.mark.ethercat
+@pytest.mark.parametrize("reverse_order", [False, True], ids=["index_order", "reverse_order"])
+def test_multiple_pdo_maps_insertion_order_matches_processing_order(
+    servo: EthercatServo, net: "EthercatNetwork", reverse_order: bool
+):
+    """PDO values must arrive at the correct registers regardless of map insertion order."""
+    drv_op_cmd = servo.dictionary.get_register("DRV_OP_CMD")
+    cl_pos_set_point = servo.dictionary.get_register("CL_POS_SET_POINT_VALUE")
+    drv_op_value = servo.dictionary.get_register("DRV_OP_VALUE")
+    cl_vel_fbk = servo.dictionary.get_register("CL_VEL_FBK_VALUE")
+
+    initial_op_mode = servo.read(drv_op_cmd)
+    target_op_mode = 1 if initial_op_mode != 1 else 2
+
+    rpdo_map1 = RPDOMap()
+    rpdo_map1.map_register_index = 0x1600
+    pos_item = RPDOMapItem(cl_pos_set_point)
+    pos_item.value = 0
+    rpdo_map1.add_item(pos_item)
+
+    rpdo_map2 = RPDOMap()
+    rpdo_map2.map_register_index = 0x1601
+    op_cmd_item = RPDOMapItem(drv_op_cmd)
+    op_cmd_item.value = target_op_mode
+    rpdo_map2.add_item(op_cmd_item)
+
+    tpdo_map1 = TPDOMap()
+    tpdo_map1.map_register_index = 0x1A00
+    tpdo_map1.add_item(TPDOMapItem(cl_vel_fbk))
+
+    tpdo_map2 = TPDOMap()
+    tpdo_map2.map_register_index = 0x1A01
+    tpdo_map2.add_item(TPDOMapItem(drv_op_value))
+
+    if reverse_order:
+        rpdo_maps = [rpdo_map2, rpdo_map1]
+        tpdo_maps = [tpdo_map2, tpdo_map1]
+    else:
+        rpdo_maps = [rpdo_map1, rpdo_map2]
+        tpdo_maps = [tpdo_map1, tpdo_map2]
+
+    servo.set_pdo_map_to_slave(rpdo_maps=rpdo_maps, tpdo_maps=tpdo_maps)
+
+    try:
+        start_stop_pdos(net)
+
+        actual_op_mode = servo.read(drv_op_cmd)
+        assert actual_op_mode == target_op_mode, (
+            f"DRV_OP_CMD: expected {target_op_mode}, got {actual_op_mode}. "
+            "RPDO byte order does not match insertion order."
+        )
+    finally:
+        servo.write(drv_op_cmd, initial_op_mode)
+
+
 def test_pdo_item_custom_size_wrong_length(open_dictionary):
     ethercat_dictionary = open_dictionary
     register = ethercat_dictionary.registers(SUBNODE)[TPDO_REGISTERS[0]]

--- a/tests/ethercat/test_pdo.py
+++ b/tests/ethercat/test_pdo.py
@@ -743,6 +743,8 @@ def test_multiple_pdo_maps_insertion_order_matches_processing_order(
             "RPDO byte order does not match insertion order."
         )
     finally:
+        # Rollback register values modified by PDO exchanges during test teardown
+        # https://novantamotion.atlassian.net/browse/CIT-657
         servo.write(drv_op_cmd, initial_op_mode)
 
 


### PR DESCRIPTION
When multiple PDO maps were configured, the processing order did not match the insertion order, causing values to be written to the wrong registers.

**Root cause:** `_process_tpdo` and `_process_rpdo` iterated over `sorted()` dict keys (index-based order), but `map_rpdos`/`map_tpdos` iterated `.values()` (insertion order). When maps were inserted in non-index order, the byte layout diverged.

## Changes

- **`ingenialink/pdo.py`**: Changed `_rpdo_maps` and `_tpdo_maps` from `dict` to `OrderedDict` to make ordering explicit. Removed `sorted()` from `_process_tpdo` and `_process_rpdo`. Updated `remove_rpdo_map`/`remove_tpdo_map` to preserve `OrderedDict` type.
- **`tests/ethercat/test_pdo.py`**: Added parametrized test `test_multiple_pdo_maps_insertion_order_matches_processing_order` that verifies PDO values arrive at the correct registers regardless of map insertion order.

Fixes INGK-1257