### PR TITLE
Fix typing of network servos

### DIFF
--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -179,6 +179,9 @@ class CustomListener(can.Listener):
         logger.error(f"An exception occurred with the IXXAT or KVASER connection. Exception: {exc}")
 
 
+CanopenServoT = TypeVar("CanopenServoT", bound=CanopenServoBase, default=CanopenServoBase)
+
+
 class NetStatusListener(Thread):
     """Network status listener thread to check if the drive is alive.
 
@@ -187,7 +190,7 @@ class NetStatusListener(Thread):
 
     """
 
-    def __init__(self, network: "CanopenNetwork"):
+    def __init__(self, network: "CanopenNetwork") -> None:
         super().__init__()
         self.__network = network
         self.__stop = False
@@ -240,9 +243,6 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-CanopenServoT = TypeVar("CanopenServoT", bound=CanopenServoBase, default=CanopenServoBase)
-
-
 class CanopenNetworkBase(Generic[CanopenServoT], Network[CanopenServoT]):
     """Base class for CANopen network communications."""
 
@@ -265,7 +265,7 @@ class CanopenNetworkBase(Generic[CanopenServoT], Network[CanopenServoT]):
         return super().get_servo_state(servo_id)
 
 
-class CanopenNetwork(CanopenNetworkBase):
+class CanopenNetwork(CanopenNetworkBase[CanopenServo]):
     """Network of the CANopen communication.
 
     Args:

--- a/ingenialink/canopen/network.py
+++ b/ingenialink/canopen/network.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from enum import Enum
 from threading import Thread
 from time import sleep
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Generic, Optional, Union
 
 import can
 import canopen
@@ -17,13 +17,20 @@ import ingenialogger
 from can import CanError
 from can.interfaces.kvaser.canlib import __get_canlib_function as get_canlib_function
 from can.interfaces.pcan.pcan import PcanCanOperationError
-from typing_extensions import override
+from typing_extensions import Any, TypeVar, override
 
 from ingenialink.canopen.register import CanopenRegister
-from ingenialink.canopen.servo import CanopenServo
+from ingenialink.canopen.servo import CanopenServo, CanopenServoBase
 from ingenialink.enums.register import RegAccess, RegCyclicType, RegDtype
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NetDevEvt, NetProt, NetState, Network, ServoTarget, SlaveInfo
+from ingenialink.network import (
+    NetDevEvt,
+    NetProt,
+    NetState,
+    Network,
+    ServoTarget,
+    SlaveInfo,
+)
 from ingenialink.servo import Servo
 from ingenialink.utils._utils import DisableLogger, convert_bytes_to_dtype
 from ingenialink.utils.mcb import MCB
@@ -233,7 +240,10 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-class CanopenNetworkBase(Network):
+CanopenServoT = TypeVar("CanopenServoT", bound=CanopenServoBase, default=CanopenServoBase)
+
+
+class CanopenNetworkBase(Generic[CanopenServoT], Network[CanopenServoT]):
     """Base class for CANopen network communications."""
 
     def get_servo_state(self, servo_id: ServoTarget) -> NetState:

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -8,10 +8,10 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from functools import lru_cache
 from threading import Thread
-from typing import TYPE_CHECKING, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Callable, Generic, Optional, Union, cast
 
 import ingenialogger
-from typing_extensions import override
+from typing_extensions import TypeVar, override
 
 from ingenialink.pdo_network_manager import PDONetworkManager
 from ingenialink.servo import Servo
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 from dataclasses import dataclass, field
 
 from ingenialink.constants import ECAT_STATE_CHANGE_TIMEOUT_US
-from ingenialink.ethercat.servo import EthercatServo
+from ingenialink.ethercat.servo import EthercatServo, EthercatServoBase
 from ingenialink.ethercat.state import SlaveState
 from ingenialink.exceptions import (
     ILError,
@@ -194,7 +194,10 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-class EthercatNetworkBase(Network):
+EthercatServoT = TypeVar("EthercatServoT", bound=EthercatServoBase, default=EthercatServoBase)
+
+
+class EthercatNetworkBase(Generic[EthercatServoT], Network[EthercatServoT]):
     """Base class for EtherCAT network communications."""
 
     def get_servo_state(self, servo_id: ServoTarget) -> NetState:

--- a/ingenialink/ethercat/network.py
+++ b/ingenialink/ethercat/network.py
@@ -108,6 +108,9 @@ class GilReleaseConfig:
         return instance
 
 
+EthercatServoT = TypeVar("EthercatServoT", bound=EthercatServoBase, default=EthercatServoBase)
+
+
 class NetStatusListener(Thread):
     """Network status listener thread to check if the drive is alive.
 
