### PR TITLE
INGK-1281 Bootloader TFTP protocol support

### DIFF
--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -6,7 +6,7 @@ import sys
 import time
 from pathlib import Path
 from types import TracebackType
-from typing import Optional, Union
+from typing import NamedTuple, Optional, Union
 
 import ingenialogger
 
@@ -37,7 +37,14 @@ TFTP_RETRIES = 3
 IPV6_NEXT_HEADER_UDP = 17
 UDP_HEADER_SIZE = 8
 
-IPv6SocketAddress = tuple[str, int, int, int]
+
+class IPv6SocketAddress(NamedTuple):
+    """IPv6 socket address matching Python's ``AF_INET6`` address tuple."""
+
+    address: str
+    port: int
+    flowinfo: int
+    scopeid: int
 
 
 class TftpUploader:
@@ -86,7 +93,7 @@ class TftpUploader:
             raise ILFirmwareLoadError("The TFTP server only accepts .lfu files.")
 
         interface_index = _get_interface_index(self._interface)
-        server_address = (self._drive_address, TFTP_PORT, 0, interface_index)
+        server_address = IPv6SocketAddress(self._drive_address, TFTP_PORT, 0, interface_index)
         logger.info(f"Uploading firmware to [{self._drive_address}%{interface_index}]:{TFTP_PORT}.")
 
         try:
@@ -127,14 +134,20 @@ class TftpUploader:
         """
         write_request = self._create_write_request(filename)
         self._tftp_socket.sendto(write_request, server_address)
-        host, _, flowinfo, scopeid = server_address
-        transfer_address = (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
+        transfer_address = IPv6SocketAddress(
+            server_address.address,
+            TFTP_TRANSFER_PORT,
+            server_address.flowinfo,
+            server_address.scopeid,
+        )
         if capture is not None:
             local_port = self._tftp_socket.getsockname()[1]
             deadline = time.monotonic() + TFTP_TIMEOUT_S
             while time.monotonic() < deadline:
                 packet = capture.read_packet()
-                if packet is not None and self._is_tftp_acknowledgement(packet, host, local_port):
+                if packet is not None and self._is_tftp_acknowledgement(
+                    packet, server_address.address, local_port
+                ):
                     return transfer_address
             raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
 

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -79,11 +79,13 @@ class TftpUploader:
             ) as tftp_socket:
                 tftp_socket.settimeout(TFTP_TIMEOUT_S)
                 if sys.platform == "win32":
+                    # Windows receives the WRQ acknowledgement through packet capture.
                     with PcapCapture(self._interface) as capture:
                         transfer_address = self._send_write_request(
                             tftp_socket, server_address, path.name, capture
                         )
                 else:
+                    # Other platforms receive the WRQ acknowledgement from the UDP socket.
                     transfer_address = self._send_write_request(
                         tftp_socket, server_address, path.name
                     )
@@ -100,13 +102,23 @@ class TftpUploader:
         filename: str,
         capture: Optional[PcapCapture] = None,
     ) -> IPv6SocketAddress:
-        """Send a WRQ and return the fixed server transfer address.
+        """Send a WRQ and wait for ACK 0 before returning the transfer address.
+
+        On Windows, ``capture`` is provided and is used to receive ACK 0. On
+        other platforms, ACK 0 is received directly from ``tftp_socket``.
+
+        Args:
+            tftp_socket: UDP socket used to send the WRQ and, outside Windows,
+                receive ACK 0.
+            server_address: IPv6 address of the server's TFTP endpoint.
+            filename: Name of the firmware file to upload.
+            capture: Windows packet capture used to receive ACK 0.
 
         Returns:
             IPv6 address of the server transfer endpoint.
 
         Raises:
-            ILFirmwareLoadError: If the captured TFTP ACK 0 is not received.
+            ILFirmwareLoadError: If TFTP ACK 0 is not received.
         """
         write_request = TftpUploader._create_write_request(filename)
         tftp_socket.sendto(write_request, server_address)
@@ -208,7 +220,11 @@ class TftpUploader:
 
     @staticmethod
     def _is_tftp_acknowledgement(packet: bytes, drive_address: str, local_port: int) -> bool:
-        """Return whether an Ethernet frame contains ACK 0 from the TFTP transfer port."""
+        """Return whether a Windows-captured Ethernet frame contains TFTP ACK 0.
+
+        The packet-capture path uses this helper to validate an IPv6 UDP frame
+        from the drive's TFTP transfer port to the local UDP socket.
+        """
         ipv6_offset = _get_ipv6_offset(packet)
         if ipv6_offset is None or len(packet) < ipv6_offset + IPV6_HEADER_SIZE:
             return False

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -13,6 +13,7 @@ from ingenialink.utils.ipv6_discovery import _get_interface_index
 logger = ingenialogger.get_logger(__name__)
 
 TFTP_PORT = 69
+TFTP_TRANSFER_PORT = 20_069
 TFTP_BLOCK_SIZE = 512
 TFTP_MAX_PACKET_SIZE = 65_535
 TFTP_WRQ = 2
@@ -64,10 +65,9 @@ class TftpUploader:
             with socket.socket(
                 socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP
             ) as tftp_socket:
-                tftp_socket.settimeout(TFTP_TIMEOUT_S)
                 transfer_address = self._send_write_request(tftp_socket, server_address, path.name)
-                tftp_socket.connect(transfer_address)
-                self._upload_blocks(tftp_socket, path)
+                tftp_socket.settimeout(TFTP_TIMEOUT_S)
+                self._upload_blocks(tftp_socket, transfer_address, path)
         except OSError as exc:
             raise ILFirmwareLoadError("Unable to upload firmware through IPv6 TFTP.") from exc
 
@@ -79,42 +79,41 @@ class TftpUploader:
         server_address: IPv6SocketAddress,
         filename: str,
     ) -> IPv6SocketAddress:
-        """Send a WRQ and return the server transfer address after ACK 0.
+        """Send a WRQ and return the fixed server transfer address.
 
         Returns:
             IPv6 address of the server transfer endpoint.
 
-        Raises:
-            ILFirmwareLoadError: If the server rejects or does not acknowledge the request.
         """
         write_request = TftpUploader._create_write_request(filename)
-        for _ in range(TFTP_RETRIES + 1):
-            tftp_socket.sendto(write_request, server_address)
-            try:
-                while True:
-                    response, source_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
-                    TftpUploader._raise_if_tftp_error(response)
-                    if TftpUploader._get_acknowledged_block(response) == 0:
-                        return TftpUploader._parse_ipv6_socket_address(source_address)
-            except socket.timeout:
-                logger.warning("Timeout waiting for TFTP ACK 0; retrying write request.")
-        raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
+        tftp_socket.sendto(write_request, server_address)
+        host, _, flowinfo, scopeid = server_address
+        return (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
 
     @staticmethod
-    def _upload_blocks(tftp_socket: socket.socket, firmware_file: Path) -> None:
+    def _upload_blocks(
+        tftp_socket: socket.socket,
+        transfer_address: IPv6SocketAddress,
+        firmware_file: Path,
+    ) -> None:
         """Send sequential TFTP data blocks until the final block is acknowledged."""
         block_number = 1
         with firmware_file.open("rb") as file:
             while True:
                 data = file.read(TFTP_BLOCK_SIZE)
                 packet = struct.pack("!HH", TFTP_DATA, block_number) + data
-                TftpUploader._send_data_block(tftp_socket, packet, block_number)
+                TftpUploader._send_data_block(tftp_socket, transfer_address, packet, block_number)
                 if len(data) < TFTP_BLOCK_SIZE:
                     return
                 block_number = (block_number + 1) & 0xFFFF
 
     @staticmethod
-    def _send_data_block(tftp_socket: socket.socket, packet: bytes, block_number: int) -> None:
+    def _send_data_block(
+        tftp_socket: socket.socket,
+        transfer_address: IPv6SocketAddress,
+        packet: bytes,
+        block_number: int,
+    ) -> None:
         """Send one DATA packet and wait for its matching ACK.
 
         Raises:
