### PR TITLE
Run old fw during weekend (friday & saturday)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,13 +72,13 @@ TestGroup WIN_DOCKER_TESTS = testManager.createGroup("WIN_DOCKER_TEST_SESSIONS",
  *   19:00, 23:00 UTC (21:00, 01:00 Barcelona Time)
  *   → Sets RUN_POLICY_NIGHTLY=true so that tests gated on the 'nightly' policy will run.
  *
- * Weekend extra builds (Saturday & Sunday only):
+ * Friday+Saturday extra builds (Friday & Saturday only):
  *   08:00, 14:00 UTC (10:00, 16:00 Barcelona Time)
  *   → Sets RUN_POLICY_NIGHTLY=true and RUN_POLICY_WEEKEND=true so that tests gated on
  *     either 'nightly' or 'weekends' policy will run.
  */
 def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true'
-def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
+def WEEKEND_CRON   = '0 8,14 * * 5,6 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
 def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
 
 pipeline {

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -36,7 +36,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
@@ -72,7 +72,7 @@ ECAT_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_E_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ECAT_TEST_SESSIONS": PyTestConfig(
                             markers="ethercat",
@@ -111,7 +111,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -147,7 +147,7 @@ ETH_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "ETH_TEST_SESSIONS": PyTestConfig(
                             markers="ethernet",
@@ -186,7 +186,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.EVE_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",
@@ -222,7 +222,7 @@ CAN_SETUP = SpecifierContainer({
                 config_file=_config_files.CAP_XCR_C_CONFIG,
                 dictionary_type=DictionaryType.XDF_V2,
                 extra_data={
-                    __EXECUTION_POLICY_KEY: "nightly",
+                    __EXECUTION_POLICY_KEY: "weekends",
                     __TEST_CONFIGS_KEY: {
                         "CAN_TEST_SESSIONS": PyTestConfig(
                             markers="canopen",


### PR DESCRIPTION
This pull request updates the scheduling and execution policies for certain test sessions to better align with when they should run. The main changes involve shifting some test executions from a "nightly" policy to a "weekends" policy, and adjusting the scheduled days for extra builds in the CI pipeline.

**Test execution policy updates:**

* Changed the execution policy for several test setups in `rack_specifiers.py` from `"nightly"` to `"weekends"`, ensuring these tests only run during the weekend policy window. [[1]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L39-R39) [[2]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L75-R75) [[3]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L114-R114) [[4]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L150-R150) [[5]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L189-R189) [[6]](diffhunk://#diff-f0f25497bf6853fe0a9f94c73490d9600976a856167e1f7f8a8baa5d37fb5925L225-R225)

**CI pipeline scheduling changes:**

* Updated the extra build schedule in `Jenkinsfile` so that "weekend" builds now run on Fridays and Saturdays instead of just Saturday and Sunday, reflecting this in both the documentation and the cron expression.