### PR TITLE
Ingk 1267 refactor test servo skip pattern to use not valid for product marker

### DIFF
--- a/tests/test_emcy.py
+++ b/tests/test_emcy.py
@@ -42,11 +42,10 @@ def test_emcy_callback(servo):
 
 
 @pytest.mark.ethercat
+@pytest.mark.not_valid_for_standard_cocomoco
 def test_emcy_callback_coco_moco_ethercat(servo):
     # EMCY test for COCO MOCO EtherCAT drives
     # Check INGK-993
-    if not is_coco_moco(servo):
-        pytest.skip("The test is only for COCO MOCO EtherCAT drives")
     emcy_test = EmcyTest()
     servo.emcy_subscribe(emcy_test.emcy_callback)
     prev_val = servo.read("DRV_PROT_USER_OVER_VOLT", subnode=1)

--- a/tests/test_get_adapters_addresses.py
+++ b/tests/test_get_adapters_addresses.py
@@ -11,17 +11,15 @@ def adapters_module():
         import ingenialink.get_adapters_addresses as adapters  # noqa: PLC0415
 
         return adapters
-    pytest.skip(f"Skipping test, only available on Windows, platform={current_platform}")
+
+    raise NotImplementedError(
+        "Get adapters addresses is not implemented on this platform. "
+        "Do not run these tests under this platform"
+    )
 
 
-@pytest.mark.canopen
 @pytest.mark.ethercat
 def test_get_adapters_addresses(adapters_module, setup_descriptor):
-    if not hasattr(setup_descriptor, "ifname"):
-        pytest.skip(
-            f"Skipping test because 'ifname' is not in the '{setup_descriptor=}' information."
-        )
-
     ifname_match = re.search(r"\{[^}]*\}", setup_descriptor.ifname)
     expected_adapter_address = ifname_match.group(0) if ifname_match else None
     assert expected_adapter_address is not None

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -53,13 +53,6 @@ class RegisterUpdateTest:
         self.call_count += 1
 
 
-def skip_if_monitoring_is_not_available(servo):
-    try:
-        servo.read("MON_DIST_STATUS")
-    except ILError:
-        pytest.skip("Monitoring is not available")
-
-
 class SDOReadTimeoutManager:
     def __init__(self, network, new_value):
         self.__net = network
