### PR TITLE
Add release-to-develop stabilization sync workflow

### DIFF
--- a/.github/workflows/release-develop-sync.yml
+++ b/.github/workflows/release-develop-sync.yml
@@ -1,0 +1,31 @@
+name: Release → develop sync
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sync-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update sync PR into develop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          EXISTING=$(gh pr list --base develop --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already open for $BRANCH -> develop, nothing to do."
+            exit 0
+          fi
+          gh pr create --base develop --head "$BRANCH" \
+            --title "Sync $BRANCH into develop" \
+            --body "Automated sync of in-progress release stabilization fixes from \`$BRANCH\` into \`develop\`.
+
+          This PR is opened on every push to the release branch while it is still active, so stabilization fixes reach \`develop\` without waiting for the release to finish. It does not replace the merge-back into \`develop\` performed by \`git flow release finish\`; merge (do not squash, to preserve commit identity) whenever convenient during stabilization."

--- a/.github/workflows/release-develop-sync.yml
+++ b/.github/workflows/release-develop-sync.yml
@@ -1,5 +1,7 @@
 name: Release → develop sync
 
+# Opens a PR to develop on every push to a release branch, so stabilization
+# fixes land before `git flow release finish` merges back at the end.
 on:
   push:
     branches:
@@ -7,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: write # needed for gh pr create/list
 
 jobs:
   sync-pr:
@@ -18,14 +20,31 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
+          # Strip "refs/heads/" to get the plain branch name gh expects.
           BRANCH="${GITHUB_REF#refs/heads/}"
+
+          # Skip if a sync PR is already open, to avoid one per push.
           EXISTING=$(gh pr list --base develop --head "$BRANCH" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
             echo "PR #$EXISTING already open for $BRANCH -> develop, nothing to do."
             exit 0
           fi
-          gh pr create --base develop --head "$BRANCH" \
-            --title "Sync $BRANCH into develop" \
-            --body "Automated sync of in-progress release stabilization fixes from \`$BRANCH\` into \`develop\`.
 
-          This PR is opened on every push to the release branch while it is still active, so stabilization fixes reach \`develop\` without waiting for the release to finish. It does not replace the merge-back into \`develop\` performed by \`git flow release finish\`; merge (do not squash, to preserve commit identity) whenever convenient during stabilization."
+          # Body goes in a file so it's normal wrapped text, not one long line.
+          cat > pr_body.md <<EOF
+          Automated sync of in-progress release stabilization fixes from
+          \`$BRANCH\` into \`develop\`.
+
+          This PR is opened on every push to the release branch while it is
+          still active, so stabilization fixes reach \`develop\` without
+          waiting for the release to finish. It does not replace the
+          merge-back into \`develop\` performed by \`git flow release finish\`;
+          merge (do not squash, to preserve commit identity) whenever
+          convenient during stabilization.
+          EOF
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "Sync $BRANCH into develop" \
+            --body-file pr_body.md

--- a/.github/workflows/release-develop-sync.yml
+++ b/.github/workflows/release-develop-sync.yml
@@ -54,14 +54,9 @@ jobs:
 
           # Body goes in a file so it's normal wrapped text, not one long line.
           cat > pr_body.md <<EOF
-          Automated sync of in-progress release stabilization fixes from
-          \`$BRANCH\` into \`develop\`, via mirror branch \`$MIRROR\`.
+          Automated sync of in-progress release stabilization fixes from \`$BRANCH\` into \`develop\`, via mirror branch \`$MIRROR\`.
 
-          Push conflict fixes directly to \`$MIRROR\` if needed; it keeps
-          receiving new commits from \`$BRANCH\` without losing that work.
-          This does not replace the merge-back into \`develop\` performed by
-          \`git flow release finish\`; merge (do not squash) whenever
-          convenient during stabilization.
+          Push conflict fixes directly to \`$MIRROR\` if needed; it keeps receiving new commits from \`$BRANCH\` without losing that work. This does not replace the merge-back into \`develop\` performed by \`git flow release finish\`; merge (do not squash) whenever convenient during stabilization.
           EOF
 
           gh pr create \

--- a/.github/workflows/release-develop-sync.yml
+++ b/.github/workflows/release-develop-sync.yml
@@ -1,30 +1,52 @@
 name: Release → develop sync
 
 # Opens a PR to develop on every push to a release branch, so stabilization
-# fixes land before `git flow release finish` merges back at the end.
+# fixes land before `git flow release finish` merges back at the end. The PR
+# head is a "sync/<branch>" mirror, not the release branch itself, so:
+#  - deleting release/* later never orphans this PR
+#  - conflict fixes can be pushed straight to the mirror branch
 on:
   push:
     branches:
       - 'release/**'
 
 permissions:
-  contents: read
+  contents: write      # needed to update the mirror branch
   pull-requests: write # needed for gh pr create/list
 
 jobs:
   sync-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Open or update sync PR into develop
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync mirror branch and open PR into develop
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          # Strip "refs/heads/" to get the plain branch name gh expects.
           BRANCH="${GITHUB_REF#refs/heads/}"
+          MIRROR="sync/${BRANCH}"
+          RELEASE_SHA=$(git rev-parse HEAD)
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Merge (not overwrite) into the mirror, so manual conflict fixes
+          # already pushed there survive the next release-branch push.
+          if git ls-remote --exit-code --heads origin "$MIRROR" >/dev/null 2>&1; then
+            git fetch origin "$MIRROR:$MIRROR"
+            git checkout "$MIRROR"
+            git merge --no-edit "$RELEASE_SHA"
+          else
+            git checkout -b "$MIRROR" "$RELEASE_SHA"
+          fi
+          git push origin "$MIRROR"
 
           # Skip if a sync PR is already open, to avoid one per push.
-          EXISTING=$(gh pr list --base develop --head "$BRANCH" --state open --json number --jq '.[0].number')
+          EXISTING=$(gh pr list --base develop --head "$MIRROR" --state open --json number --jq '.[0].number')
           if [ -n "$EXISTING" ]; then
             echo "PR #$EXISTING already open for $BRANCH -> develop, nothing to do."
             exit 0
@@ -33,18 +55,17 @@ jobs:
           # Body goes in a file so it's normal wrapped text, not one long line.
           cat > pr_body.md <<EOF
           Automated sync of in-progress release stabilization fixes from
-          \`$BRANCH\` into \`develop\`.
+          \`$BRANCH\` into \`develop\`, via mirror branch \`$MIRROR\`.
 
-          This PR is opened on every push to the release branch while it is
-          still active, so stabilization fixes reach \`develop\` without
-          waiting for the release to finish. It does not replace the
-          merge-back into \`develop\` performed by \`git flow release finish\`;
-          merge (do not squash, to preserve commit identity) whenever
+          Push conflict fixes directly to \`$MIRROR\` if needed; it keeps
+          receiving new commits from \`$BRANCH\` without losing that work.
+          This does not replace the merge-back into \`develop\` performed by
+          \`git flow release finish\`; merge (do not squash) whenever
           convenient during stabilization.
           EOF
 
           gh pr create \
             --base develop \
-            --head "$BRANCH" \
+            --head "$MIRROR" \
             --title "Sync $BRANCH into develop" \
             --body-file pr_body.md

--- a/.github/workflows/release-develop-sync.yml
+++ b/.github/workflows/release-develop-sync.yml
@@ -52,15 +52,10 @@ jobs:
             exit 0
           fi
 
-          # Body goes in a file so it's normal wrapped text, not one long line.
-          cat > pr_body.md <<EOF
-          Automated sync of in-progress release stabilization fixes from \`$BRANCH\` into \`develop\`, via mirror branch \`$MIRROR\`.
-
-          Push conflict fixes directly to \`$MIRROR\` if needed; it keeps receiving new commits from \`$BRANCH\` without losing that work. This does not replace the merge-back into \`develop\` performed by \`git flow release finish\`; merge (do not squash) whenever convenient during stabilization.
-          EOF
-
           gh pr create \
             --base develop \
             --head "$MIRROR" \
             --title "Sync $BRANCH into develop" \
-            --body-file pr_body.md
+            --body "Automated sync of in-progress release stabilization fixes from \`$BRANCH\` into \`develop\`, via mirror branch \`$MIRROR\`.
+
+          Push conflict fixes directly to \`$MIRROR\` if needed; it keeps receiving new commits from \`$BRANCH\` without losing that work. This does not replace the merge-back into \`develop\` performed by \`git flow release finish\`; merge (do not squash) whenever convenient during stabilization."


### PR DESCRIPTION
We got confused with @julieta-prieto about some changes that were on the release branch and not in develop. I have manually merged it but since we expect to not close the release soon and continue working with develop I'm evaluating using a bot for syncing release candidates to develop automatically to avoid confusion and manual work.

It is a a GitHub Actions workflow that opens (and keeps updated) a PR into `develop` whenever this release branch is pushed to, so stabilization fixes reach `develop` without waiting for the release to finish.

The PR head is a `sync/<branch>` mirror branch rather than the release branch itself so conflict fixes can be pushed directly to the mirror branch, and it keeps merging in new release-branch commits without losing that work. It also guarantees that the relase branch is not automatically deleted after sync merges (it's a configuration practical for most branches)

Does not replace the merge-back into `develop` performed by `git flow release finish` — this just keeps develop current during stabilization.

Tested end-to-end on a disposable `release/0.0.0-test` branch (closed/deleted after testing): #846 (mirror-branch version — confirmed a second push reused the same PR and merged into the mirror instead of duplicating).