@@ -121,7 +124,7 @@ class NetStatusListener(Thread):
 
     """
 
-    def __init__(self, network: "EthercatNetwork", refresh_time: float = 0.25):
+    def __init__(self, network: "EthercatNetwork", refresh_time: float = 0.25) -> None:
         super().__init__()
         self.__network = network
         self.__refresh_time = refresh_time
@@ -150,6 +153,10 @@ class NetStatusListener(Thread):
 
         # Phase 1: per-slave disconnection detection
         for servo in self.__network.servos:
+            if not isinstance(servo, EthercatServo):
+                # Virtual servos do not have slave id
+                # https://novantamotion.atlassian.net/browse/INGK-1286
+                continue
             slave_id = servo.slave_id
             servo_state = self.__network.get_servo_state(slave_id)
             is_servo_alive = servo.slave_exists and (servo.slave.state != pysoem.NONE_STATE)
@@ -158,7 +165,8 @@ class NetStatusListener(Thread):
 
         # Phase 2: skip recovery if every slave is already connected
         if not any(
-            self.__network.get_servo_state(servo.slave_id) == NetState.DISCONNECTED
+            isinstance(servo, EthercatServo)  # INGK-1286
+            and self.__network.get_servo_state(servo.slave_id) == NetState.DISCONNECTED
             for servo in self.__network.servos
         ):
             return
@@ -169,6 +177,9 @@ class NetStatusListener(Thread):
 
         # Phase 4: emit ADDED only for slaves that are actually alive after recovery
         for servo in self.__network.servos:
+            if not isinstance(servo, EthercatServo):
+                # INGK-1286
+                continue
             slave_id = servo.slave_id
             servo_state = self.__network.get_servo_state(slave_id)
             is_servo_alive = servo.slave_exists and (servo.slave.state != pysoem.NONE_STATE)
@@ -194,9 +205,6 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-EthercatServoT = TypeVar("EthercatServoT", bound=EthercatServoBase, default=EthercatServoBase)
-
-
 class EthercatNetworkBase(Generic[EthercatServoT], Network[EthercatServoT]):
     """Base class for EtherCAT network communications."""
 
@@ -218,7 +226,7 @@ class EthercatNetworkBase(Generic[EthercatServoT], Network[EthercatServoT]):
         return NetProt.ECAT
 
 
-class EthercatNetwork(EthercatNetworkBase):
+class EthercatNetwork(EthercatNetworkBase[EthercatServo]):
     """Network for all EtherCAT communications.
 
     Args:

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -4,6 +4,7 @@ import ipaddress
 import os
 import socket
 import time
+from abc import abstractmethod
 from collections import OrderedDict
 from ftplib import FTP
 from threading import Thread
@@ -12,7 +13,7 @@ from typing import Callable, Generic, Optional, Union
 
 import ingenialogger
 from multiping import multi_ping
-from typing_extensions import TypeVar, override, reveal_type
+from typing_extensions import TypeVar, override
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.ethernet.resources import BASIC_ETHERNET_V2_XDF
@@ -29,7 +30,6 @@ from ingenialink.servo import Servo
 from ingenialink.utils.udp import UDP
 
 from .servo import EthernetServo, EthernetServoBase
-from ..virtual.ethernet import VirtualEthernetServo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -47,7 +47,10 @@ MAX_NUMBER_OF_SCAN_TRIES = 2
 SCAN_CONNECTION_TIMEOUT = 0.5
 
 
