### PR TITLE
INGK-1268 remove available pdos restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Fix issues of servo status listener of ethercat drives when the drive is on operational state
+- Removed number of PDO mappings pre-flight check
 
 ## [7.6.0] - 2026-03-20
 ### Added

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -913,9 +913,6 @@ class PDOServo(Servo):
         and adds them to the PDO Assign object.
 
         WARNING: This operation can not be done if the servo is not in pre-operational state.
-
-        Raises:
-            ILError: If there are no available PDOs.
         """
         self.check_servo_is_in_preoperational_state()
         self.write(self.ETG_COMMS_RPDO_ASSIGN_TOTAL, len(self._rpdo_maps), subnode=0)
@@ -934,9 +931,6 @@ class PDOServo(Servo):
         and adds them to the PDO Assign object
 
         WARNING: This operation can not be done if the servo is not in pre-operational state.
-
-        Raises:
-            ILError: If there are no available PDOs.
         """
         self.check_servo_is_in_preoperational_state()
         self.write(self.ETG_COMMS_TPDO_ASSIGN_TOTAL, len(self._tpdo_maps), subnode=0)

--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -851,8 +851,6 @@ class TPDOMap(PDOMap):
 class PDOServo(Servo):
     """Abstract class to implement PDOs in a Servo class."""
 
-    AVAILABLE_PDOS = 2
-
     ETG_COMMS_RPDO_ASSIGN_TOTAL = "ETG_COMMS_RPDO_ASSIGN_TOTAL"
     ETG_COMMS_RPDO_ASSIGN_1 = "ETG_COMMS_RPDO_ASSIGN_1"
 
@@ -920,11 +918,6 @@ class PDOServo(Servo):
             ILError: If there are no available PDOs.
         """
         self.check_servo_is_in_preoperational_state()
-        if len(self._rpdo_maps) > self.AVAILABLE_PDOS:
-            raise ILError(
-                f"Could not map the RPDO maps, received {len(self._rpdo_maps)} PDOs and only"
-                f" {self.AVAILABLE_PDOS} are available"
-            )
         self.write(self.ETG_COMMS_RPDO_ASSIGN_TOTAL, len(self._rpdo_maps), subnode=0)
         rpdo_assigns = b""
         for rpdo_map in self._rpdo_maps.values():
@@ -946,11 +939,6 @@ class PDOServo(Servo):
             ILError: If there are no available PDOs.
         """
         self.check_servo_is_in_preoperational_state()
-        if len(self._tpdo_maps) > self.AVAILABLE_PDOS:
-            raise ILError(
-                f"Could not map the TPDO maps, received {len(self._tpdo_maps)} PDOs and only"
-                f" {self.AVAILABLE_PDOS} are available"
-            )
         self.write(self.ETG_COMMS_TPDO_ASSIGN_TOTAL, len(self._tpdo_maps), subnode=0)
         tpdo_assigns = b""
         for tpdo_map in self._tpdo_maps.values():


### PR DESCRIPTION
Drives have different pdo mapping restrictions and it the current pre-flight restrictions do not the real ones. We could potentially implement them with some dictionary information, and some hard-coded one, but I think it is too complex for what is worth it as current restrictions are:
 - Everest: 1 PDO Map (3 total, 1 concurrently)
 - CoMoCo: 3 PDO Maps (3 total/3 concurrently)
 - CoMoCo Safe: 3 PDO Maps (4 in total, 3 concurrently)