@@ -122,7 +121,7 @@ class TftpUploader:
         """
         previous_block = (block_number - 1) & 0xFFFF
         for _ in range(TFTP_RETRIES + 1):
-            tftp_socket.send(packet)
+            tftp_socket.sendto(packet, transfer_address)
             try:
                 while True:
                     response = tftp_socket.recv(TFTP_MAX_PACKET_SIZE)
@@ -175,24 +174,3 @@ class TftpUploader:
         error_code = int.from_bytes(packet[2:4], "big")
         error_message = packet[4:].rstrip(b"\0").decode(errors="replace")
         raise ILFirmwareLoadError(f"TFTP error {error_code}: {error_message}")
-
-    @staticmethod
-    def _parse_ipv6_socket_address(address: object) -> IPv6SocketAddress:
-        """Validate and return an IPv6 socket address received from the server.
-
-        Returns:
-            Validated IPv6 socket address.
-
-        Raises:
-            ILFirmwareLoadError: If the address is not a valid IPv6 socket address.
-        """
-        if (
-            not isinstance(address, tuple)
-            or len(address) != 4
-            or not isinstance(address[0], str)
-            or not isinstance(address[1], int)
-            or not isinstance(address[2], int)
-            or not isinstance(address[3], int)
-        ):
-            raise ILFirmwareLoadError("The TFTP server returned an invalid transfer address.")
-        return address

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -6,7 +6,7 @@ import sys
 import time
 from pathlib import Path
 from types import TracebackType
-from typing import NamedTuple, Optional, Union
+from typing import Callable, NamedTuple, Optional, Union
 
 import ingenialogger
 
@@ -80,11 +80,17 @@ class TftpUploader:
         """Close the owned socket when leaving the context."""
         self._tftp_socket.close()
 
-    def upload_file(self, firmware_file: Union[str, Path]) -> None:
+    def upload_file(
+        self,
+        firmware_file: Union[str, Path],
+        callback_progress: Optional[Callable[[int], None]] = None,
+    ) -> None:
         """Upload an LFU firmware file through TFTP.
 
         Args:
             firmware_file: Path to the LFU firmware file.
+            callback_progress: Optional callback receiving the acknowledged upload progress
+                as a percentage.
 
         Raises:
             FileNotFoundError: If the firmware file does not exist.
@@ -108,7 +114,7 @@ class TftpUploader:
             else:
                 # Other platforms receive the WRQ acknowledgement from the UDP socket.
                 transfer_address = self._send_write_request(server_address, path.name)
-            self._upload_blocks(transfer_address, path)
+            self._upload_blocks(transfer_address, path, callback_progress)
         except OSError as exc:
             raise ILFirmwareLoadError("Unable to upload firmware through IPv6 TFTP.") from exc
 
@@ -170,15 +176,30 @@ class TftpUploader:
         self,
         transfer_address: IPv6SocketAddress,
         firmware_file: Path,
+        callback_progress: Optional[Callable[[int], None]],
     ) -> None:
-        """Send sequential TFTP data blocks until the final block is acknowledged."""
+        """Send sequential TFTP data blocks until the final block is acknowledged.
+
+        Progress is reported only after a DATA block has been acknowledged.
+        """
         block_number = 1
+        transferred_bytes = 0
+        reported_progress = 0
+        total_bytes = firmware_file.stat().st_size
         with firmware_file.open("rb") as file:
             while True:
                 data = file.read(TFTP_BLOCK_SIZE)
                 packet = struct.pack("!HH", TFTP_DATA, block_number) + data
                 self._send_data_block(transfer_address, packet, block_number)
-                if len(data) < TFTP_BLOCK_SIZE:
+                transferred_bytes += len(data)
+                final_block = len(data) < TFTP_BLOCK_SIZE
+                progress = (
+                    100 if final_block else min(99, int(transferred_bytes * 100 / total_bytes))
+                )
+                if callback_progress is not None and progress != reported_progress:
+                    callback_progress(progress)
+                    reported_progress = progress
+                if final_block:
                     return
                 block_number = (block_number + 1) & 0xFFFF
 

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -2,13 +2,23 @@
 
 import socket
 import struct
+import sys
+import time
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 import ingenialogger
 
 from ingenialink.exceptions import ILFirmwareLoadError
-from ingenialink.utils.ipv6_discovery import _get_interface_index
+from ingenialink.utils.ipv6_discovery import (
+    IPV6_HEADER_SIZE,
+    IPV6_NEXT_HEADER_OFFSET,
+    IPV6_SOURCE_ADDRESS_OFFSET,
+    _get_interface_index,
+    _get_ipv6_extension_header,
+    _get_ipv6_offset,
+)
+from ingenialink.utils.ipv6_pcap_capture import PcapCapture
 
 logger = ingenialogger.get_logger(__name__)
 
@@ -23,6 +33,8 @@ TFTP_ERROR = 5
 TFTP_MODE = b"octet"
 TFTP_TIMEOUT_S = 5.0
 TFTP_RETRIES = 3
+IPV6_NEXT_HEADER_UDP = 17
+UDP_HEADER_SIZE = 8
 
 IPv6SocketAddress = tuple[str, int, int, int]
 
@@ -65,7 +77,15 @@ class TftpUploader:
             with socket.socket(
                 socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP
             ) as tftp_socket:
-                transfer_address = self._send_write_request(tftp_socket, server_address, path.name)
+                if sys.platform == "win32":
+                    with PcapCapture(self._interface) as capture:
+                        transfer_address = self._send_write_request(
+                            tftp_socket, server_address, path.name, capture
+                        )
+                else:
+                    transfer_address = self._send_write_request(
+                        tftp_socket, server_address, path.name
+                    )
                 tftp_socket.settimeout(TFTP_TIMEOUT_S)
                 self._upload_blocks(tftp_socket, transfer_address, path)
         except OSError as exc:
@@ -78,17 +98,32 @@ class TftpUploader:
         tftp_socket: socket.socket,
         server_address: IPv6SocketAddress,
         filename: str,
+        capture: Optional[PcapCapture] = None,
     ) -> IPv6SocketAddress:
         """Send a WRQ and return the fixed server transfer address.
 
         Returns:
             IPv6 address of the server transfer endpoint.
 
+        Raises:
+            ILFirmwareLoadError: If the captured TFTP ACK 0 is not received.
         """
         write_request = TftpUploader._create_write_request(filename)
         tftp_socket.sendto(write_request, server_address)
         host, _, flowinfo, scopeid = server_address