-class NetStatusListener(Thread):
+EthernetServoT = TypeVar("EthernetServoT", bound=EthernetServoBase, default=EthernetServoBase)
+
+
+class NetStatusListener(Thread, Generic[EthernetServoT]):
     """Network status listener thread to check if the drive is alive.
 
     Args:
@@ -55,7 +58,9 @@ class NetStatusListener(Thread):
 
     """
 
-    def __init__(self, network: "EthernetNetworkBase", refresh_time: float = 0.25) -> None:
+    def __init__(
+        self, network: "EthernetNetworkBase[EthernetServoT]", refresh_time: float = 0.25
+    ) -> None:
         super().__init__()
         self.__network = network
         self.__refresh_time = refresh_time
@@ -69,7 +74,8 @@ class NetStatusListener(Thread):
         """
         for servo in self.__network.servos:
             if not isinstance(servo, EthernetServo):
-                # Virtual ethernet servos do not yet implement ip address
+                # Virtual ethernet servos do not yet implement ip address attr
+                # https://novantamotion.atlassian.net/browse/INGK-1286
                 continue
 
             servo_ip = servo.ip_address
@@ -98,9 +104,6 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-EthernetServoT = TypeVar("EthernetServoT", bound=EthernetServoBase, default=EthernetServoBase)
-
-
 class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
     """Network for all Ethernet communications.
 
@@ -116,7 +119,7 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
             self.__subnet = ipaddress.ip_network(subnet, strict=False)
         else:
             self.__subnet = None
