### PR TITLE
Cit 594 revert ingk specifier version run latest during the day run old at night

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
 from summit_testing_framework.jenkins.pytest_config import PyTestConfig
-from summit_testing_framework.pytest_helpers.import_helpers import import_module_from_local_path
+from summit_testing_framework.pytest_helpers.import_helpers import (
+    import_module_from_local_path,
+)
 from summit_testing_framework.setups.specifier_container import SpecifierContainer
 from summit_testing_framework.setups.specifiers import (
     DictionaryType,
@@ -34,7 +36,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
@@ -44,17 +46,17 @@ ECAT_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.8.0": VersionConfig.from_version(
-                version="2.8.0",
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
-                            run_test_stage_uid="ethercat_everest_2.8.0",
-                            stage_name="EtherCAT Everest - FW. 2.8.0",
+                            run_test_stage_uid="ethercat_everest_2.8.1",
+                            stage_name="EtherCAT Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -70,7 +72,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
@@ -80,17 +82,17 @@ ECAT_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.9.0": VersionConfig.from_version(
-                version="2.9.0",
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
                 config_file=_config_files.CAP_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
-                            run_test_stage_uid="ethercat_capitan_2.9.0",
-                            stage_name="EtherCAT Capitan - FW. 2.9.0",
+                            run_test_stage_uid="ethercat_capitan_2.10.0",
+                            stage_name="EtherCAT Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -109,7 +111,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -119,17 +121,17 @@ ETH_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.8.0": VersionConfig.from_version(
-                version="2.8.0",
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
-                            run_test_stage_uid="ethernet_everest_2.8.0",
-                            stage_name="Ethernet Everest - FW. 2.8.0",
+                            run_test_stage_uid="ethernet_everest_2.8.1",
+                            stage_name="Ethernet Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -145,7 +147,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -155,17 +157,17 @@ ETH_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.9.0": VersionConfig.from_version(
-                version="2.9.0",
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
-                            run_test_stage_uid="ethernet_capitan_2.9.0",
-                            stage_name="Ethernet Capitan - FW. 2.9.0",
+                            run_test_stage_uid="ethernet_capitan_2.10.0",
+                            stage_name="Ethernet Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -184,7 +186,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -194,17 +196,17 @@ CAN_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.8.0": VersionConfig.from_version(
-                version="2.8.0",
+            "2.8.1": VersionConfig.from_version(
+                version="2.8.1",
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
-                            run_test_stage_uid="canopen_everest_2.8.0",
-                            stage_name="CANopen Everest - FW. 2.8.0",
+                            run_test_stage_uid="canopen_everest_2.8.1",
+                            stage_name="CANopen Everest - FW. 2.8.1",
                         )
                     },
                 },
@@ -220,7 +222,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "always",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "nightly",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -230,17 +232,17 @@ CAN_SETUP = SpecifierContainer({
                     },
                 },
             ),
-            "2.9.0": VersionConfig.from_version(
-                version="2.9.0",
+            "2.10.0": VersionConfig.from_version(
+                version="2.10.0",
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",  # https://novantamotion.atlassian.net/browse/CIT-594
+                    __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
-                            run_test_stage_uid="canopen_capitan_2.9.0",
-                            stage_name="CANopen Capitan - FW. 2.9.0",
+                            run_test_stage_uid="canopen_capitan_2.10.0",
+                            stage_name="CANopen Capitan - FW. 2.10.0",
                         )
                     },
                 },
@@ -295,13 +297,11 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
 ECAT_MULTISLAVE_SETUP = MultiRackServiceConfigSpecifier.create(
     identifier="ECAT_MULTISLAVE",
     specifiers=[
-        # https://novantamotion.atlassian.net/browse/CIT-594
         ECAT_SETUP.get_specifier_by_identifier_with_version(
-            identifier=PartNumber.EVE_XCR_E, version="2.6.0"
+            identifier=PartNumber.EVE_XCR_E, version="2.8.1"
         ),
-        # https://novantamotion.atlassian.net/browse/CIT-594
         ECAT_SETUP.get_specifier_by_identifier_with_version(
-            identifier=PartNumber.CAP_XCR_E, version="2.6.0"
+            identifier=PartNumber.CAP_XCR_E, version="2.10.0"
         ),
     ],
     extra_data={


### PR DESCRIPTION
This pull request updates the firmware version configurations and execution policies for various test setups in `tests/setups/rack_specifiers.py`. The main changes include bumping firmware versions to newer releases and adjusting the execution policy between "always" and "nightly" for specific test cases. Additionally, the multiservice rack configuration now uses the latest firmware versions.

**Firmware version and configuration updates:**

* Updated all references of firmware version `"2.8.0"` to `"2.8.1"` and `"2.9.0"` to `"2.10.0"` throughout the specifiers for Everest and Capitan devices, including associated `run_test_stage_uid` and `stage_name` fields. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L47-R59) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L83-R95) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L122-R134) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L158-R170) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L197-R209) [[6]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L233-R245)
* Adjusted execution policy for several configurations, switching between `"always"` and `"nightly"` to reflect the new testing schedule. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L37-R39) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L47-R59) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L73-R75) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L83-R95) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L112-R114) [[6]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L122-R134) [[7]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L148-R150) [[8]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L158-R170) [[9]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L187-R189) [[10]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L197-R209) [[11]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L223-R225) [[12]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L233-R245)
* Updated the `ECAT_MULTISLAVE_SETUP` to use the latest firmware versions (`2.8.1` for Everest and `2.10.0` for Capitan) instead of the older `2.6.0` versions.

**Code style and import improvements:**

* Reformatted the import statement for `import_module_from_local_path` for better readability.