-        return (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
+        transfer_address = (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
+        if capture is None:
+            return transfer_address
+
+        local_port = tftp_socket.getsockname()[1]
+        deadline = time.monotonic() + TFTP_TIMEOUT_S
+        while time.monotonic() < deadline:
+            packet = capture.read_packet()
+            if packet is not None and TftpUploader._is_tftp_acknowledgement(
+                packet, host, local_port
+            ):
+                return transfer_address
+        raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
 
     @staticmethod
     def _upload_blocks(
@@ -159,6 +194,35 @@ class TftpUploader:
         if len(packet) < 4 or int.from_bytes(packet[:2], "big") != TFTP_ACK:
             return None
         return int.from_bytes(packet[2:4], "big")
+
+    @staticmethod
+    def _is_tftp_acknowledgement(packet: bytes, drive_address: str, local_port: int) -> bool:
+        """Return whether an Ethernet frame contains ACK 0 from the TFTP transfer port."""
+        ipv6_offset = _get_ipv6_offset(packet)
+        if ipv6_offset is None or len(packet) < ipv6_offset + IPV6_HEADER_SIZE:
+            return False
+        if packet[ipv6_offset] >> 4 != 6:
+            return False
+        next_header = packet[ipv6_offset + IPV6_NEXT_HEADER_OFFSET]
+        udp_offset = ipv6_offset + IPV6_HEADER_SIZE
+        while next_header != IPV6_NEXT_HEADER_UDP:
+            extension_header = _get_ipv6_extension_header(packet, udp_offset, next_header)
+            if extension_header is None:
+                return False
+            next_header, udp_offset = extension_header
+        if len(packet) < udp_offset + UDP_HEADER_SIZE:
+            return False
+        source_address = packet[
+            ipv6_offset + IPV6_SOURCE_ADDRESS_OFFSET : ipv6_offset + IPV6_SOURCE_ADDRESS_OFFSET + 16
+        ]
+        source_port = int.from_bytes(packet[udp_offset : udp_offset + 2], "big")
+        destination_port = int.from_bytes(packet[udp_offset + 2 : udp_offset + 4], "big")
+        return (
+            source_address == socket.inet_pton(socket.AF_INET6, drive_address)
+            and source_port == TFTP_TRANSFER_PORT
+            and destination_port == local_port
+            and TftpUploader._get_acknowledged_block(packet[udp_offset + UDP_HEADER_SIZE :]) == 0
+        )
 
     @staticmethod
     def _raise_if_tftp_error(packet: bytes) -> None:

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -5,6 +5,7 @@ import struct
 import sys
 import time
 from pathlib import Path
+from types import TracebackType
 from typing import Optional, Union
 
 import ingenialogger
@@ -52,6 +53,21 @@ class TftpUploader:
     def __init__(self, drive_address: str, interface: str) -> None:
         self._drive_address = drive_address
         self._interface = interface
+        self._tftp_socket = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        self._tftp_socket.settimeout(TFTP_TIMEOUT_S)
+
+    def __enter__(self) -> "TftpUploader":
+        """Return the uploader while keeping its socket open."""
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        """Close the owned socket when leaving the context."""
+        self._tftp_socket.close()
 
     def upload_file(self, firmware_file: Union[str, Path]) -> None:
         """Upload an LFU firmware file through TFTP.
@@ -74,30 +90,21 @@ class TftpUploader:
         logger.info(f"Uploading firmware to [{self._drive_address}%{interface_index}]:{TFTP_PORT}.")
 
         try:
-            with socket.socket(
-                socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP
-            ) as tftp_socket:
-                tftp_socket.settimeout(TFTP_TIMEOUT_S)
-                if sys.platform == "win32":
-                    # Windows receives the WRQ acknowledgement through packet capture.
-                    with PcapCapture(self._interface) as capture:
-                        transfer_address = self._send_write_request(
-                            tftp_socket, server_address, path.name, capture
-                        )
-                else:
-                    # Other platforms receive the WRQ acknowledgement from the UDP socket.
-                    transfer_address = self._send_write_request(
-                        tftp_socket, server_address, path.name
-                    )
-                self._upload_blocks(tftp_socket, transfer_address, path)
+            if sys.platform == "win32":
+                # Windows receives the WRQ acknowledgement through packet capture.
+                with PcapCapture(self._interface) as capture:
+                    transfer_address = self._send_write_request(server_address, path.name, capture)
+            else:
+                # Other platforms receive the WRQ acknowledgement from the UDP socket.
+                transfer_address = self._send_write_request(server_address, path.name)
+            self._upload_blocks(transfer_address, path)
         except OSError as exc:
             raise ILFirmwareLoadError("Unable to upload firmware through IPv6 TFTP.") from exc
 
         logger.info("IPv6 TFTP firmware upload completed successfully.")
 
-    @staticmethod
     def _send_write_request(
-        tftp_socket: socket.socket,
+        self,
         server_address: IPv6SocketAddress,
         filename: str,
         capture: Optional[PcapCapture] = None,
@@ -105,11 +112,9 @@ class TftpUploader:
         """Send a WRQ and wait for ACK 0 before returning the transfer address.
 
         On Windows, ``capture`` is provided and is used to receive ACK 0. On
-        other platforms, ACK 0 is received directly from ``tftp_socket``.
+        other platforms, ACK 0 is received directly from the owned UDP socket.
 
         Args:
-            tftp_socket: UDP socket used to send the WRQ and, outside Windows,
-                receive ACK 0.
             server_address: IPv6 address of the server's TFTP endpoint.
             filename: Name of the firmware file to upload.
             capture: Windows packet capture used to receive ACK 0.
@@ -120,35 +125,32 @@ class TftpUploader:
         Raises:
             ILFirmwareLoadError: If TFTP ACK 0 is not received.
         """
-        write_request = TftpUploader._create_write_request(filename)
-        tftp_socket.sendto(write_request, server_address)
+        write_request = self._create_write_request(filename)
+        self._tftp_socket.sendto(write_request, server_address)
         host, _, flowinfo, scopeid = server_address
         transfer_address = (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
         if capture is not None:
-            local_port = tftp_socket.getsockname()[1]
+            local_port = self._tftp_socket.getsockname()[1]
             deadline = time.monotonic() + TFTP_TIMEOUT_S
             while time.monotonic() < deadline:
                 packet = capture.read_packet()
-                if packet is not None and TftpUploader._is_tftp_acknowledgement(
-                    packet, host, local_port
-                ):
+                if packet is not None and self._is_tftp_acknowledgement(packet, host, local_port):
                     return transfer_address
             raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
 
         try:
             while True:
-                response, sender_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
+                response, sender_address = self._tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
                 if sender_address != transfer_address:
                     continue
-                TftpUploader._raise_if_tftp_error(response)
-                if TftpUploader._get_acknowledged_block(response) == 0:
+                self._raise_if_tftp_error(response)
+                if self._get_acknowledged_block(response) == 0:
                     return transfer_address
         except socket.timeout as exc:
             raise ILFirmwareLoadError("No TFTP ACK received for block 0.") from exc
 
-    @staticmethod
     def _upload_blocks(
-        tftp_socket: socket.socket,
+        self,
         transfer_address: IPv6SocketAddress,
         firmware_file: Path,
     ) -> None:
@@ -158,14 +160,13 @@ class TftpUploader:
             while True:
                 data = file.read(TFTP_BLOCK_SIZE)
                 packet = struct.pack("!HH", TFTP_DATA, block_number) + data
-                TftpUploader._send_data_block(tftp_socket, transfer_address, packet, block_number)
+                self._send_data_block(transfer_address, packet, block_number)
                 if len(data) < TFTP_BLOCK_SIZE:
                     return
                 block_number = (block_number + 1) & 0xFFFF
 
-    @staticmethod
     def _send_data_block(
-        tftp_socket: socket.socket,
+        self,
         transfer_address: IPv6SocketAddress,
         packet: bytes,
         block_number: int,
@@ -177,14 +178,14 @@ class TftpUploader:
         """
         previous_block = (block_number - 1) & 0xFFFF
         for _ in range(TFTP_RETRIES + 1):
-            tftp_socket.sendto(packet, transfer_address)
+            self._tftp_socket.sendto(packet, transfer_address)
             try:
                 while True:
-                    response, sender_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
+                    response, sender_address = self._tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
                     if sender_address != transfer_address:
                         continue
-                    TftpUploader._raise_if_tftp_error(response)
-                    acknowledged_block = TftpUploader._get_acknowledged_block(response)
+                    self._raise_if_tftp_error(response)
+                    acknowledged_block = self._get_acknowledged_block(response)
                     if acknowledged_block == block_number:
                         return
                     if acknowledged_block == previous_block:
@@ -193,8 +194,7 @@ class TftpUploader:
                 logger.warning(f"Timeout waiting for TFTP ACK {block_number}; retrying data block.")
         raise ILFirmwareLoadError(f"No TFTP ACK received for block {block_number}.")
 
-    @staticmethod
-    def _create_write_request(filename: str) -> bytes:
+    def _create_write_request(self, filename: str) -> bytes:
         """Create an octet-mode TFTP WRQ packet.
 
         Returns:
@@ -211,15 +211,13 @@ class TftpUploader:
             ) from exc
         return struct.pack("!H", TFTP_WRQ) + encoded_filename + b"\0" + TFTP_MODE + b"\0"
 
-    @staticmethod
-    def _get_acknowledged_block(packet: bytes) -> Union[int, None]:
+    def _get_acknowledged_block(self, packet: bytes) -> Union[int, None]:
         """Return the acknowledged block when a packet is a valid ACK."""
         if len(packet) < 4 or int.from_bytes(packet[:2], "big") != TFTP_ACK:
             return None
         return int.from_bytes(packet[2:4], "big")
 
-    @staticmethod
-    def _is_tftp_acknowledgement(packet: bytes, drive_address: str, local_port: int) -> bool:
+    def _is_tftp_acknowledgement(self, packet: bytes, drive_address: str, local_port: int) -> bool:
         """Return whether a Windows-captured Ethernet frame contains TFTP ACK 0.
 
         The packet-capture path uses this helper to validate an IPv6 UDP frame
@@ -248,11 +246,10 @@ class TftpUploader:
             source_address == socket.inet_pton(socket.AF_INET6, drive_address)
             and source_port == TFTP_TRANSFER_PORT
             and destination_port == local_port
-            and TftpUploader._get_acknowledged_block(packet[udp_offset + UDP_HEADER_SIZE :]) == 0
+            and self._get_acknowledged_block(packet[udp_offset + UDP_HEADER_SIZE :]) == 0
         )
 
-    @staticmethod
-    def _raise_if_tftp_error(packet: bytes) -> None:
+    def _raise_if_tftp_error(self, packet: bytes) -> None:
         """Raise an IngeniaLink error when the server returns TFTP ERROR.
 
         Raises:

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -1,0 +1,198 @@
+"""Upload LFU firmware files through TFTP over IPv6."""
+
+import socket
+import struct
+from pathlib import Path
+from typing import Union
+
+import ingenialogger
+
+from ingenialink.exceptions import ILFirmwareLoadError
+from ingenialink.utils.ipv6_discovery import _get_interface_index
+
+logger = ingenialogger.get_logger(__name__)
+
+TFTP_PORT = 69
+TFTP_BLOCK_SIZE = 512
+TFTP_MAX_PACKET_SIZE = 65_535
+TFTP_WRQ = 2
+TFTP_DATA = 3
+TFTP_ACK = 4
+TFTP_ERROR = 5
+TFTP_MODE = b"octet"
+TFTP_TIMEOUT_S = 5.0
+TFTP_RETRIES = 3
+
+IPv6SocketAddress = tuple[str, int, int, int]
+
+
+class TftpUploader:
+    """Upload firmware files to an IPv6 drive through TFTP.
+
+    Args:
+        drive_address: IPv6 address of the drive. Link-local addresses are
+            scoped with ``interface``.
+        interface: Network interface in the same format as
+            :func:`ingenialink.utils.ipv6_discovery.discover_ipv6_devices`.
+    """
+
+    def __init__(self, drive_address: str, interface: str) -> None:
+        self._drive_address = drive_address
+        self._interface = interface
+
+    def upload_file(self, firmware_file: Union[str, Path]) -> None:
+        """Upload an LFU firmware file through TFTP.
+
+        Args:
+            firmware_file: Path to the LFU firmware file.
+
+        Raises:
+            FileNotFoundError: If the firmware file does not exist.
+            ILFirmwareLoadError: If the file is invalid or the TFTP transfer fails.
+        """
+        path = Path(firmware_file)
+        if not path.is_file():
+            raise FileNotFoundError(f"Could not find {path}.")
+        if path.suffix.lower() != ".lfu":
+            raise ILFirmwareLoadError("The TFTP server only accepts .lfu files.")
+
+        interface_index = _get_interface_index(self._interface)
+        server_address = (self._drive_address, TFTP_PORT, 0, interface_index)
+        logger.info(f"Uploading firmware to [{self._drive_address}%{interface_index}]:{TFTP_PORT}.")
+
+        try:
+            with socket.socket(
+                socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP
+            ) as tftp_socket:
+                tftp_socket.settimeout(TFTP_TIMEOUT_S)
+                transfer_address = self._send_write_request(tftp_socket, server_address, path.name)
+                tftp_socket.connect(transfer_address)
+                self._upload_blocks(tftp_socket, path)
+        except OSError as exc:
+            raise ILFirmwareLoadError("Unable to upload firmware through IPv6 TFTP.") from exc
+
+        logger.info("IPv6 TFTP firmware upload completed successfully.")
+
+    @staticmethod
+    def _send_write_request(
+        tftp_socket: socket.socket,
+        server_address: IPv6SocketAddress,
+        filename: str,
+    ) -> IPv6SocketAddress:
+        """Send a WRQ and return the server transfer address after ACK 0.
+
+        Returns:
+            IPv6 address of the server transfer endpoint.
+
+        Raises:
+            ILFirmwareLoadError: If the server rejects or does not acknowledge the request.
+        """
+        write_request = TftpUploader._create_write_request(filename)
+        for _ in range(TFTP_RETRIES + 1):
+            tftp_socket.sendto(write_request, server_address)
+            try:
+                while True:
+                    response, source_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
+                    TftpUploader._raise_if_tftp_error(response)
+                    if TftpUploader._get_acknowledged_block(response) == 0:
+                        return TftpUploader._parse_ipv6_socket_address(source_address)
+            except socket.timeout:
+                logger.warning("Timeout waiting for TFTP ACK 0; retrying write request.")
+        raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
+
+    @staticmethod
+    def _upload_blocks(tftp_socket: socket.socket, firmware_file: Path) -> None:
+        """Send sequential TFTP data blocks until the final block is acknowledged."""
+        block_number = 1
+        with firmware_file.open("rb") as file:
+            while True:
+                data = file.read(TFTP_BLOCK_SIZE)
+                packet = struct.pack("!HH", TFTP_DATA, block_number) + data
+                TftpUploader._send_data_block(tftp_socket, packet, block_number)
+                if len(data) < TFTP_BLOCK_SIZE:
+                    return
+                block_number = (block_number + 1) & 0xFFFF
+
+    @staticmethod
+    def _send_data_block(tftp_socket: socket.socket, packet: bytes, block_number: int) -> None:
+        """Send one DATA packet and wait for its matching ACK.
+
+        Raises:
+            ILFirmwareLoadError: If the server rejects or does not acknowledge the data.
+        """
+        previous_block = (block_number - 1) & 0xFFFF
+        for _ in range(TFTP_RETRIES + 1):
+            tftp_socket.send(packet)
+            try:
+                while True:
+                    response = tftp_socket.recv(TFTP_MAX_PACKET_SIZE)
+                    TftpUploader._raise_if_tftp_error(response)
+                    acknowledged_block = TftpUploader._get_acknowledged_block(response)
+                    if acknowledged_block == block_number:
+                        return
+                    if acknowledged_block != previous_block:
+                        continue
+            except socket.timeout:
+                logger.warning(f"Timeout waiting for TFTP ACK {block_number}; retrying data block.")
+        raise ILFirmwareLoadError(f"No TFTP ACK received for block {block_number}.")
+
+    @staticmethod
+    def _create_write_request(filename: str) -> bytes:
+        """Create an octet-mode TFTP WRQ packet.
+
+        Returns:
+            Encoded TFTP write request.
+
+        Raises:
+            ILFirmwareLoadError: If the filename is not ASCII.
+        """
+        try:
+            encoded_filename = filename.encode("ascii")
+        except UnicodeEncodeError as exc:
+            raise ILFirmwareLoadError(
+                "The firmware filename must contain only ASCII characters."
+            ) from exc
+        return struct.pack("!H", TFTP_WRQ) + encoded_filename + b"\0" + TFTP_MODE + b"\0"
+
+    @staticmethod
+    def _get_acknowledged_block(packet: bytes) -> Union[int, None]:
+        """Return the acknowledged block when a packet is a valid ACK."""
+        if len(packet) < 4 or int.from_bytes(packet[:2], "big") != TFTP_ACK:
+            return None
+        return int.from_bytes(packet[2:4], "big")
+
+    @staticmethod
+    def _raise_if_tftp_error(packet: bytes) -> None:
+        """Raise an IngeniaLink error when the server returns TFTP ERROR.
+
+        Raises:
+            ILFirmwareLoadError: If the packet is a TFTP error response.
+        """
+        if len(packet) < 2 or int.from_bytes(packet[:2], "big") != TFTP_ERROR:
+            return
+        if len(packet) < 4:
+            raise ILFirmwareLoadError("The TFTP server returned an invalid error packet.")
+        error_code = int.from_bytes(packet[2:4], "big")
+        error_message = packet[4:].rstrip(b"\0").decode(errors="replace")
+        raise ILFirmwareLoadError(f"TFTP error {error_code}: {error_message}")
+
+    @staticmethod
+    def _parse_ipv6_socket_address(address: object) -> IPv6SocketAddress:
+        """Validate and return an IPv6 socket address received from the server.
+
+        Returns:
+            Validated IPv6 socket address.
+
+        Raises:
+            ILFirmwareLoadError: If the address is not a valid IPv6 socket address.
+        """
+        if (
+            not isinstance(address, tuple)
+            or len(address) != 4
+            or not isinstance(address[0], str)
+            or not isinstance(address[1], int)
+            or not isinstance(address[2], int)
+            or not isinstance(address[3], int)
+        ):
+            raise ILFirmwareLoadError("The TFTP server returned an invalid transfer address.")
+        return address

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -77,6 +77,7 @@ class TftpUploader:
             with socket.socket(
                 socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP
             ) as tftp_socket:
+                tftp_socket.settimeout(TFTP_TIMEOUT_S)
                 if sys.platform == "win32":
                     with PcapCapture(self._interface) as capture:
                         transfer_address = self._send_write_request(
@@ -86,7 +87,6 @@ class TftpUploader:
                     transfer_address = self._send_write_request(
                         tftp_socket, server_address, path.name
                     )
-                tftp_socket.settimeout(TFTP_TIMEOUT_S)
                 self._upload_blocks(tftp_socket, transfer_address, path)
         except OSError as exc:
             raise ILFirmwareLoadError("Unable to upload firmware through IPv6 TFTP.") from exc
@@ -112,18 +112,27 @@ class TftpUploader:
         tftp_socket.sendto(write_request, server_address)
         host, _, flowinfo, scopeid = server_address
         transfer_address = (host, TFTP_TRANSFER_PORT, flowinfo, scopeid)
-        if capture is None:
-            return transfer_address
+        if capture is not None:
+            local_port = tftp_socket.getsockname()[1]
+            deadline = time.monotonic() + TFTP_TIMEOUT_S
+            while time.monotonic() < deadline:
+                packet = capture.read_packet()
+                if packet is not None and TftpUploader._is_tftp_acknowledgement(
+                    packet, host, local_port
+                ):
+                    return transfer_address
+            raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
 
-        local_port = tftp_socket.getsockname()[1]
-        deadline = time.monotonic() + TFTP_TIMEOUT_S
-        while time.monotonic() < deadline:
-            packet = capture.read_packet()
-            if packet is not None and TftpUploader._is_tftp_acknowledgement(
-                packet, host, local_port
-            ):
-                return transfer_address
-        raise ILFirmwareLoadError("No TFTP ACK received for block 0.")
+        try:
+            while True:
+                response, sender_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
+                if sender_address != transfer_address:
+                    continue
+                TftpUploader._raise_if_tftp_error(response)
+                if TftpUploader._get_acknowledged_block(response) == 0:
+                    return transfer_address
+        except socket.timeout as exc:
+            raise ILFirmwareLoadError("No TFTP ACK received for block 0.") from exc
 
     @staticmethod
     def _upload_blocks(
@@ -159,13 +168,15 @@ class TftpUploader:
             tftp_socket.sendto(packet, transfer_address)
             try:
                 while True:
-                    response = tftp_socket.recv(TFTP_MAX_PACKET_SIZE)
+                    response, sender_address = tftp_socket.recvfrom(TFTP_MAX_PACKET_SIZE)
+                    if sender_address != transfer_address:
+                        continue
                     TftpUploader._raise_if_tftp_error(response)
                     acknowledged_block = TftpUploader._get_acknowledged_block(response)
                     if acknowledged_block == block_number:
                         return
-                    if acknowledged_block != previous_block:
-                        continue
+                    if acknowledged_block == previous_block:
+                        break
             except socket.timeout:
                 logger.warning(f"Timeout waiting for TFTP ACK {block_number}; retrying data block.")
         raise ILFirmwareLoadError(f"No TFTP ACK received for block {block_number}.")

--- a/ingenialink/utils/ipv6_tftp.py
+++ b/ingenialink/utils/ipv6_tftp.py
@@ -50,6 +50,10 @@ class IPv6SocketAddress(NamedTuple):
 class TftpUploader:
     """Upload firmware files to an IPv6 drive through TFTP.
 
+    The packet exchange follows `RFC 1350 - The TFTP Protocol (Revision 2)
+    <https://www.rfc-editor.org/rfc/rfc1350>`_. This implementation uses the
+    base WRQ, DATA, ACK, and ERROR messages without TFTP option extensions.
+
     Args:
         drive_address: IPv6 address of the drive. Link-local addresses are
             scoped with ``interface``.

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -24,8 +24,32 @@ def tftp_socket(mocker):
     return socket_mock
 
 
+def _tftp_acknowledgement_frame(source_address: str, destination_port: int) -> bytes:
+    """Build an Ethernet-framed IPv6 UDP TFTP ACK 0.
+
+    Returns:
+        Ethernet frame containing an IPv6 UDP TFTP ACK 0.
+    """
+    tftp_acknowledgement = struct.pack("!HH", TFTP_ACK, 0)
+    udp_header = struct.pack(
+        "!HHHH",
+        20_069,
+        destination_port,
+        8 + len(tftp_acknowledgement),
+        0,
+    )
+    ipv6_header = (
+        bytes.fromhex("60000000")
+        + struct.pack("!HBB", len(udp_header + tftp_acknowledgement), 17, 64)
+        + socket.inet_pton(socket.AF_INET6, source_address)
+        + socket.inet_pton(socket.AF_INET6, "fe80::2")
+    )
+    return bytes(12) + bytes.fromhex("86dd") + ipv6_header + udp_header + tftp_acknowledgement
+
+
 def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_socket, tmp_path):
     """Upload a final data block using the discovery interface index."""
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "linux")
     firmware_file = tmp_path / "firmware.lfu"
     firmware_file.write_bytes(b"firmware")
     interface_index = mocker.patch(
@@ -69,6 +93,7 @@ def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
     mocker, tftp_socket, tmp_path
 ):
     """Retry a data block after its ACK times out without retransmitting the WRQ."""
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "linux")
     firmware_file = tmp_path / "firmware.lfu"
     firmware_file.write_bytes(b"firmware")
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
@@ -87,8 +112,31 @@ def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
     assert tftp_socket.sendto.call_args_list[2].args[1] == ("fe80::1", 20_069, 0, 4)
 
 