-        self.__listener_net_status: Optional[NetStatusListener] = None
+        self.__listener_net_status: Optional[NetStatusListener[EthernetServoT]] = None
 
     @staticmethod
     def load_firmware(
@@ -247,6 +250,21 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
                 detected_slaves.update(ping_responses)
         return list(detected_slaves.keys())
 
+    @abstractmethod
+    def _create_servo(
+        self,
+        *,
+        target: str,
+        dictionary: str,
+        port: int,
+        connection_timeout: float,
+        servo_status_listener: bool,
+        is_eoe: bool,
+        disconnect_callback: Optional[Callable[[Servo], None]],
+    ) -> EthernetServoT:
+        """Create a servo for this Ethernet network implementation."""
+        raise NotImplementedError
+
     def scan_slaves(self) -> list[str]:  # type: ignore [override]
         """Scan drives connected to the network.
 
@@ -276,7 +294,7 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
         net_status_listener: bool = False,
         is_eoe: bool = False,
         disconnect_callback: Optional[Callable[[Servo], None]] = None,
-    ) -> EthernetServo:
+    ) -> EthernetServoT:
         """Connects to a slave through the given network settings.
 
         Args:
@@ -298,13 +316,13 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
         Returns:
             EthernetServo: Instance of the servo connected.
         """
-        servo = EthernetServo(
-            target,
-            dictionary,
-            port,
-            connection_timeout,
-            servo_status_listener,
-            is_eoe,
+        servo = self._create_servo(
+            target=target,
+            dictionary=dictionary,
+            port=port,
+            connection_timeout=connection_timeout,
+            servo_status_listener=servo_status_listener,
+            is_eoe=is_eoe,
             disconnect_callback=disconnect_callback,
         )
         try:
@@ -321,16 +339,19 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
             self.stop_status_listener()
         return servo
 
-    def disconnect_from_slave(self, servo: EthernetServo) -> None:  # type: ignore [override]
+    def disconnect_from_slave(self, servo: EthernetServoT) -> None:  # type: ignore [override]
         """Disconnects the slave from the network.
 
         Args:
             servo: Instance of the servo connected.
 
+        Raises:
+            ValueError: If the provided servo is not an Ethernet servo.
+
         """
         servo.stop_status_listener()
         self.close_socket(servo.socket)
-        self._set_servo_state(servo.ip_address, NetState.DISCONNECTED)
+        self._set_servo_state(servo, NetState.DISCONNECTED)
         self.servos.remove(servo)
         if len(self.servos) == 0:
             self.stop_status_listener()
@@ -346,7 +367,7 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
     def start_status_listener(self) -> None:
         """Start monitoring network events (CONNECTION/DISCONNECTION)."""
         if self.__listener_net_status is None:
-            listener = NetStatusListener(self)
+            listener = NetStatusListener[EthernetServoT](self)
             listener.start()
             self.__listener_net_status = listener
 
@@ -441,5 +462,26 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
         return NetProt.ETH
 
 
-class EthernetNetwork(EthernetNetworkBase):
+class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
     """Network for all Ethernet communications."""
+
+    def _create_servo(
+        self,
+        *,
+        target: str,
+        dictionary: str,
+        port: int,
+        connection_timeout: float,
+        servo_status_listener: bool,
+        is_eoe: bool,
+        disconnect_callback: Optional[Callable[[Servo], None]],
+    ) -> EthernetServo:
+        return EthernetServo(
+            target,
+            dictionary,
+            port,
+            connection_timeout,
+            servo_status_listener,
+            is_eoe,
+            disconnect_callback=disconnect_callback,
+        )

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -8,20 +8,28 @@ from collections import OrderedDict
 from ftplib import FTP
 from threading import Thread
 from time import sleep
-from typing import Callable, Optional, Union
+from typing import Callable, Generic, Optional, Union
 
 import ingenialogger
 from multiping import multi_ping
-from typing_extensions import override
+from typing_extensions import TypeVar, override, reveal_type
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.ethernet.resources import BASIC_ETHERNET_V2_XDF
 from ingenialink.exceptions import ILError, ILFirmwareLoadError
-from ingenialink.network import NetDevEvt, NetProt, NetState, Network, ServoTarget, SlaveInfo
+from ingenialink.network import (
+    NetDevEvt,
+    NetProt,
+    NetState,
+    Network,
+    ServoTarget,
+    SlaveInfo,
+)
 from ingenialink.servo import Servo
 from ingenialink.utils.udp import UDP
 
-from .servo import EthernetServo
+from .servo import EthernetServo, EthernetServoBase
+from ..virtual.ethernet import VirtualEthernetServo
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -60,6 +68,10 @@ class NetStatusListener(Thread):
         subscribers of any state changes (connection/disconnection).
         """
         for servo in self.__network.servos:
+            if not isinstance(servo, EthernetServo):
+                # Virtual ethernet servos do not yet implement ip address
+                continue
+
             servo_ip = servo.ip_address
             servo_state = self.__network.get_servo_state(servo_ip)
             is_servo_alive = servo.is_alive(attemps=MAX_NUM_UNSUCCESSFUL_PINGS)
@@ -86,7 +98,10 @@ class NetStatusListener(Thread):
         self.__stop = True
 
 
-class EthernetNetworkBase(Network):
+EthernetServoT = TypeVar("EthernetServoT", bound=EthernetServoBase, default=EthernetServoBase)
+
+
+class EthernetNetworkBase(Generic[EthernetServoT], Network[EthernetServoT]):
     """Network for all Ethernet communications.
 
     Args:

--- a/ingenialink/ethernet/servo.py
+++ b/ingenialink/ethernet/servo.py
@@ -32,26 +32,6 @@ logger = ingenialogger.get_logger(__name__)
 class EthernetServoBase(Servo, ABC):
     """Declaration of the base Ethernet servo behavior."""
 
-
-class EthernetServo(EthernetServoBase):
-    """Servo object for all the Ethernet slave functionalities.
-
-    Args:
-        socket: Socket.
-        dictionary_path: Path to the dictionary.
-        servo_status_listener: Toggle the listener of the servo for
-            its status, errors, faults, etc.
-        is_eoe: True if communication is EoE. ``False`` by default.
-
-    """
-
-    MAX_WRITE_SIZE = ETH_MAX_WRITE_SIZE
-
-    COMMS_ETH_IP = "COMMS_ETH_IP"
-    COMMS_ETH_NET_MASK = "COMMS_ETH_NET_MASK"
-    COMMS_ETH_NET_GATEWAY = "COMMS_ETH_GW"
-    COMMS_ETH_MAC = "COMMS_ETH_MAC"
-
     interface = Interface.ETH
 
     def __init__(
@@ -77,6 +57,26 @@ class EthernetServo(EthernetServoBase):
             servo_status_listener,
             disconnect_callback=disconnect_callback,
         )
+
+
+class EthernetServo(EthernetServoBase):
+    """Servo object for all the Ethernet slave functionalities.
+
+    Args:
+        socket: Socket.
+        dictionary_path: Path to the dictionary.
+        servo_status_listener: Toggle the listener of the servo for
+            its status, errors, faults, etc.
+        is_eoe: True if communication is EoE. ``False`` by default.
+
+    """
+
+    MAX_WRITE_SIZE = ETH_MAX_WRITE_SIZE
+
+    COMMS_ETH_IP = "COMMS_ETH_IP"
+    COMMS_ETH_NET_MASK = "COMMS_ETH_NET_MASK"
+    COMMS_ETH_NET_GATEWAY = "COMMS_ETH_GW"
+    COMMS_ETH_MAC = "COMMS_ETH_MAC"
 
     def store_tcp_ip_parameters(self) -> None:
         """Stores the TCP/IP values.

--- a/ingenialink/network.py
+++ b/ingenialink/network.py
@@ -2,9 +2,10 @@ import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Any, Callable, Optional, Union
+from typing import Callable, Generic, Optional, Union
 
 import ingenialogger
+from typing_extensions import Any, TypeVar
 
 from ingenialink.enums.network import NetDevEvt, NetProt, NetState
 from ingenialink.servo import Servo
@@ -27,11 +28,14 @@ ServoTarget = Union[int, str, Servo]
 the :class:`Servo` instance itself."""
 
 
-class Network(ABC):
+ServoT = TypeVar("ServoT", bound=Servo, default=Servo)
+
+
+class Network(ABC, Generic[ServoT]):
     """Declaration of a general Network object."""
 
     def __init__(self) -> None:
-        self.servos: list[Any] = []
+        self.servos: list[ServoT] = []
         """List of the connected servos in the network."""
 
         self._servo_registry: dict[Union[int, str], Servo] = {}

--- a/ingenialink/virtual/canopen/network.py
+++ b/ingenialink/virtual/canopen/network.py
@@ -61,7 +61,7 @@ class VirtualCanopenNetStatusListener(Thread):
         self.__stop = True
 
 
-class VirtualCanopenNetwork(CanopenNetworkBase):
+class VirtualCanopenNetwork(CanopenNetworkBase[VirtualCanopenServo]):
     """Network for all virtual CANopen drive communications."""
 
     def __init__(self) -> None:
@@ -81,9 +81,7 @@ class VirtualCanopenNetwork(CanopenNetworkBase):
             List of discovered target node IDs.
 
         """
-        if self.servos:
-            return [servo.target for servo in self.servos]
-        return []
+        return [servo.target for servo in self.servos if isinstance(servo.target, int)]
 
     def scan_slaves_info(self) -> OrderedDict[int, SlaveInfo]:
         """Scan for virtual CANopen drives and retrieve basic info.

--- a/ingenialink/virtual/ethercat/network.py
+++ b/ingenialink/virtual/ethercat/network.py
@@ -61,7 +61,7 @@ class VirtualNetStatusListener(Thread):
         self.__stop = True
 
 
-class VirtualEthercatNetwork(EthercatNetworkBase):
+class VirtualEthercatNetwork(EthercatNetworkBase[VirtualEthercatServo]):
     """Network for all virtual EtherCAT drive communications."""
 
     def __init__(self) -> None:

--- a/ingenialink/virtual/ethernet/network.py
+++ b/ingenialink/virtual/ethernet/network.py
@@ -9,12 +9,33 @@ from ingenialink.virtual.base_network import VirtualNetworkBase
 from ingenialink.virtual.ethernet.servo import VirtualEthernetServo
 
 
-class VirtualEthernetNetwork(EthernetNetworkBase):
+class VirtualEthernetNetwork(EthernetNetworkBase[VirtualEthernetServo]):
     """Network for all virtual Ethernet drive communications."""
 
     def __init__(self) -> None:
         super().__init__()
         self._virtual_base = VirtualNetworkBase()
+
+    def _create_servo(
+        self,
+        *,
+        target: str,
+        dictionary: str,
+        port: int,
+        connection_timeout: float,
+        servo_status_listener: bool,
+        is_eoe: bool,
+        disconnect_callback: Optional[Callable[[Servo], None]],
+    ) -> VirtualEthernetServo:
+        return VirtualEthernetServo(
+            target,
+            dictionary,
+            port,
+            connection_timeout,
+            servo_status_listener,
+            is_eoe,
+            disconnect_callback=disconnect_callback,
+        )
 
     def connect_to_slave(  # type: ignore [override]
         self,


### PR DESCRIPTION
This pull request introduces a type-safe, generic design for network and servo classes across CANopen, EtherCAT, and Ethernet modules as a followup to this comment https://github.com/ingeniamc/ingenialink-python/pull/843#discussion_r3612568326. The main change is the introduction of generic type variables (`TypeVar`) and the use of Python generics to allow network classes to work with different servo subclasses, improving type safety and extensibility. Additionally, there are refactorings to support virtual servos and abstract servo creation.

### Type System Improvements

* Introduced `TypeVar` type variables (e.g., `ServoT`, `CanopenServoT`, `EthercatServoT`, `EthernetServoT`) and made `Network`, `CanopenNetworkBase`, `EthercatNetworkBase`, and `EthernetNetworkBase` generic classes, allowing them to operate with specific servo subclasses in a type-safe manner. [[1]](diffhunk://#diff-1c1e70e3c48d45082bf7a92af77462bdef9964ae1b2b18d8497fe193e498e3cfL5-R8) [[2]](diffhunk://#diff-1c1e70e3c48d45082bf7a92af77462bdef9964ae1b2b18d8497fe193e498e3cfL30-R38) [[3]](diffhunk://#diff-0102da6ec2346715de6f5cc2a7282c8ce27df7b6e5a7272f1018d92e39ec8896R182-R184) [[4]](diffhunk://#diff-32c203261291b32f8d1e8e6673460fe1df4af20a6747d60ddf5ec1eff0b06f97R111-R113) [[5]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL42-R63)
* Updated method signatures and class attributes to use these generic types, ensuring that servo lists and operations are type-checked. [[1]](diffhunk://#diff-1c1e70e3c48d45082bf7a92af77462bdef9964ae1b2b18d8497fe193e498e3cfL30-R38) [[2]](diffhunk://#diff-0102da6ec2346715de6f5cc2a7282c8ce27df7b6e5a7272f1018d92e39ec8896L236-R246) [[3]](diffhunk://#diff-32c203261291b32f8d1e8e6673460fe1df4af20a6747d60ddf5ec1eff0b06f97L197-R208) [[4]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL89-R107)

### Servo Creation and Extensibility

* Added an abstract `_create_servo` method to `EthernetNetworkBase` to allow subclasses to control how servo instances are created, and implemented it in `EthernetNetwork`. [[1]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fR253-R267) [[2]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL429-R487)
* Refactored `connect_to_slave` and `disconnect_from_slave` methods to use the generic servo type and the abstract creation method. [[1]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL264-R297) [[2]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL286-R325) [[3]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fL309-R354)

### Virtual Servo Support

* Updated network status listener logic in EtherCAT and Ethernet modules to skip non-hardware (virtual) servos, preventing errors when attributes like `slave_id` or `ip_address` are missing. This supports future extensibility for virtual devices tracked by INGK-1286. [[1]](diffhunk://#diff-32c203261291b32f8d1e8e6673460fe1df4af20a6747d60ddf5ec1eff0b06f97R156-R159) [[2]](diffhunk://#diff-32c203261291b32f8d1e8e6673460fe1df4af20a6747d60ddf5ec1eff0b06f97L161-R169) [[3]](diffhunk://#diff-32c203261291b32f8d1e8e6673460fe1df4af20a6747d60ddf5ec1eff0b06f97R180-R182) [[4]](diffhunk://#diff-0d1b484079813b5da21eed3f031bb595dc50a1282e58da0127005072bb45c30fR76-R80)