### PR TITLE
Cit 740 do not restore cia 301 pdo registers

### DIFF
--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -642,7 +642,9 @@ class DriveContextManager:
                 # Ethercat PDO mapping registers are restored via complete access, not individually.
                 "ETG_COMMS_RPDO_MAP*",
                 "ETG_COMMS_TPDO_MAP*",
-                # Canopen PDO mapping registers are not implemented and are not restorable individually.
+                # Canopen PDO mapping registers are not implemented
+                # and are not restorable individually.
+                # See INGK-733
                 "CIA301_COMMS_RPDO*",
                 "CIA301_COMMS_TPDO*",
             )

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -639,9 +639,12 @@ class DriveContextManager:
                 # Total number of error register should not be restored, only a 0 can be written
                 "ETG_ERROR_FIELD",
                 "CIA301_COMMS_ERROR_FIELD",
-                # PDO mapping registers are restored via complete access, not individually.
+                # Ethercat PDO mapping registers are restored via complete access, not individually.
                 "ETG_COMMS_RPDO_MAP*",
                 "ETG_COMMS_TPDO_MAP*",
+                # Canopen PDO mapping registers are not implemented and are not restorable individually.
+                "CIA301_COMMS_RPDO*",
+                "CIA301_COMMS_TPDO*",
             )
         )
 