+def test_upload_ipv6_firmware_waits_for_captured_write_request_ack(mocker, tftp_socket, tmp_path):
+    """Use the Windows pcap ACK 0 to begin the data transfer."""
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.write_bytes(b"firmware")
+    capture = mocker.MagicMock()
+    capture.__enter__.return_value = capture
+    capture.read_packet.return_value = _tftp_acknowledgement_frame("fe80::1", 53_000)
+    tftp_socket.getsockname.return_value = ("fe80::2", 53_000, 0, 7)
+    tftp_socket.recv.return_value = struct.pack("!HH", TFTP_ACK, 1)
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "win32")
+    mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=7)
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
+    pcap_capture = mocker.patch("ingenialink.utils.ipv6_tftp.PcapCapture", return_value=capture)
+
+    TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
+
+    pcap_capture.assert_called_once_with(r"\Device\NPF_{GUID}")
+    capture.read_packet.assert_called_once_with()
+    assert tftp_socket.sendto.call_args_list[0].args[1] == ("fe80::1", 69, 0, 7)
+    assert tftp_socket.sendto.call_args_list[1].args[1] == ("fe80::1", 20_069, 0, 7)
+
+
 def test_upload_ipv6_firmware_raises_on_tftp_error(mocker, tftp_socket, tmp_path):
     """Expose server TFTP errors through the standard firmware exception."""
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "linux")
     firmware_file = tmp_path / "firmware.lfu"
     firmware_file.touch()
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -1,0 +1,71 @@
+import socket
+import struct
+
+import pytest
+
+from ingenialink.exceptions import ILFirmwareLoadError
+from ingenialink.utils.ipv6_tftp import (
+    TFTP_ACK,
+    TFTP_DATA,
+    TFTP_WRQ,
+    TftpUploader,
+)
+
+
+@pytest.fixture
+def tftp_socket(mocker):
+    """Provide a UDP socket mock that supports the socket context manager.
+
+    Returns:
+        Mocked UDP socket.
+    """
+    socket_mock = mocker.MagicMock()
+    socket_mock.__enter__.return_value = socket_mock
+    return socket_mock
+
+
+def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_socket, tmp_path):
+    """Upload a final data block using the discovery interface index."""
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.write_bytes(b"firmware")
+    interface_index = mocker.patch(
+        "ingenialink.utils.ipv6_tftp._get_interface_index", return_value=7
+    )
+    socket_factory = mocker.patch(
+        "ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket
+    )
+    tftp_socket.recvfrom.return_value = (struct.pack("!HH", TFTP_ACK, 0), ("fe80::1", 1234, 0, 7))
+    tftp_socket.recv.return_value = struct.pack("!HH", TFTP_ACK, 1)
+
+    TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
+
+    interface_index.assert_called_once_with(r"\Device\NPF_{GUID}")
+    socket_factory.assert_called_once_with(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    write_request, destination = tftp_socket.sendto.call_args.args
+    assert destination == ("fe80::1", 69, 0, 7)
+    assert struct.unpack("!H", write_request[:2])[0] == TFTP_WRQ
+    tftp_socket.connect.assert_called_once_with(("fe80::1", 1234, 0, 7))
+    data_packet = tftp_socket.send.call_args.args[0]
+    assert struct.unpack("!HH", data_packet[:4]) == (TFTP_DATA, 1)
+    assert data_packet[4:] == b"firmware"
+
+
+def test_upload_ipv6_firmware_rejects_non_lfu_file(tmp_path):
+    """Reject files the drive TFTP server cannot accept before using sockets."""
+    firmware_file = tmp_path / "firmware.bin"
+    firmware_file.touch()
+
+    with pytest.raises(ILFirmwareLoadError, match="only accepts .lfu"):
+        TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+
+
+def test_upload_ipv6_firmware_raises_on_tftp_error(mocker, tftp_socket, tmp_path):
+    """Expose server TFTP errors through the standard firmware exception."""
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.touch()
+    mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
+    tftp_socket.recvfrom.return_value = b"\0\x05\0\x01access denied\0", ("fe80::1", 69, 0, 4)
+
+    with pytest.raises(ILFirmwareLoadError, match="TFTP error 1: access denied"):
+        TftpUploader("fe80::1", "eth0").upload_file(firmware_file)

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -58,9 +58,10 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
     socket_factory = mocker.patch(
         "ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket
     )
-    tftp_socket.recv.side_effect = [
-        struct.pack("!HH", TFTP_ACK, 0),
-        struct.pack("!HH", TFTP_ACK, 1),
+    transfer_address = ("fe80::1", 20_069, 0, 7)
+    tftp_socket.recvfrom.side_effect = [
+        (struct.pack("!HH", TFTP_ACK, 0), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
     ]
 
     TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
@@ -72,12 +73,12 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
     assert destination == ("fe80::1", 69, 0, 7)
     assert struct.unpack("!H", write_request[:2])[0] == TFTP_WRQ
     tftp_socket.connect.assert_not_called()
-    data_packet, transfer_address = tftp_socket.sendto.call_args_list[1].args
-    assert transfer_address == ("fe80::1", 20_069, 0, 7)
+    data_packet, data_transfer_address = tftp_socket.sendto.call_args_list[1].args
+    assert data_transfer_address == transfer_address
     assert struct.unpack("!HH", data_packet[:4]) == (TFTP_DATA, 1)
     assert data_packet[4:] == b"firmware"
     assert tftp_socket.sendto.call_count == 2
-    tftp_socket.recvfrom.assert_not_called()
+    assert tftp_socket.recvfrom.call_count == 2
 
 
 def test_upload_ipv6_firmware_rejects_non_lfu_file(tmp_path):
@@ -98,10 +99,11 @@ def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
     firmware_file.write_bytes(b"firmware")
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
     mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
-    tftp_socket.recv.side_effect = [
-        struct.pack("!HH", TFTP_ACK, 0),
+    transfer_address = ("fe80::1", 20_069, 0, 4)
+    tftp_socket.recvfrom.side_effect = [
+        (struct.pack("!HH", TFTP_ACK, 0), transfer_address),
         socket.timeout(),
-        struct.pack("!HH", TFTP_ACK, 1),
+        (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
     ]
 
     TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
@@ -112,6 +114,46 @@ def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
     assert tftp_socket.sendto.call_args_list[2].args[1] == ("fe80::1", 20_069, 0, 4)
 
 
+def test_upload_ipv6_firmware_ignores_responses_from_another_endpoint(
+    mocker, tftp_socket, tmp_path
+):
+    """Only accept TFTP responses from the drive transfer endpoint."""
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "linux")
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.write_bytes(b"firmware")
+    mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
+    transfer_address = ("fe80::1", 20_069, 0, 4)
+    tftp_socket.recvfrom.side_effect = [
+        (struct.pack("!HH", TFTP_ACK, 0), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 1), ("fe80::2", 20_069, 0, 4)),
+        (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
+    ]
+
+    TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+
+    assert tftp_socket.sendto.call_count == 2
+    assert tftp_socket.recvfrom.call_count == 3
+
+
+def test_send_data_block_resends_immediately_after_duplicate_ack(tftp_socket):
+    """Retransmit the current data block when the previous ACK is repeated."""
+    transfer_address = ("fe80::1", 20_069, 0, 4)
+    packet = struct.pack("!HH", TFTP_DATA, 2) + b"firmware"
+    tftp_socket.recvfrom.side_effect = [
+        (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 2), transfer_address),
+    ]
+
+    TftpUploader._send_data_block(tftp_socket, transfer_address, packet, 2)
+
+    assert tftp_socket.sendto.call_count == 2
+    assert [call.args for call in tftp_socket.sendto.call_args_list] == [
+        (packet, transfer_address),
+        (packet, transfer_address),
+    ]
+
+
 def test_upload_ipv6_firmware_waits_for_captured_write_request_ack(mocker, tftp_socket, tmp_path):
     """Use the Windows pcap ACK 0 to begin the data transfer."""
     firmware_file = tmp_path / "firmware.lfu"
@@ -120,7 +162,10 @@ def test_upload_ipv6_firmware_waits_for_captured_write_request_ack(mocker, tftp_
     capture.__enter__.return_value = capture
     capture.read_packet.return_value = _tftp_acknowledgement_frame("fe80::1", 53_000)
     tftp_socket.getsockname.return_value = ("fe80::2", 53_000, 0, 7)
-    tftp_socket.recv.return_value = struct.pack("!HH", TFTP_ACK, 1)
+    tftp_socket.recvfrom.return_value = (
+        struct.pack("!HH", TFTP_ACK, 1),
+        ("fe80::1", 20_069, 0, 7),
+    )
     mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "win32")
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=7)
     mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
@@ -141,7 +186,10 @@ def test_upload_ipv6_firmware_raises_on_tftp_error(mocker, tftp_socket, tmp_path
     firmware_file.touch()
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
     mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
-    tftp_socket.recv.return_value = b"\0\x05\0\x01access denied\0"
+    tftp_socket.recvfrom.return_value = (
+        b"\0\x05\0\x01access denied\0",
+        ("fe80::1", 20_069, 0, 4),
+    )
 
     with pytest.raises(ILFirmwareLoadError, match="TFTP error 1: access denied"):
         TftpUploader("fe80::1", "eth0").upload_file(firmware_file)

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -64,11 +64,13 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
         (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
     ]
 
-    TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
+    with TftpUploader("fe80::1", r"\Device\NPF_{GUID}") as uploader:
+        uploader.upload_file(firmware_file)
 
     interface_index.assert_called_once_with(r"\Device\NPF_{GUID}")
     socket_factory.assert_called_once_with(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
     tftp_socket.settimeout.assert_called_once_with(5.0)
+    tftp_socket.close.assert_called_once_with()
     write_request, destination = tftp_socket.sendto.call_args_list[0].args
     assert destination == ("fe80::1", 69, 0, 7)
     assert struct.unpack("!H", write_request[:2])[0] == TFTP_WRQ
@@ -81,13 +83,17 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
     assert tftp_socket.recvfrom.call_count == 2
 
 
-def test_upload_ipv6_firmware_rejects_non_lfu_file(tmp_path):
-    """Reject files the drive TFTP server cannot accept before using sockets."""
+def test_upload_ipv6_firmware_rejects_non_lfu_file(mocker, tftp_socket, tmp_path):
+    """Reject files the drive TFTP server cannot accept before network communication."""
     firmware_file = tmp_path / "firmware.bin"
     firmware_file.touch()
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
 
-    with pytest.raises(ILFirmwareLoadError, match="only accepts .lfu"):
-        TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+    with (
+        pytest.raises(ILFirmwareLoadError, match="only accepts .lfu"),
+        TftpUploader("fe80::1", "eth0") as uploader,
+    ):
+        uploader.upload_file(firmware_file)
 
 
 def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
@@ -106,7 +112,8 @@ def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
         (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
     ]
 
-    TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+    with TftpUploader("fe80::1", "eth0") as uploader:
+        uploader.upload_file(firmware_file)
 
     assert tftp_socket.sendto.call_count == 3
     assert tftp_socket.sendto.call_args_list[0].args[1] == ("fe80::1", 69, 0, 4)
@@ -130,13 +137,14 @@ def test_upload_ipv6_firmware_ignores_responses_from_another_endpoint(
         (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
     ]
 
-    TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+    with TftpUploader("fe80::1", "eth0") as uploader:
+        uploader.upload_file(firmware_file)
 
     assert tftp_socket.sendto.call_count == 2
     assert tftp_socket.recvfrom.call_count == 3
 
 
-def test_send_data_block_resends_immediately_after_duplicate_ack(tftp_socket):
+def test_send_data_block_resends_immediately_after_duplicate_ack(mocker, tftp_socket):
     """Retransmit the current data block when the previous ACK is repeated."""
     transfer_address = ("fe80::1", 20_069, 0, 4)
     packet = struct.pack("!HH", TFTP_DATA, 2) + b"firmware"
@@ -144,8 +152,10 @@ def test_send_data_block_resends_immediately_after_duplicate_ack(tftp_socket):
         (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
         (struct.pack("!HH", TFTP_ACK, 2), transfer_address),
     ]
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
 
-    TftpUploader._send_data_block(tftp_socket, transfer_address, packet, 2)
+    with TftpUploader("fe80::1", "eth0") as uploader:
+        uploader._send_data_block(transfer_address, packet, 2)
 
     assert tftp_socket.sendto.call_count == 2
     assert [call.args for call in tftp_socket.sendto.call_args_list] == [
@@ -171,7 +181,8 @@ def test_upload_ipv6_firmware_waits_for_captured_write_request_ack(mocker, tftp_
     mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
     pcap_capture = mocker.patch("ingenialink.utils.ipv6_tftp.PcapCapture", return_value=capture)
 
-    TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
+    with TftpUploader("fe80::1", r"\Device\NPF_{GUID}") as uploader:
+        uploader.upload_file(firmware_file)
 
     pcap_capture.assert_called_once_with(r"\Device\NPF_{GUID}")
     capture.read_packet.assert_called_once_with()
@@ -191,5 +202,8 @@ def test_upload_ipv6_firmware_raises_on_tftp_error(mocker, tftp_socket, tmp_path
         ("fe80::1", 20_069, 0, 4),
     )
 
-    with pytest.raises(ILFirmwareLoadError, match="TFTP error 1: access denied"):
-        TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+    with (
+        pytest.raises(ILFirmwareLoadError, match="TFTP error 1: access denied"),
+        TftpUploader("fe80::1", "eth0") as uploader,
+    ):
+        uploader.upload_file(firmware_file)

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -34,20 +34,26 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
     socket_factory = mocker.patch(
         "ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket
     )
-    tftp_socket.recvfrom.return_value = (struct.pack("!HH", TFTP_ACK, 0), ("fe80::1", 1234, 0, 7))
-    tftp_socket.recv.return_value = struct.pack("!HH", TFTP_ACK, 1)
+    tftp_socket.recv.side_effect = [
+        struct.pack("!HH", TFTP_ACK, 0),
+        struct.pack("!HH", TFTP_ACK, 1),
+    ]
 
     TftpUploader("fe80::1", r"\Device\NPF_{GUID}").upload_file(firmware_file)
 
     interface_index.assert_called_once_with(r"\Device\NPF_{GUID}")
     socket_factory.assert_called_once_with(socket.AF_INET6, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
-    write_request, destination = tftp_socket.sendto.call_args.args
+    tftp_socket.settimeout.assert_called_once_with(5.0)
+    write_request, destination = tftp_socket.sendto.call_args_list[0].args
     assert destination == ("fe80::1", 69, 0, 7)
     assert struct.unpack("!H", write_request[:2])[0] == TFTP_WRQ
-    tftp_socket.connect.assert_called_once_with(("fe80::1", 1234, 0, 7))
-    data_packet = tftp_socket.send.call_args.args[0]
+    tftp_socket.connect.assert_not_called()
+    data_packet, transfer_address = tftp_socket.sendto.call_args_list[1].args
+    assert transfer_address == ("fe80::1", 20_069, 0, 7)
     assert struct.unpack("!HH", data_packet[:4]) == (TFTP_DATA, 1)
     assert data_packet[4:] == b"firmware"
+    assert tftp_socket.sendto.call_count == 2
+    tftp_socket.recvfrom.assert_not_called()
 
 
 def test_upload_ipv6_firmware_rejects_non_lfu_file(tmp_path):
@@ -59,13 +65,35 @@ def test_upload_ipv6_firmware_rejects_non_lfu_file(tmp_path):
         TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
 
 
+def test_upload_ipv6_firmware_retries_data_without_repeating_write_request(
+    mocker, tftp_socket, tmp_path
+):
+    """Retry a data block after its ACK times out without retransmitting the WRQ."""
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.write_bytes(b"firmware")
+    mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
+    tftp_socket.recv.side_effect = [
+        struct.pack("!HH", TFTP_ACK, 0),
+        socket.timeout(),
+        struct.pack("!HH", TFTP_ACK, 1),
+    ]
+
+    TftpUploader("fe80::1", "eth0").upload_file(firmware_file)
+
+    assert tftp_socket.sendto.call_count == 3
+    assert tftp_socket.sendto.call_args_list[0].args[1] == ("fe80::1", 69, 0, 4)
+    assert tftp_socket.sendto.call_args_list[1].args[1] == ("fe80::1", 20_069, 0, 4)
+    assert tftp_socket.sendto.call_args_list[2].args[1] == ("fe80::1", 20_069, 0, 4)
+
+
 def test_upload_ipv6_firmware_raises_on_tftp_error(mocker, tftp_socket, tmp_path):
     """Expose server TFTP errors through the standard firmware exception."""
     firmware_file = tmp_path / "firmware.lfu"
     firmware_file.touch()
     mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
     mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
-    tftp_socket.recvfrom.return_value = b"\0\x05\0\x01access denied\0", ("fe80::1", 69, 0, 4)
+    tftp_socket.recv.return_value = b"\0\x05\0\x01access denied\0"
 
     with pytest.raises(ILFirmwareLoadError, match="TFTP error 1: access denied"):
         TftpUploader("fe80::1", "eth0").upload_file(firmware_file)

--- a/tests/test_ipv6_tftp.py
+++ b/tests/test_ipv6_tftp.py
@@ -83,6 +83,32 @@ def test_upload_ipv6_firmware_uses_scoped_address_and_uploads_file(mocker, tftp_
     assert tftp_socket.recvfrom.call_count == 2
 
 
+def test_upload_ipv6_firmware_reports_acknowledged_progress(mocker, tftp_socket, tmp_path):
+    """Report progress after each acknowledged data block."""
+    mocker.patch("ingenialink.utils.ipv6_tftp.sys.platform", "linux")
+    firmware_file = tmp_path / "firmware.lfu"
+    firmware_file.write_bytes(b"firmware" * 128 + b"x")
+    mocker.patch("ingenialink.utils.ipv6_tftp._get_interface_index", return_value=4)
+    mocker.patch("ingenialink.utils.ipv6_tftp.socket.socket", return_value=tftp_socket)
+    transfer_address = ("fe80::1", 20_069, 0, 4)
+    tftp_socket.recvfrom.side_effect = [
+        (struct.pack("!HH", TFTP_ACK, 0), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 1), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 2), transfer_address),
+        (struct.pack("!HH", TFTP_ACK, 3), transfer_address),
+    ]
+    callback_progress = mocker.Mock()
+
+    with TftpUploader("fe80::1", "eth0") as uploader:
+        uploader.upload_file(firmware_file, callback_progress)
+
+    assert [call.args for call in callback_progress.call_args_list] == [
+        (49,),
+        (99,),
+        (100,),
+    ]
+
+
 def test_upload_ipv6_firmware_rejects_non_lfu_file(mocker, tftp_socket, tmp_path):
     """Reject files the drive TFTP server cannot accept before network communication."""
     firmware_file = tmp_path / "firmware.bin"


### PR DESCRIPTION
## Description

Add TFTP firmware upload support for IPv6-connected drives.

- Add `TftpUploader` for uploading `.lfu` firmware files over IPv6.
- Support interface-scoped IPv6 addresses and platform-specific networking requirements.
- Include transfer validation, error handling, and retry behavior.

## Tests

- [x] Added unit tests covering successful uploads, errors, retries, address scoping, and platform-specific behavior.
- [x] Manually validated the TFTP connection, write request, and start of the data transfer with the drive bootloader.

## Documentation

- Added docstrings for the uploader and TFTP helper methods.

> [!NOTE]
> End-to-end application transfer could not yet be validated because a valid application `.lfu` file is not currently available. The TFTP session is established successfully and the transfer starts. The drive then rejects the initial data block with the `Failed to verify product signature` error, as expected because the available `.lfu` file is not valid.