@@ -76,7 +69,7 @@ class SDOReadTimeoutManager:
 
 @pytest.fixture
 def create_monitoring(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.monitoring_disable()
     servo.monitoring_remove_all_mapped_registers()
     registers_key = ["CL_CUR_D_REF_VALUE"]
@@ -92,7 +85,7 @@ def create_monitoring(servo):
 
 @pytest.fixture()
 def create_disturbance(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     data = list(range(DISTURBANCE_NUM_SAMPLES))
     servo.disturbance_disable()
     servo.disturbance_remove_all_mapped_registers()
@@ -459,7 +452,7 @@ def test_write(servo) -> None:
 @pytest.mark.ethercat
 @pytest.mark.virtual
 def test_monitoring_enable_disable(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.monitoring_enable()
     assert servo.read(servo.MONITORING_DIST_ENABLE, subnode=0) == 1
     servo.monitoring_disable()
@@ -483,7 +476,7 @@ def test_monitoring_remove_data(create_monitoring):
 @pytest.mark.ethercat
 @pytest.mark.virtual
 def test_monitoring_map_register(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.monitoring_remove_all_mapped_registers()
     registers_key = ["CL_POS_SET_POINT_VALUE", "CL_VEL_SET_POINT_VALUE"]
     data_size = 4
@@ -538,7 +531,7 @@ def test_monitoring_read_data(create_monitoring):
 @pytest.mark.ethercat
 @pytest.mark.virtual
 def test_disturbance_enable_disable(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.disturbance_enable()
     assert servo.read(servo.DISTURBANCE_ENABLE, subnode=0) == 1
     servo.disturbance_disable()
@@ -564,7 +557,7 @@ def test_disturbance_remove_data(create_disturbance):
 @pytest.mark.ethercat
 @pytest.mark.virtual
 def test_disturbance_map_register(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.disturbance_remove_all_mapped_registers()
     registers_key = ["CL_POS_SET_POINT_VALUE", "CL_VEL_SET_POINT_VALUE"]
     data_size = 4
@@ -669,7 +662,7 @@ def test_status_word_wait_change(servo):
 @pytest.mark.ethercat
 @pytest.mark.virtual
 def test_disturbance_overflow(servo):
-    skip_if_monitoring_is_not_available(servo)
+
     servo.disturbance_disable()
     servo.disturbance_remove_all_mapped_registers()
     servo.disturbance_set_mapped_register(

--- a/tests/test_servo.py
+++ b/tests/test_servo.py
@@ -447,12 +447,16 @@ def test_write(servo) -> None:
     assert value == saved_value
 
 
+def when_monitoring_available():
+    return pytest.mark.not_valid_for_standard_cocomoco(interfaces=[Interface.CAN, Interface.ECAT])
+
+
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
 @pytest.mark.virtual
+@when_monitoring_available()
 def test_monitoring_enable_disable(servo):
-
     servo.monitoring_enable()
     assert servo.read(servo.MONITORING_DIST_ENABLE, subnode=0) == 1
     servo.monitoring_disable()
@@ -462,6 +466,7 @@ def test_monitoring_enable_disable(servo):
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
+@when_monitoring_available()
 def test_monitoring_remove_data(create_monitoring):
     servo = create_monitoring
     servo.monitoring_enable()
@@ -475,6 +480,7 @@ def test_monitoring_remove_data(create_monitoring):
 @pytest.mark.canopen
 @pytest.mark.ethercat
 @pytest.mark.virtual
+@when_monitoring_available()
 def test_monitoring_map_register(servo):
 
     servo.monitoring_remove_all_mapped_registers()
@@ -498,6 +504,7 @@ def test_monitoring_map_register(servo):
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
+@when_monitoring_available()
 def test_monitoring_data_size(create_monitoring):
     servo = create_monitoring
     servo.monitoring_enable()
@@ -511,6 +518,7 @@ def test_monitoring_data_size(create_monitoring):
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
+@when_monitoring_available()
 def test_monitoring_read_data(create_monitoring):
     servo = create_monitoring
     servo.monitoring_enable()
@@ -530,8 +538,8 @@ def test_monitoring_read_data(create_monitoring):
 @pytest.mark.canopen
 @pytest.mark.ethercat
 @pytest.mark.virtual
+@when_monitoring_available()
 def test_disturbance_enable_disable(servo):
-
     servo.disturbance_enable()
     assert servo.read(servo.DISTURBANCE_ENABLE, subnode=0) == 1
     servo.disturbance_disable()
@@ -541,6 +549,7 @@ def test_disturbance_enable_disable(servo):
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
+@when_monitoring_available()
 def test_disturbance_remove_data(create_disturbance):
     servo = create_disturbance
     servo.disturbance_enable()
@@ -556,6 +565,7 @@ def test_disturbance_remove_data(create_disturbance):
 @pytest.mark.canopen
 @pytest.mark.ethercat
 @pytest.mark.virtual
+@when_monitoring_available()
 def test_disturbance_map_register(servo):
 
     servo.disturbance_remove_all_mapped_registers()
@@ -579,6 +589,7 @@ def test_disturbance_map_register(servo):
 @pytest.mark.ethernet
 @pytest.mark.canopen
 @pytest.mark.ethercat
+@when_monitoring_available()
 def test_disturbance_data_size(create_disturbance):
     servo = create_disturbance
     servo.disturbance_enable()
@@ -661,8 +672,8 @@ def test_status_word_wait_change(servo):
 @pytest.mark.canopen
 @pytest.mark.ethercat
 @pytest.mark.virtual
+@when_monitoring_available()
 def test_disturbance_overflow(servo):
-
     servo.disturbance_disable()
     servo.disturbance_remove_all_mapped_registers()
     servo.disturbance_set_mapped_register(


### PR DESCRIPTION
Refactors skip patterns in hardware tests to use `summit-testing-framework` product markers instead of inline `pytest.skip()` calls. This makes filtering declarative (at collection time) and consistent with the rest of the test suite.