### PR TITLE
Ingm 761 update safety to release version skip broken tests

### DIFF
--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -271,22 +271,17 @@ ECAT_DEN_S_NET_E_SETUP = RackServiceConfigSpecifier.from_version_configs(
                 },
             },
         ),
-        "PHASE2": VersionConfig.from_files(
-            version="2.9.0.16",
+        "PHASE2": VersionConfig.from_version(
+            version="2.10.0",
             config_file=None,
-            firmware=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.8/den-s-net-e_2.9.0.lfu"
-            ),
-            dictionary=Path(
-                "//azr-srv-ingfs1/dist/products/i050_summit/i056_den-s-net-e/release_candidate/2.9.0.8/den-s-net-e_2.9.0.008_v3.xdf"
-            ),
+            dictionary_type=DictionaryType.XDF_V3,
             extra_data={
                 __EXECUTION_POLICY_KEY: "always",
                 __TEST_CONFIGS_KEY: {
                     "ECAT_TEST_SESSIONS": PyTestConfig(
                         markers="fsoe",
-                        run_test_stage_uid="fsoe_phase2",
-                        stage_name="Safety Denali Phase II",
+                        run_test_stage_uid="fsoe_phase2_2.10.0",
+                        stage_name="Safety Denali Phase II - FW. 2.10.0",
                     )
                 },
             },

--- a/tests/setups/rack_specifiers.py
+++ b/tests/setups/rack_specifiers.py
@@ -85,7 +85,7 @@ ECAT_SETUP = SpecifierContainer({
             "2.10.0": VersionConfig.from_version(
                 version="2.10.0",
                 config_file=_config_files.CAP_XCR_E_CONFIG,
-                dictionary_type=DictionaryType.XDF_V2,
+                dictionary_type=DictionaryType.XDF_V3,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
@@ -160,7 +160,7 @@ ETH_SETUP = SpecifierContainer({
             "2.10.0": VersionConfig.from_version(
                 version="2.10.0",
                 config_file=_config_files.CAP_XCR_C_CONFIG,
-                dictionary_type=DictionaryType.XDF_V2,
+                dictionary_type=DictionaryType.XDF_V3,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {
@@ -235,7 +235,7 @@ CAN_SETUP = SpecifierContainer({
             "2.10.0": VersionConfig.from_version(
                 version="2.10.0",
                 config_file=_config_files.CAP_XCR_C_CONFIG,
-                dictionary_type=DictionaryType.XDF_V2,
+                dictionary_type=DictionaryType.XDF_V3,
                 extra_data={
                     __EXECUTION_POLICY_KEY: "always",
                     __TEST_CONFIGS_KEY: {

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -42,6 +42,7 @@ def real_servo_with_tables(servo) -> Generator[tuple[Servo, Table] :, None, None
     try:
         table = servo.get_table(uid="MEM_USR", axis=0)
         yield servo, table  # Table already exists, skip injection
+        return
     except (ValueError, KeyError):
         # Expected: table not found in dictionary
         pass

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -40,8 +40,8 @@ def real_servo_with_tables(servo) -> Generator[tuple[Servo, Table] :, None, None
     """
     # Assert that the table is not already defined in the XDF
     try:
-        servo.get_table(uid="MEM_USR", axis=0)
-        return  # Table already exists, skip injection
+        table = servo.get_table(uid="MEM_USR", axis=0)
+        yield servo, table  # Table already exists, skip injection
     except (ValueError, KeyError):
         # Expected: table not found in dictionary
         pass

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -39,14 +39,9 @@ def real_servo_with_tables(servo) -> Generator[tuple[Servo, Table] :, None, None
         Tuple[Servo, Table]: The real servo and the user memory table.
     """
     # Assert that the table is not already defined in the XDF
-    # When XDFs are updated to include tables, this assertion will fail
-    # and we can remove this injection logic
     try:
         servo.get_table(uid="MEM_USR", axis=0)
-        raise AssertionError(
-            "MEM_USR table is now defined in the XDF dictionary! "
-            "Please remove the table injection logic from this fixture."
-        )
+        return  # Table already exists, skip injection
     except (ValueError, KeyError):
         # Expected: table not found in dictionary
         pass


### PR DESCRIPTION
This pull request updates the configuration for the "PHASE2" test setup in `rack_specifiers.py` to use a newer firmware version and simplifies how the version is specified. The most important changes are:

**Test Configuration Updates:**

* Updated the "PHASE2" configuration to use version "2.10.0" instead of "2.9.0.16", and switched from `VersionConfig.from_files` to `VersionConfig.from_version` for a simpler setup.
* Removed explicit firmware and dictionary file paths, replacing them with a `dictionary_type` parameter set to `DictionaryType.XDF_V3`.
* Updated test metadata for "PHASE2" to use a new test stage UID (`fsoe_phase2_2.10.0`) and a stage name reflecting the new firmware version ("Safety Denali Phase II - FW. 2.10.0").