### PR TITLE
Cit 703 add entry to allow to archive tests outputs based on glob patterns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
+// https://novantamotion.atlassian.net/browse/CIT-707
 @Library('cicd-lib@d6a0923') _
 
 import python.VirtualEnvironment

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('cicd-lib@59677f0') _
+@Library('cicd-lib@d6a0923') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -154,6 +154,7 @@ pipeline {
                         jobName: "${env.JOB_NAME}-#${env.BUILD_NUMBER}",
                         wiresharkScope: params.WIRESHARK_LOGGING_SCOPE,
                         clearSuccessfulWiresharkLogs: params.CLEAR_SUCCESSFUL_WIRESHARK_LOGS,
+                        archiveData: "*",
                     )
 
                     // Configure if ECAT and ETH sessions use Wireshark logging based on parameter


### PR DESCRIPTION
This pull request updates the Jenkins pipeline to use a newer version of the shared library and ensures that all data is archived during the pipeline execution. These changes improve pipeline reliability and traceability.

Pipeline configuration updates:

* Updated the `@Library` reference in `Jenkinsfile` to use `cicd-lib@d6a0923`, which pulls in the latest changes from the shared pipeline library.
* Added the `archiveData: "*"` parameter to the Wireshark logging step to ensure all relevant data is archived for each build.