--- a/ingenialink/drive_context_manager.py
+++ b/ingenialink/drive_context_manager.py
@@ -466,6 +466,8 @@ class DriveRegistersSession:
         Args:
             register: The register to mark as dirty.
         """
+        if register in self._do_not_restore_registers:
+            return
         if register not in self.baseline._values:
             return
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1576,11 +1576,6 @@ class Servo:
         if _reg.access == RegAccess.RO:
             raise ILAccessError("Register is Read-only")
         data_bytes = data if isinstance(data, bytes) else convert_dtype_to_bytes(data, _reg.dtype)
-        if _reg.identifier is not None and _reg.identifier.startswith((
-            "CIA301_COMMS_TPDO",
-            "CIA301_COMMS_RPDO",
-        )):
-            logger.warning(f"DEBUG: about to write {_reg.identifier}={data!r}", stack_info=True)
         self._write_raw(_reg, data_bytes)
         self._notify_register_update(_reg, data)
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1576,6 +1576,12 @@ class Servo:
         if _reg.access == RegAccess.RO:
             raise ILAccessError("Register is Read-only")
         data_bytes = data if isinstance(data, bytes) else convert_dtype_to_bytes(data, _reg.dtype)
+        if _reg.identifier is not None and _reg.identifier.startswith(
+            ("CIA301_COMMS_TPDO", "CIA301_COMMS_RPDO")
+        ):
+            logger.warning(
+                f"DEBUG: about to write {_reg.identifier}={data!r}", stack_info=True
+            )
         self._write_raw(_reg, data_bytes)
         self._notify_register_update(_reg, data)
 

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -1576,12 +1576,11 @@ class Servo:
         if _reg.access == RegAccess.RO:
             raise ILAccessError("Register is Read-only")
         data_bytes = data if isinstance(data, bytes) else convert_dtype_to_bytes(data, _reg.dtype)
-        if _reg.identifier is not None and _reg.identifier.startswith(
-            ("CIA301_COMMS_TPDO", "CIA301_COMMS_RPDO")
-        ):
-            logger.warning(
-                f"DEBUG: about to write {_reg.identifier}={data!r}", stack_info=True
-            )
+        if _reg.identifier is not None and _reg.identifier.startswith((
+            "CIA301_COMMS_TPDO",
+            "CIA301_COMMS_RPDO",
+        )):
+            logger.warning(f"DEBUG: about to write {_reg.identifier}={data!r}", stack_info=True)
         self._write_raw(_reg, data_bytes)
         self._notify_register_update(_reg, data)
 

--- a/tests/test_drive_context_manager.py
+++ b/tests/test_drive_context_manager.py
@@ -114,6 +114,9 @@ def test_drive_context_manager_skips_default_do_not_restore_registers(servo: "Se
             # complete access).  ASSIGN registers are NOT excluded.
             "ETG_COMMS_RPDO_MAP*",
             "ETG_COMMS_TPDO_MAP*",
+            # CANopen PDO mapping registers are not restorable individually (see INGK-733).
+            "CIA301_COMMS_RPDO*",
+            "CIA301_COMMS_TPDO*",
         )
     )
 
@@ -139,6 +142,8 @@ def test_drive_context_manager_with_do_not_restore_registers(servo: "Servo"):
             _USER_OVER_VOLTAGE_UID,
             "ETG_COMMS_RPDO_MAP*",
             "ETG_COMMS_TPDO_MAP*",
+            "CIA301_COMMS_RPDO*",
+            "CIA301_COMMS_TPDO*",
         )
     )
 


### PR DESCRIPTION
Context manager is graceful when restoring the pdo registers but it logs errors. there’s a stream of error logs on all canopen tests that makes it hard to debug things. It does not make sense since we don’t even implement canopen pdos 

```
2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_8. Exception: Code 0x06010000, Unsupported access to an object
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.drive_context_manager:drive_context_manager.py:57 CIA301_COMMS_TPDO4_MAP_8 failed to restore on axis=0 after 2 attempts: ILRegisterAccessError('Error writing CIA301_COMMS_TPDO4_MAP_8. Code 0x06010000, Unsupported access to an object')
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_7. Exception: Code 0x06010000, Unsupported access to an object
[2026-07-09T08:50:56.350Z] INFO     ingenialink.drive_context_manager:drive_context_manager.py:52 CIA301_COMMS_TPDO4_MAP_7 failed to restore on axis=0 with exception ILRegisterAccessError('Error writing CIA301_COMMS_TPDO4_MAP_7. Code 0x06010000, Unsupported access to an object'), attempt (1/2)
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_7. Exception: Code 0x06010000, Unsupported access to an object
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.drive_context_manager:drive_context_manager.py:57 CIA301_COMMS_TPDO4_MAP_7 failed to restore on axis=0 after 2 attempts: ILRegisterAccessError('Error writing CIA301_COMMS_TPDO4_MAP_7. Code 0x06010000, Unsupported access to an object')
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_6. Exception: Code 0x06010000, Unsupported access to an object
[2026-07-09T08:50:56.350Z] INFO     ingenialink.drive_context_manager:drive_context_manager.py:52 CIA301_COMMS_TPDO4_MAP_6 failed to restore on axis=0 with exception ILRegisterAccessError('Error writing CIA301_COMMS_TPDO4_MAP_6. Code 0x06010000, Unsupported access to an object'), attempt (1/2)
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_6. Exception: Code 0x06010000, Unsupported access to an object
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.drive_context_manager:drive_context_manager.py:57 CIA301_COMMS_TPDO4_MAP_6 failed to restore on axis=0 after 2 attempts: ILRegisterAccessError('Error writing CIA301_COMMS_TPDO4_MAP_6. Code 0x06010000, Unsupported access to an object')
[2026-07-09T08:50:56.350Z] ERROR    ingenialink.canopen.servo:servo.py:108 Failed writing CIA301_COMMS_TPDO4_MAP_5. Exception: Code 0x06010000, Unsupported access to an object
```


* Updated the default list of "do not restore" registers in `DriveContextManager` to include CANopen PDO mapping registers (`CIA301_COMMS_RPDO*`, `CIA301_COMMS_TPDO*`), with comments referencing INGK-733.
* Fixed * Modified the `set_dirty_register` method to immediately return if the register is in the "do not restore" list, respecting the settings of the manager

**Test coverage updates:**

* Updated `test_drive_context_manager_skips_default_do_not_restore_registers` and `test_drive_context_manager_with_do_not_restore_registers` to include the new CANopen PDO mapping registers, ensuring the tests reflect the expanded exclusion list. [[1]](diffhunk://#diff-fb948e1dc7176fd6124e91e2de2cb5c7d92d834ed85ac4bcc4e3ef18df57b5a7R117-R119) [[2]](diffhunk://#diff-fb948e1dc7176fd6124e91e2de2cb5c7d92d834ed85ac4bcc4e3ef18df57b5a7R145-R146)
* Verified that the logs are about a manageable 600 lines, even with debug level set to INFO