### PR TITLE
Fix parameter selection for cron

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,8 @@ TestGroup WIN_DOCKER_TESTS = testManager.createGroup("WIN_DOCKER_TEST_SESSIONS",
  */
 def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true'
 def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
-def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
+//def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
+def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=RUN_POLICY_NIGHTLY:selected"
 
 def pipelineParams = PyTestParams.pytestParams(this, currentBuild, [
     branchName: env.BRANCH_NAME,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ TestGroup WIN_DOCKER_TESTS = testManager.createGroup("WIN_DOCKER_TEST_SESSIONS",
 def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true'
 def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
 //def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
-def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY:selected"
+def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=Tag this build as nightly:selected"
 
 def pipelineParams = PyTestParams.pytestParams(this, currentBuild, [
     branchName: env.BRANCH_NAME,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ TestGroup WIN_DOCKER_TESTS = testManager.createGroup("WIN_DOCKER_TEST_SESSIONS",
 def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true'
 def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
 //def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
-def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=RUN_POLICY_NIGHTLY:selected"
+def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY:selected"
 
 def pipelineParams = PyTestParams.pytestParams(this, currentBuild, [
     branchName: env.BRANCH_NAME,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,10 +75,9 @@ TestGroup WIN_DOCKER_TESTS = testManager.createGroup("WIN_DOCKER_TEST_SESSIONS",
  *   → Sets RUN_POLICY_NIGHTLY=true and RUN_POLICY_WEEKEND=true so that tests gated on
  *     either 'nightly' or 'weekends' policy will run.
  */
-def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true'
-def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=true;RUN_POLICY_WEEKEND=true'
-//def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
-def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=Tag this build as nightly:selected"
+def NIGHTLY_CRON   = '0 19,23 * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=Tag this build as nightly:selected'
+def WEEKEND_CRON   = '0 8,14 * * 6-7 % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=Tag this build as nightly:selected;RUN_POLICY_WEEKEND=Tag this build as weekend:selected'
+def CRON_SETTINGS  = BRANCH_NAME == "develop" ? "${NIGHTLY_CRON}\n${WEEKEND_CRON}" : ""
 
 def pipelineParams = PyTestParams.pytestParams(this, currentBuild, [
     branchName: env.BRANCH_NAME,


### PR DESCRIPTION
[Doc]
After the introducing of reactive checkboxes, boolean parameters were not being passed to cron jobs and all nightly/weekend jobs did not execute HW tests for a few days.
The new library we're using does not accept "True" as a selection of the checkbox:
https://github.com/biouno/uno-choice-plugin/blob/d52405db6658ede2110ef22b6b4c663da853dcbe/src/test/java/org/biouno/unochoice/util/TestUtils.java#L45

<img width="581" height="348" alt="image" src="https://github.com/user-attachments/assets/9d479f6c-0297-45f9-8528-def23750f523" />
The label + ":selected" must be used

[Test]
Tested with https://github.com/ingeniamc/ingenialink-python/commit/861973ee9fba0da5718c9680a609d4d91d8fd662
`def CRON_SETTINGS  = "0 * * * * % PYTHON_VERSIONS=All;RUN_POLICY_NIGHTLY=RUN_POLICY_NIGHTLY:selected"`

the optionss were correctly set:
<img width="724" height="1582" alt="image" src="https://github.com/user-attachments/assets/48b44a31-f98a-4a95-a361-dec3ebe04c96" />

It's a bit weird how it looks, but that is another issue