### PR TITLE
CIT-696 Add pull request checkbox check

### DIFF
--- a/.github/workflows/check-pr-checkboxes.yml
+++ b/.github/workflows/check-pr-checkboxes.yml
@@ -1,0 +1,96 @@
+name: Check pull request checkboxes
+
+# Keep this workflow independent of the pull request's code. It reads only
+# GitHub metadata, so it is safe to run for pull requests from forks.
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created, edited, deleted]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  check-checkboxes:
+    if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request description and comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullNumber = context.payload.pull_request?.number ?? context.issue.number;
+            const { owner, repo } = context.repo;
+
+            const pullRequest = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+
+            const sources = [
+              {
+                name: 'PR description',
+                body: pullRequest.data.body ?? '',
+                url: pullRequest.data.html_url,
+              },
+            ];
+
+            const issueComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pullNumber, per_page: 100 },
+            );
+            sources.push(...issueComments.map((comment) => ({
+              name: `Comment by ${comment.user?.login ?? 'unknown user'}`,
+              body: comment.body ?? '',
+              url: comment.html_url,
+            })));
+
+            const reviews = await github.paginate(
+              github.rest.pulls.listReviews,
+              { owner, repo, pull_number: pullNumber, per_page: 100 },
+            );
+            sources.push(...reviews.map((review) => ({
+              name: `Review by ${review.user?.login ?? 'unknown user'}`,
+              body: review.body ?? '',
+              url: review.html_url ?? pullRequest.data.html_url,
+            })));
+
+            const reviewComments = await github.paginate(
+              github.rest.pulls.listReviewComments,
+              { owner, repo, pull_number: pullNumber, per_page: 100 },
+            );
+            sources.push(...reviewComments.map((comment) => ({
+              name: `Review comment by ${comment.user?.login ?? 'unknown user'}`,
+              body: comment.body ?? '',
+              url: comment.html_url,
+            })));
+
+            // GitHub task-list items are normally written as `- [ ] task`.
+            // Match unordered and ordered lists, while ignoring checked items.
+            const uncheckedTask = /^\s*(?:[-*+]|\d+\.)\s+\[\s\].*$/gim;
+            const unchecked = [];
+
+            for (const source of sources) {
+              for (const match of source.body.matchAll(uncheckedTask)) {
+                const line = match[0].trim();
+                unchecked.push(`- ${source.name}: ${line} (${source.url})`);
+              }
+            }
+
+            if (unchecked.length > 0) {
+              core.setFailed([
+                `Found ${unchecked.length} unchecked task-list item${unchecked.length === 1 ? '' : 's'} in PR #${pullNumber}:`,
+                ...unchecked,
+                '',
+                'Check or remove each item before merging.',
+              ].join('\n'));
+            } else {
+              core.info(`All task-list items in PR #${pullNumber} are checked.`);
+            }

--- a/.github/workflows/check-pr-checkboxes.yml
+++ b/.github/workflows/check-pr-checkboxes.yml
@@ -1,96 +1,30 @@
 name: Check pull request checkboxes
 
-# Keep this workflow independent of the pull request's code. It reads only
+# This workflow does not check out the pull request's code. It reads only
 # GitHub metadata, so it is safe to run for pull requests from forks.
+#
+# Runs triggered by issue_comment are associated with the default branch, not
+# the pull request, so the action reports the result as a `pr-checkboxes`
+# commit status on the pull request head commit instead of failing the job.
+# Make `pr-checkboxes` the required check in branch protection, not this job.
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created, edited, deleted]
-  pull_request_review:
-    types: [submitted, edited, dismissed]
-  pull_request_review_comment:
-    types: [created, edited, deleted]
 
 permissions:
   issues: read
   pull-requests: read
+  statuses: write
 
 jobs:
   check-checkboxes:
     if: github.event_name != 'issue_comment' || github.event.issue.pull_request != null
     runs-on: ubuntu-latest
     steps:
-      - name: Check pull request description and comments
-        uses: actions/github-script@v7
+      # add-commit-status-support branch
+      - uses: ingeniamc/require-checklist-action@8ccb7177cf740d1ba759906d5c91f54ee1137598
         with:
