### PR TITLE
Cit 691 add test selection filter to sessions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@da66751') _
+@Library('cicd-lib@112bb66') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@89fbfea') _
+@Library('cicd-lib@56bbe39') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
+import utils.BuildParamUtils
 import pytest.TestSession
 import pytest.TestGroup
 import pytest.PyTestManager
@@ -119,10 +120,10 @@ properties([
         booleanParam(name: 'RUN_POLICY_NIGHTLY', defaultValue: false, description: 'Tag this build as a nightly build (set automatically by cron triggers)'),
         booleanParam(name: 'RUN_POLICY_WEEKEND', defaultValue: false, description: 'Tag this build as a weekend build (set automatically by weekend cron triggers)'),
         // Show the previous build's pytest selection as the initial value in the form.
-        // If PYTEST_SELECTION contains data, it will override test_session_filter. If both are empty, all tests will run.
+        // If PYTEST_SELECTION contains data, it acts as an additional selector alongside test_session_filter.
         string(
             name: 'PYTEST_SELECTION',
-            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_SELECTION', ''),
+            defaultValue: BuildParamUtils.latestBuildParamValue(currentBuild, 'PYTEST_SELECTION', ''),
             description: '''
                 Pytest selection string to select which tests to run.<br>
                 See <a href="https://docs.pytest.org/en/stable/how-to/usage.html#specifying-tests-selecting-tests" target="_blank">
@@ -134,7 +135,7 @@ properties([
         // If PYTEST_SELECTION is empty, this will have no effect since all tests will run once by default.
         string(
             name: 'PYTEST_REPEAT_COUNTS',
-            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_REPEAT_COUNTS', '1'),
+            defaultValue: BuildParamUtils.latestBuildParamValue(currentBuild, 'PYTEST_REPEAT_COUNTS', '1'),
             description: '''
                 Pytest repeat count used for <code>--count</code>.<br>
                 See <a href="https://github.com/pytest-dev/pytest-repeat" target="_blank">

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@d2aedbd') _
+@Library('cicd-lib@3a0e465') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -134,7 +134,7 @@ properties([
         // If PYTEST_SELECTION is empty, this will have no effect since all tests will run once by default.
         string(
             name: 'PYTEST_REPEAT_COUNTS',
-            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_REPEAT_COUNTS', ''),
+            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_REPEAT_COUNTS', '1'),
             description: '''
                 Pytest repeat count used for <code>--count</code>.<br>
                 See <a href="https://github.com/pytest-dev/pytest-repeat" target="_blank">
@@ -326,7 +326,7 @@ pipeline {
                                         }
                                     }
                                 }
-                                stage('Resolve WIN_DOCKER_TESTS') {
+                                stage('Resolve Test Session') {
                                     steps {
                                         script {
                                             testManager.resolveSession(WIN_DOCKER_TESTS)
@@ -432,9 +432,13 @@ pipeline {
                                             testManager.echoTestGroupsSummary()
                                             testManager.collectTestsForDashboard()
                                             testManager.generateTestDashboard()
-
+                                        }
+                                    }
+                                }
+                                stage('Resolve Test Sessions') {
+                                    steps {
+                                        script {
                                             testManager.resolveSessions(excludeGroups: [WIN_DOCKER_TESTS])
-
                                         }
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@56bbe39') _
+@Library('cicd-lib@70fbc61') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -121,9 +121,10 @@ properties([
         booleanParam(name: 'RUN_POLICY_WEEKEND', defaultValue: false, description: 'Tag this build as a weekend build (set automatically by weekend cron triggers)'),
         // Show the previous build's pytest selection as the initial value in the form.
         // If PYTEST_SELECTION contains data, it acts as an additional selector alongside test_session_filter.
+        // If master/develop/release branch, default to empty (no filter applied by default)
         string(
             name: 'PYTEST_SELECTION',
-            defaultValue: BuildParamUtils.latestBuildParamValue(currentBuild, 'PYTEST_SELECTION', ''),
+            defaultValue: env.BRANCH_NAME in [BRANCH_NAME_MASTER, 'develop'] || env.BRANCH_NAME?.startsWith('release/') ? '' : BuildParamUtils.latestBuildParamValue(currentBuild, 'PYTEST_SELECTION', ''),
             description: '''
                 Pytest selection string to select which tests to run.<br>
                 See <a href="https://docs.pytest.org/en/stable/how-to/usage.html#specifying-tests-selecting-tests" target="_blank">

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@8f29029') _
+@Library('cicd-lib@d2aedbd') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -40,9 +40,9 @@ def reassignFilePermissions() {
 }
 
 VEnvManager venvManager = new VEnvManager(
-  pipeline: this,
-  default_python_version: DEFAULT_PYTHON_VERSION,
-  poetry_default_install_command: "poetry sync --no-root --all-groups"
+    pipeline: this,
+    default_python_version: DEFAULT_PYTHON_VERSION,
+    poetry_default_install_command: "poetry sync --no-root --all-groups"
 )
 
 PyTestManager testManager = new PyTestManager(pipeline: this, venvManager: venvManager)
@@ -261,7 +261,7 @@ pipeline {
                                     steps {
                                         script {
                                             venvManager.createPoetryEnvironments(
-                                              pythonVersions: ALL_PYTHON_VERSIONS
+                                                pythonVersions: ALL_PYTHON_VERSIONS
                                             )
                                         }
                                     }
@@ -326,6 +326,13 @@ pipeline {
                                         }
                                     }
                                 }
+                                stage('Resolve WIN_DOCKER_TESTS') {
+                                    steps {
+                                        script {
+                                            testManager.resolveSession(WIN_DOCKER_TESTS)
+                                        }
+                                    }
+                                }
                                 stage('Run unit tests (no-pcap) tests on docker') {
                                     when {
                                         expression {
@@ -375,7 +382,7 @@ pipeline {
                                     steps {
                                         script {
                                             venvManager.createPoetryEnvironments(
-                                              pythonVersions: ([DEFAULT_PYTHON_VERSION] as Set) + venvManager.defaultVenvNamesToVersion(TEST_SESSIONS.runInVirtualEnvs)
+                                                pythonVersions: ([DEFAULT_PYTHON_VERSION] as Set) + venvManager.defaultVenvNamesToVersion(TEST_SESSIONS.runInVirtualEnvs)
                                             )
                                         }
                                     }
@@ -410,7 +417,7 @@ pipeline {
                                             venvManager.forVirtualEnvs(TEST_SESSIONS.runInVirtualEnvs) { venv ->
                                                 venv.run("poetry run poe install-wheel")
                                             }
-                                            
+
                                             // Export specifiers and populate TestGroup sessions (policy + uid-regex evaluated here).
                                             testManager.buildTestSessions("tests.setups.rack_specifiers")
                                             testManager.buildTestSessions("tests.setups.virtual_drive_specifier")
@@ -425,6 +432,9 @@ pipeline {
                                             testManager.echoTestGroupsSummary()
                                             testManager.collectTestsForDashboard()
                                             testManager.generateTestDashboard()
+
+                                            testManager.resolveSessions(excludeGroups: [WIN_DOCKER_TESTS])
+
                                         }
                                     }
                                 }
@@ -500,7 +510,7 @@ pipeline {
                 }
             }
         }
-        
+
         stage('Tests') {
             parallel {
                 stage('EtherCAT/No Connection - Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@cb7497c') _
+@Library('cicd-lib@89fbfea') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@d6a0923') _
+@Library('cicd-lib@8f29029') _
 
 import python.VirtualEnvironment
 import python.VEnvManager
@@ -80,19 +80,13 @@ def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=tru
 def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
 def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
 
-pipeline {
-    agent none
-    options {
-        timestamps()
-    }
-    triggers {
-        parameterizedCron(CRON_SETTINGS)
-    }
-    parameters {
+properties([
+    pipelineTriggers([parameterizedCron(CRON_SETTINGS)]),
+    parameters ([
         choice(
                 choices: ['MIN', 'MAX', 'MIN_MAX', 'All'],
                 name: 'PYTHON_VERSIONS'
-        )
+        ),
         choice(
             choices: [
                 '.*',
@@ -115,15 +109,47 @@ pipeline {
             ],
             name: 'test_session_filter',
             description: 'Regex pattern for which test sessions to run (e.g. "fsoe.*", "ethercat_everest.*", ".*" for all)'
-        )
-        booleanParam(name: 'WIRESHARK_LOGGING', defaultValue: false, description: 'Enable Wireshark logging')
+        ),
+        booleanParam(name: 'WIRESHARK_LOGGING', defaultValue: false, description: 'Enable Wireshark logging'),
         choice(
                 choices: ['function', 'module', 'session'],
                 name: 'WIRESHARK_LOGGING_SCOPE'
+        ),
+        booleanParam(name: 'CLEAR_SUCCESSFUL_WIRESHARK_LOGS', defaultValue: true, description: 'Clears Wireshark logs if the test passed'),
+        booleanParam(name: 'RUN_POLICY_NIGHTLY', defaultValue: false, description: 'Tag this build as a nightly build (set automatically by cron triggers)'),
+        booleanParam(name: 'RUN_POLICY_WEEKEND', defaultValue: false, description: 'Tag this build as a weekend build (set automatically by weekend cron triggers)'),
+        // Show the previous build's pytest selection as the initial value in the form.
+        // If PYTEST_SELECTION contains data, it will override test_session_filter. If both are empty, all tests will run.
+        string(
+            name: 'PYTEST_SELECTION',
+            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_SELECTION', ''),
+            description: '''
+                Pytest selection string to select which tests to run.<br>
+                See <a href="https://docs.pytest.org/en/stable/how-to/usage.html#specifying-tests-selecting-tests" target="_blank">
+                pytest selecting tests documentation
+                </a>
+            '''
+        ),
+        // Repeat-count input will be used for --count arguments (pytest-repeat plugin) for all test sessions that are run.
+        // If PYTEST_SELECTION is empty, this will have no effect since all tests will run once by default.
+        string(
+            name: 'PYTEST_REPEAT_COUNTS',
+            defaultValue: TEST_SESSIONS.latestBuildParamValue(currentBuild, 'PYTEST_REPEAT_COUNTS', ''),
+            description: '''
+                Pytest repeat count used for <code>--count</code>.<br>
+                See <a href="https://github.com/pytest-dev/pytest-repeat" target="_blank">
+                pytest repeat plugin documentation
+                </a>.<br>
+                <span style="color:red;">Only has effect when PYTEST_SELECTION is set.</span>
+            '''
         )
-        booleanParam(name: 'CLEAR_SUCCESSFUL_WIRESHARK_LOGS', defaultValue: true, description: 'Clears Wireshark logs if the test passed')
-        booleanParam(name: 'RUN_POLICY_NIGHTLY', defaultValue: false, description: 'Tag this build as a nightly build (set automatically by cron triggers)')
-        booleanParam(name: 'RUN_POLICY_WEEKEND', defaultValue: false, description: 'Tag this build as a weekend build (set automatically by weekend cron triggers)')
+    ])
+])
+
+pipeline {
+    agent none
+    options {
+        timestamps()
     }
     stages {
         stage("Set env") {
@@ -156,6 +182,7 @@ pipeline {
                         wiresharkScope: params.WIRESHARK_LOGGING_SCOPE,
                         clearSuccessfulWiresharkLogs: params.CLEAR_SUCCESSFUL_WIRESHARK_LOGS,
                         archiveData: "*",
+                        testSelectionRepeatCount: params.PYTEST_REPEAT_COUNTS?.trim()?.isInteger() ? params.PYTEST_REPEAT_COUNTS.toInteger() : 1,
                     )
 
                     // Configure if ECAT and ETH sessions use Wireshark logging based on parameter
@@ -167,6 +194,7 @@ pipeline {
                     )
 
                     testManager.testSessionFilter = params.test_session_filter
+                    testManager.testSessionSelection = params.PYTEST_SELECTION
 
                     // Parse run policy tags from boolean parameters
                     def runPolicyTags = [] as Set

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@70fbc61') _
+@Library('cicd-lib@da66751') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // https://novantamotion.atlassian.net/browse/CIT-707
-@Library('cicd-lib@3a0e465') _
+@Library('cicd-lib@cb7497c') _
 
 import python.VirtualEnvironment
 import python.VEnvManager

--- a/poetry.lock
+++ b/poetry.lock
@@ -3701,6 +3701,21 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+description = "pytest plugin for repeating tests"
+optional = false
+python-versions = ">=3.9"
+groups = ["tests"]
+files = [
+    {file = "pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3"},
+    {file = "pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485"},
+]
+
+[package.dependencies]
+pytest = "*"
+
+[[package]]
 name = "python-can"
 version = "4.6.1"
 description = "Controller Area Network interface module for Python"
@@ -5897,4 +5912,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "42fde0e49747eab7b84cee3f510302ca5ff2685022dc78ef948c9c0c8f7b7f14"
+content-hash = "2b8f269d8bc754cf07668be00cc82f19d45d8d47822d64ef9eb48212eaa7b92e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,9 @@ priority = "supplemental"
 
 [build-system]
 requires = [
-  "setuptools==75.6.0", 
-  "setuptools_scm[toml]>=8", 
-  "wheel==0.42.0", 
+  "setuptools==75.6.0",
+  "setuptools_scm[toml]>=8",
+  "wheel==0.42.0",
   "Cython==3.0.11",
   "setuptools_scm_policies @ http://pypi.novanta.com/packages/setuptools_scm_policies-0.2.0-py3-none-any.whl"
 ]
@@ -120,6 +120,7 @@ pytest = "==8.4.1"
 pytest-env = "==1.1.5"
 pytest-cov = "==7.1.0"
 pytest-mock = "==3.15.1"
+pytest-repeat = "==0.9.4"
 pytest-console-scripts = "==1.4.1"
 twisted = "==25.5.0"
 summit-testing-framework = {version = "0.3.0.post243+develop.82ae762"}


### PR DESCRIPTION
**Check [CICD](https://bitbucket.org/novantamotion/cicd-lib/pull-requests/53) PR for how-to-use-it instructions.**

This pull request updates the test job configuration in the `Jenkinsfile` to improve test selection and repeatability, and adds a new test dependency. The main changes include switching to a new version of the shared CI/CD library, adding parameters for selecting and repeating pytest tests, and updating variable declarations for consistency.

**Jenkins pipeline improvements:**

* Switched the shared CI/CD library reference, enabling new features for test selection.
* Added `PYTEST_SELECTION` and `PYTEST_REPEAT_COUNTS` as new pipeline parameters, allowing users to specify which tests to run and how many times to repeat them. These parameters are also passed to the test session manager for execution.
* Updated the pipeline parameters section to use the `properties` block instead of inline parameters for better maintainability and flexibility.

**Test dependency updates:**

* Added the `pytest-repeat` plugin to `pyproject.toml` to support repeated test execution via the new pipeline parameter.