### PR TITLE
Ingk 1243 read monitoring registers without complete access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [Unreleased]
+### Changed
+- Monitoring registers reads without complete access
 
 ## [7.6.1] - 2026-04-29
 ### Added

--- a/ingenialink/ethercat/servo.py
+++ b/ingenialink/ethercat/servo.py
@@ -296,9 +296,8 @@ class EthercatServo(EthercatServoBase):
         if not super()._is_monitoring_implemented():
             raise NotImplementedError("Monitoring is not supported by this device.")
         if not isinstance(
-            data := self.read_complete_access(
-                self.MONITORING_DATA,
-                subnode=0,
+            data := self._read_raw(
+                cast("EthercatRegister", self._get_reg(self.MONITORING_DATA, subnode=0)),
                 buffer_size=self.MONITORING_DATA_BUFFER_SIZE,
             ),
             bytes,
@@ -317,7 +316,7 @@ class EthercatServo(EthercatServoBase):
         """
         if not super()._is_disturbance_implemented():
             raise NotImplementedError("Disturbance is not supported by this device.")
-        return self.write_complete_access(self.DIST_DATA, subnode=0, data=data)
+        return self.write(self.DIST_DATA, subnode=0, data=data)
 
     def emcy_subscribe(self, callback: Callable[[EmergencyMessage], None]) -> None:
         """Subscribe to emergency messages.


### PR DESCRIPTION
This pull request updates monitoring and disturbance handling in the EtherCAT servo implementation to improve how register reads and writes are performed, and updates the changelog to reflect this change.

**Monitoring and Disturbance Handling Updates:**

* Changed monitoring data reads to use the lower-level `_read_raw` method instead of `read_complete_access`, allowing reads without requiring complete access to the register (`ingenialink/ethercat/servo.py`).
* Changed disturbance data writes to use the standard `write` method instead of `write_complete_access`, simplifying the write operation (`ingenialink/ethercat/servo.py`).

**Documentation:**

* Updated `CHANGELOG.md` to note that monitoring now registers reads without requiring complete access.