-          script: |
-            const pullNumber = context.payload.pull_request?.number ?? context.issue.number;
-            const { owner, repo } = context.repo;
-
-            const pullRequest = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: pullNumber,
-            });
-
-            const sources = [
-              {
-                name: 'PR description',
-                body: pullRequest.data.body ?? '',
-                url: pullRequest.data.html_url,
-              },
-            ];
-
-            const issueComments = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number: pullNumber, per_page: 100 },
-            );
-            sources.push(...issueComments.map((comment) => ({
-              name: `Comment by ${comment.user?.login ?? 'unknown user'}`,
-              body: comment.body ?? '',
-              url: comment.html_url,
-            })));
-
-            const reviews = await github.paginate(
-              github.rest.pulls.listReviews,
-              { owner, repo, pull_number: pullNumber, per_page: 100 },
-            );
-            sources.push(...reviews.map((review) => ({
-              name: `Review by ${review.user?.login ?? 'unknown user'}`,
-              body: review.body ?? '',
-              url: review.html_url ?? pullRequest.data.html_url,
-            })));
-
-            const reviewComments = await github.paginate(
-              github.rest.pulls.listReviewComments,
-              { owner, repo, pull_number: pullNumber, per_page: 100 },
-            );
-            sources.push(...reviewComments.map((comment) => ({
-              name: `Review comment by ${comment.user?.login ?? 'unknown user'}`,
-              body: comment.body ?? '',
-              url: comment.html_url,
-            })));
-
-            // GitHub task-list items are normally written as `- [ ] task`.
-            // Match unordered and ordered lists, while ignoring checked items.
-            const uncheckedTask = /^\s*(?:[-*+]|\d+\.)\s+\[\s\].*$/gim;
-            const unchecked = [];
-
-            for (const source of sources) {
-              for (const match of source.body.matchAll(uncheckedTask)) {
-                const line = match[0].trim();
-                unchecked.push(`- ${source.name}: ${line} (${source.url})`);
-              }
-            }
-
-            if (unchecked.length > 0) {
-              core.setFailed([
-                `Found ${unchecked.length} unchecked task-list item${unchecked.length === 1 ? '' : 's'} in PR #${pullNumber}:`,
-                ...unchecked,
-                '',
-                'Check or remove each item before merging.',
-              ].join('\n'));
-            } else {
-              core.info(`All task-list items in PR #${pullNumber} are checked.`);
-            }
+          commitStatusContext: pr-checkboxes
+          requireChecklist: false


### PR DESCRIPTION
Adds a workflow that blocks merging while any task-list item (`- [ ]`) in the PR description or comments is unchecked, using [ingeniamc/require-checklist-action](https://github.com/ingeniamc/require-checklist-action) (fork of [mheap/require-checklist-action](https://github.com/mheap/require-checklist-action), change under review in [ingeniamc/require-checklist-action#1](https://github.com/ingeniamc/require-checklist-action/pull/1)).

The result is reported as a `pr-checkboxes` commit status on the PR head commit rather than through the job outcome. This keeps the status current when a checkbox is ticked in a *comment*: those runs are triggered by `issue_comment`, whose automatic job check attaches to the default branch instead of the PR. The workflow reads only GitHub metadata (no code checkout), so it is safe for `pull_request_target`, and the action is pinned to a commit SHA.

Validated end to end on a fork ([polfeliu/ingenialink-python#2](https://github.com/polfeliu/ingenialink-python/pull/2)): description and comment checkboxes both flip the status immediately.

Notes for after merge:
- Branch protection should require the `pr-checkboxes` status, not the `check-checkboxes` job (the job always succeeds by design).
- `pull_request_target` and `issue_comment` read the workflow from `master`, so it only activates once merged — it cannot run on this PR itself, thats why it was tested on a fork.

Test checklist (will be enforced on PRs after merge):

- [x] Checked item
- [ ] Unchecked item — after merge, ticking this on any open PR flips its `pr-checkboxes` status