### PR TITLE
CIT-731 Reduce build time of pipeline by moving stages to linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -265,24 +265,6 @@ pipeline {
                                         }
                                     }
                                 }
-                                stage('Make a static type analysis') {
-                                    steps {
-                                        script {
-                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
-                                                venv.run("poetry run poe type")
-                                            }
-                                        }
-                                    }
-                                }
-                                stage('Check formatting') {
-                                    steps {
-                                        script {
-                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
-                                                venv.run("poetry run poe format")
-                                            }
-                                        }
-                                    }
-                                }
                                 stage('Archive artifacts') {
                                     steps {
                                         archiveArtifacts(artifacts: "dist\\*", followSymlinks: false)
@@ -290,25 +272,6 @@ pipeline {
                                             stash_name = "publish_wheels-windows"
                                             wheel_stashes.add(stash_name)
                                             stash includes: "dist\\*", name: stash_name
-                                        }
-                                    }
-                                }
-                                stage('Generate documentation') {
-                                    steps {
-                                        script {
-                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
-                                                venv.run("poetry run poe install-wheel")
-                                                venv.run("poetry run poe docs")
-                                            }
-                                        }
-                                    }
-                                    post {
-                                        success {
-                                            script {
-                                                venvManager.runInWorkingFolder('"C:\\Program Files\\7-Zip\\7z.exe" a -r docs.zip -w _docs -mem=AES256')
-                                                venvManager.copyFromWorkingFolder("docs.zip")
-                                            }
-                                            stash includes: 'docs.zip', name: 'docs'
                                         }
                                     }
                                 }
@@ -393,6 +356,42 @@ pipeline {
                                             stash_name = "publish_wheels-linux"
                                             wheel_stashes.add(stash_name)
                                             stash includes: "dist/*", name: stash_name
+                                        }
+                                    }
+                                }
+                                stage('Make a static type analysis') {
+                                    steps {
+                                        script {
+                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
+                                                venv.run("poetry run poe type")
+                                            }
+                                        }
+                                    }
+                                }
+                                stage('Check formatting') {
+                                    steps {
+                                        script {
+                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
+                                                venv.run("poetry run poe format")
+                                            }
+                                        }
+                                    }
+                                }
+                                stage('Generate documentation') {
+                                    steps {
+                                        script {
+                                            venvManager.withPython(DEFAULT_PYTHON_VERSION) { venv ->
+                                                venv.run("poetry run poe install-wheel")
+                                                venv.run("poetry run poe docs")
+                                            }
+                                            venvManager.copyFromWorkingFolder("_docs/")
+                                            sh 'zip -r docs.zip _docs'
+                                        }
+                                        archiveArtifacts artifacts: 'docs.zip'
+                                    }
+                                    post {
+                                        success {
+                                            stash includes: 'docs.zip', name: 'docs'
                                         }
                                     }
                                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -385,13 +385,12 @@ pipeline {
                                                 venv.run("poetry run poe docs")
                                             }
                                             venvManager.copyFromWorkingFolder("_docs/")
-                                            sh 'zip -r docs.zip _docs'
                                         }
-                                        archiveArtifacts artifacts: 'docs.zip'
                                     }
                                     post {
                                         success {
-                                            stash includes: 'docs.zip', name: 'docs'
+                                            archiveArtifacts artifacts: '_docs/**'
+                                            stash includes: '_docs/**', name: 'docs'
                                         }
                                     }
                                 }
@@ -459,7 +458,6 @@ pipeline {
                     }
                     steps {
                         unstash 'docs'
-                        unzip zipFile: 'docs.zip', dir: '.'
                         publishDistExt('_docs', DISTEXT_PROJECT_DIR, true)
                     }
                 }


### PR DESCRIPTION
Moves several stages from windows to linux, to improve availability and speed. Additionally the docs are not zipped any longer and are archieved and stashed directly. As an awesome consequence the docs can be displayed directly on jenkins without needing to donwload them: http://jenkins.ingenia/job/Novanta%20Motion%20-%20Ingenia%20-%20Git/job/ingenialink-python/view/change-requests/job/PR-854/2/artifact/_docs/index.html

**Pipeline stage reorganization and improvements:**

* Moved the `Make a static type analysis`, `Check formatting`, and `Generate documentation` stages further down in the pipeline, on linux node[[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L268-L285) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L296-L314) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R362-R396)

**Artifact handling changes:**

* Updated the `Generate documentation` stage to archive and stash the `_docs/` folder directly instead of zipping it, simplifying artifact management and removing the need for manual zipping and unzipping. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L296-L314) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R362-R396) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L463)