### PR TITLE
INGK-1280 Raw SDCP serialization testing with bootloader

### DIFF
--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -1,4 +1,4 @@
-"""Serialization utilities for Servo Drives Control Protocol frames."""
+"""SDCP message encoding and frame deserialization utilities."""
 
 from __future__ import annotations
 
@@ -158,8 +158,6 @@ class _SDCPCodec:
         flags: int,
         transaction_id: int,
         payload: bytes = b"",
-        *,
-        payload_name: str = "payload",
     ) -> bytes:
         """Serialize the common SDCP header and raw operation payload.
 
@@ -172,7 +170,7 @@ class _SDCPCodec:
 
         """
         if not isinstance(payload, bytes):
-            raise TypeError(f"{payload_name} must be bytes")
+            raise TypeError("payload must be bytes")
         header = b"".join((
             _SDCPCodec.serialize_uint(_SDCPFields.OPCODE, opcode),
             _SDCPCodec.serialize_uint(_SDCPFields.FLAGS, flags),
@@ -292,7 +290,6 @@ class SDCPWriteRequest(_SDCPMessage):
             SDCPFlag.NONE,
             self.transaction_id,
             payload,
-            payload_name="value",
         )
 
 
@@ -404,13 +401,17 @@ class SDCPReadResponse(_SDCPMessage):
         Returns:
             The binary SDCP frame.
 
+        Raises:
+            TypeError: If the value payload is not bytes.
+
         """
+        if not isinstance(self.value, bytes):
+            raise TypeError("value must be bytes")
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.READ,
             SDCPFlag.REPLY,
             self.transaction_id,
             self.value,
-            payload_name="value",
         )
 
 
@@ -465,7 +466,7 @@ class SDCPUnsubscribeResponse(_SDCPMessage):
 
 @dataclass(frozen=True, repr=False)
 class SDCPErrorResponse(_SDCPMessage):
-    """Base class for operation-specific SDCP error responses."""
+    """Abstract base class for operation-specific SDCP error responses."""
 
     error_code: int
 

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -102,25 +102,52 @@ class SDCPSerializer:
     TRANSACTION_ID_SIZE = 2
 
     @classmethod
-    def serialize(cls, opcode: int, flags: int, transaction_id: int, payload: bytes = b"") -> bytes:
+    def serialize(
+        cls,
+        opcode: int,
+        flags: int,
+        transaction_id: int,
+        index: int | None = None,
+        subindex: int | None = None,
+        payload: bytes = b"",
+    ) -> bytes:
         """Serialize an SDCP acyclic frame.
 
         Args:
             opcode: Operation identifier in the range 0 to 255.
             flags: Flag bitmask in the range 0 to 255.
             transaction_id: Request identifier in the range 0 to 65535.
-            payload: Raw operation-specific bytes to append after the header.
+            index: Dictionary index for Read, Write, and Subscribe requests.
+            subindex: Dictionary subindex for Read, Write, and Subscribe requests.
+            payload: Bytes following the dictionary address, such as a value to
+                write or subscription parameters.
 
         Returns:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         Raises:
-            ValueError: If a header field does not fit its protocol-defined size.
+            ValueError: If a field does not fit its protocol-defined size or
+                a dictionary request does not include a complete address or a
+                Write request does not include a value payload.
 
         """
         cls._validate_uint("opcode", opcode, cls.OPCODE_SIZE)
         cls._validate_uint("flags", flags, cls.FLAGS_SIZE)
         cls._validate_uint("transaction_id", transaction_id, cls.TRANSACTION_ID_SIZE)
+        if (index is None) != (subindex is None):
+            raise ValueError("index and subindex must be provided together")
+        if cls._is_dictionary_request(opcode, flags) and index is None:
+            raise ValueError("dictionary requests require index and subindex")
+        if opcode == SDCPOpcode.WRITE and flags == SDCPFlag.NONE and not payload:
+            raise ValueError("Write requests require a value payload")
+        if index is not None and subindex is not None:
+            cls._validate_uint("index", index, cls.TRANSACTION_ID_SIZE)
+            cls._validate_uint("subindex", subindex, cls.OPCODE_SIZE)
+            payload = (
+                index.to_bytes(cls.TRANSACTION_ID_SIZE, "big")
+                + subindex.to_bytes(cls.OPCODE_SIZE, "big")
+                + payload
+            )
 
         return b"".join((
             opcode.to_bytes(cls.OPCODE_SIZE, "big"),
@@ -172,11 +199,21 @@ class SDCPSerializer:
             The parsed index and subindex, or ``None`` values when absent.
 
         """
-        dictionary_opcodes = (SDCPOpcode.READ, SDCPOpcode.WRITE, SDCPOpcode.SUBSCRIBE)
-        if opcode not in dictionary_opcodes or flags != SDCPFlag.NONE or len(payload) < 3:
+        if not SDCPSerializer._is_dictionary_request(opcode, flags) or len(payload) < 3:
             return None, None
 
         return int.from_bytes(payload[:2], "big"), payload[2]
+
+    @staticmethod
+    def _is_dictionary_request(opcode: int, flags: int) -> bool:
+        """Determine whether a frame requires a dictionary address.
+
+        Returns:
+            ``True`` for unflagged Read, Write, and Subscribe requests.
+
+        """
+        dictionary_opcodes = (SDCPOpcode.READ, SDCPOpcode.WRITE, SDCPOpcode.SUBSCRIBE)
+        return opcode in dictionary_opcodes and flags == SDCPFlag.NONE
 
     @staticmethod
     def _validate_uint(field_name: str, value: int, size: int) -> None:

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -1,0 +1,191 @@
+"""Serialization utilities for Servo Drives Control Protocol frames."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import IntEnum, IntFlag
+
+
+class SDCPOpcode(IntEnum):
+    """Opcodes defined by the SDCP acyclic communication protocol."""
+
+    IDENTIFY = 0x01
+    READ = 0x02
+    WRITE = 0x03
+    SUBSCRIBE = 0x04
+    UNSUBSCRIBE = 0x05
+
+
+class SDCPFlag(IntFlag):
+    """Flags defined by the SDCP acyclic communication protocol."""
+
+    NONE = 0x00
+    REPLY = 0x01
+    ERROR = 0x02
+
+
+@dataclass(frozen=True)
+class SDCPFrame:
+    """An SDCP acyclic frame split into its header and payload fields.
+
+    Attributes:
+        opcode: Operation identifier.
+        flags: Bitmask that modifies the operation behavior.
+        transaction_id: Request identifier echoed by the response.
+        payload: Operation-specific bytes excluding a parsed dictionary address.
+        index: Dictionary index parsed from a dictionary request, when available.
+        subindex: Dictionary subindex parsed from a dictionary request, when available.
+
+    """
+
+    opcode: int
+    flags: int
+    transaction_id: int
+    payload: bytes
+    index: int | None = None
+    subindex: int | None = None
+
+    def __repr__(self) -> str:
+        """Return a protocol-oriented representation of the SDCP frame."""
+        dictionary_address = ""
+        if self.index is not None and self.subindex is not None:
+            dictionary_address = f", index=0x{self.index:04X}, subindex=0x{self.subindex:02X}"
+
+        return (
+            "SDCPFrame("
+            f"opcode={self._format_opcode()}, flags={self._format_flags()}, "
+            f"transaction_id=0x{self.transaction_id:04X}{dictionary_address}, "
+            f"payload=0x{self.payload.hex().upper()})"
+        )
+
+    def _format_opcode(self) -> str:
+        """Format the opcode as its name when it is defined by SDCP.
+
+        Returns:
+            The opcode name or its hexadecimal value when unknown.
+
+        """
+        try:
+            return SDCPOpcode(self.opcode).name
+        except ValueError:
+            return f"0x{self.opcode:02X}"
+
+    def _format_flags(self) -> str:
+        """Format each known flag and retain unknown flag bits in hexadecimal.
+
+        Returns:
+            A pipe-delimited representation of the flag bits.
+
+        """
+        if self.flags == SDCPFlag.NONE:
+            return SDCPFlag.NONE.name or "NONE"
+
+        flag_names = [flag.name or f"0x{flag:02X}" for flag in SDCPFlag if self.flags & flag]
+        known_flags = SDCPFlag.REPLY | SDCPFlag.ERROR
+        unknown_flags = self.flags & ~known_flags
+        if unknown_flags:
+            flag_names.append(f"0x{unknown_flags:02X}")
+        return " | ".join(flag_names) if flag_names else "0"
+
+
+class SDCPSerializer:
+    """Serialize and deserialize SDCP acyclic frames.
+
+    SDCP uses a four-byte header with one-byte opcode and flags fields followed
+    by a two-byte big-endian transaction ID. The operation-specific payload is
+    preserved as raw bytes because its layout depends on the opcode.
+    """
+
+    HEADER_SIZE = 4
+    OPCODE_SIZE = 1
+    FLAGS_SIZE = 1
+    TRANSACTION_ID_SIZE = 2
+
+    @classmethod
+    def serialize(cls, opcode: int, flags: int, transaction_id: int, payload: bytes = b"") -> bytes:
+        """Serialize an SDCP acyclic frame.
+
+        Args:
+            opcode: Operation identifier in the range 0 to 255.
+            flags: Flag bitmask in the range 0 to 255.
+            transaction_id: Request identifier in the range 0 to 65535.
+            payload: Raw operation-specific bytes to append after the header.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        Raises:
+            ValueError: If a header field does not fit its protocol-defined size.
+
+        """
+        cls._validate_uint("opcode", opcode, cls.OPCODE_SIZE)
+        cls._validate_uint("flags", flags, cls.FLAGS_SIZE)
+        cls._validate_uint("transaction_id", transaction_id, cls.TRANSACTION_ID_SIZE)
+
+        return b"".join((
+            opcode.to_bytes(cls.OPCODE_SIZE, "big"),
+            flags.to_bytes(cls.FLAGS_SIZE, "big"),
+            transaction_id.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+            payload,
+        ))
+
+    @classmethod
+    def deserialize(cls, frame: bytes) -> SDCPFrame:
+        """Deserialize an SDCP acyclic frame.
+
+        Args:
+            frame: The UDP payload containing an SDCP acyclic frame.
+
+        Returns:
+            The decoded SDCP frame.
+
+        Raises:
+            ValueError: If the frame is shorter than the four-byte SDCP header.
+
+        """
+        if len(frame) < cls.HEADER_SIZE:
+            raise ValueError("SDCP frame must include a four-byte header")
+
+        opcode = frame[0]
+        flags = frame[1]
+        payload = frame[cls.HEADER_SIZE :]
+        index, subindex = cls._deserialize_dictionary_address(opcode, flags, payload)
+        if index is not None and subindex is not None:
+            payload = payload[3:]
+
+        return SDCPFrame(
+            opcode=opcode,
+            flags=flags,
+            transaction_id=int.from_bytes(frame[2 : cls.HEADER_SIZE], "big"),
+            payload=payload,
+            index=index,
+            subindex=subindex,
+        )
+
+    @staticmethod
+    def _deserialize_dictionary_address(
+        opcode: int, flags: int, payload: bytes
+    ) -> tuple[int | None, int | None]:
+        """Deserialize a dictionary address from a dictionary request payload.
+
+        Returns:
+            The parsed index and subindex, or ``None`` values when absent.
+
+        """
+        dictionary_opcodes = (SDCPOpcode.READ, SDCPOpcode.WRITE, SDCPOpcode.SUBSCRIBE)
+        if opcode not in dictionary_opcodes or flags != SDCPFlag.NONE or len(payload) < 3:
+            return None, None
+
+        return int.from_bytes(payload[:2], "big"), payload[2]
+
+    @staticmethod
+    def _validate_uint(field_name: str, value: int, size: int) -> None:
+        """Validate that an integer fits in an unsigned protocol field.
+
+        Raises:
+            ValueError: If the integer cannot fit in the field.
+
+        """
+        maximum_value = (1 << (size * 8)) - 1
+        if not 0 <= value <= maximum_value:
+            raise ValueError(f"{field_name} must be in the range 0 to {maximum_value}")

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -10,7 +10,7 @@ from typing import Literal, Union
 class SDCPOpcode(IntEnum):
     """Opcodes defined by the SDCP acyclic communication protocol."""
 
-    IDENTIFY = 0x01
+    IDENTIFICATION = 0x01
     READ = 0x02
     WRITE = 0x03
     SUBSCRIBE = 0x04
@@ -44,11 +44,20 @@ class _SDCPField(Enum):
     CYCLIC_TIME_MS = ("cyclic_time_ms", 2)
     MESSAGE_COUNT = ("message_count", 2)
     ERROR_CODE = ("error_code", 4)
+    PROTOCOL_VERSION = ("protocol_version", 1)
+    SERIAL_NUMBER = ("serial_number", 4)
+    PRODUCT_CODE = ("product_code", 4)
+    REVISION_NUMBER = ("revision_number", 4)
 
     @property
     def size(self) -> int:
         """Return the fixed size of the protocol field in bytes."""
         return self.value[1]
+
+    @property
+    def display_as_hex(self) -> bool:
+        """Return whether the field should use hexadecimal representation."""
+        return self not in {_SDCPField.CYCLIC_TIME_MS, _SDCPField.MESSAGE_COUNT}
 
 
 @dataclass(frozen=True, repr=False)
@@ -56,10 +65,10 @@ class _SDCPMessageRepresentation:
     """Base class for typed SDCP messages."""
 
     def __repr__(self) -> str:
-        """Return a protocol-oriented representation using hexadecimal values.
+        """Return a protocol-oriented representation.
 
         Returns:
-            The message type and its fields formatted as protocol values.
+            The message type and its fields formatted for debugging.
 
         """
         formatted_fields = []
@@ -67,10 +76,17 @@ class _SDCPMessageRepresentation:
             value = getattr(self, message_field.name)
             if isinstance(value, bytes):
                 formatted_value = f"0x{value.hex().upper()}"
+            elif message_field.name == "opcode":
+                try:
+                    formatted_value = f"SDCPOpcode.{SDCPOpcode(value).name}"
+                except ValueError:
+                    formatted_value = f"0x{value:02X}"
             elif isinstance(value, int):
                 protocol_field = _SDCPField.__members__.get(message_field.name.upper())
-                width = protocol_field.size * 2 if protocol_field else 0
-                formatted_value = f"0x{value:0{width}X}" if width else f"0x{value:X}"
+                if protocol_field and protocol_field.display_as_hex:
+                    formatted_value = f"0x{value:0{protocol_field.size * 2}X}"
+                else:
+                    formatted_value = str(value)
             else:
                 formatted_value = repr(value)
             formatted_fields.append(f"{message_field.name}={formatted_value}")
@@ -79,8 +95,8 @@ class _SDCPMessageRepresentation:
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPIdentifyRequest(_SDCPMessageRepresentation):
-    """An SDCP Identify request."""
+class SDCPIdentificationRequest(_SDCPMessageRepresentation):
+    """An SDCP Identification request."""
 
     transaction_id: int
 
@@ -134,11 +150,14 @@ class SDCPUnsubscribeRequest(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPIdentifyResponse(_SDCPMessageRepresentation):
-    """An SDCP Identify response with raw identification data."""
+class SDCPIdentificationResponse(_SDCPMessageRepresentation):
+    """An SDCP Identification response."""
 
     transaction_id: int
-    identification: bytes
+    protocol_version: int
+    serial_number: int
+    product_code: int
+    revision_number: int
 
 
 @dataclass(frozen=True, repr=False)
@@ -175,7 +194,7 @@ class SDCPUnsubscribeResponse(_SDCPMessageRepresentation):
 class SDCPErrorResponse(_SDCPMessageRepresentation):
     """An SDCP error response."""
 
-    opcode: int
+    opcode: SDCPOpcode
     transaction_id: int
     error_code: int
 
@@ -191,13 +210,13 @@ class SDCPUnknownFrame(_SDCPMessageRepresentation):
 
 
 SDCPMessage = Union[
-    SDCPIdentifyRequest,
+    SDCPIdentificationRequest,
     SDCPReadRequest,
     SDCPWriteRequest,
     SDCPPeriodicSubscriptionRequest,
     SDCPEventSubscriptionRequest,
     SDCPUnsubscribeRequest,
-    SDCPIdentifyResponse,
+    SDCPIdentificationResponse,
     SDCPReadResponse,
     SDCPWriteResponse,
     SDCPSubscribeResponse,
@@ -219,8 +238,8 @@ class SDCPSerializer:
     HEADER_SIZE = _SDCPField.OPCODE.size + _SDCPField.FLAGS.size + _SDCPField.TRANSACTION_ID.size
 
     @classmethod
-    def serialize_identify_request(cls, transaction_id: int) -> bytes:
-        """Serialize an Identify request.
+    def serialize_identification_request(cls, transaction_id: int) -> bytes:
+        """Serialize an Identification request.
 
         Args:
             transaction_id: Request identifier in the range 0 to 65535.
@@ -229,7 +248,7 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         """
-        return cls._serialize_frame(SDCPOpcode.IDENTIFY, SDCPFlag.NONE, transaction_id)
+        return cls._serialize_frame(SDCPOpcode.IDENTIFICATION, SDCPFlag.NONE, transaction_id)
 
     @classmethod
     def serialize_read_request(cls, transaction_id: int, index: int, subindex: int) -> bytes:
@@ -478,9 +497,9 @@ class SDCPSerializer:
         except ValueError:
             return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
 
-        if operation == SDCPOpcode.IDENTIFY:
-            cls._validate_payload_size(payload, 0, "Identify request")
-            return SDCPIdentifyRequest(transaction_id)
+        if operation == SDCPOpcode.IDENTIFICATION:
+            cls._validate_payload_size(payload, 0, "Identification request")
+            return SDCPIdentificationRequest(transaction_id)
         if operation == SDCPOpcode.READ:
             cls._validate_payload_size(payload, 3, "Read request")
             index, subindex = cls._deserialize_dictionary_address(payload, "Read request", 0)
@@ -518,8 +537,8 @@ class SDCPSerializer:
         except ValueError:
             return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
 
-        if operation == SDCPOpcode.IDENTIFY:
-            return SDCPIdentifyResponse(transaction_id, payload)
+        if operation == SDCPOpcode.IDENTIFICATION:
+            return cls._deserialize_identification_response(transaction_id, payload)
         if operation == SDCPOpcode.READ:
             return SDCPReadResponse(transaction_id, payload)
         if operation == SDCPOpcode.WRITE:
@@ -542,7 +561,7 @@ class SDCPSerializer:
     @classmethod
     def _deserialize_error_response(
         cls, opcode: int, transaction_id: int, payload: bytes
-    ) -> SDCPErrorResponse:
+    ) -> SDCPMessage:
         """Deserialize an SDCP error response.
 
         Returns:
@@ -552,9 +571,53 @@ class SDCPSerializer:
             ValueError: If the error payload is not a 32-bit error code.
 
         """
+        try:
+            operation = SDCPOpcode(opcode)
+        except ValueError:
+            return SDCPUnknownFrame(
+                opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, transaction_id, payload
+            )
+
         cls._validate_payload_size(payload, _SDCPField.ERROR_CODE.size, "Error response")
         return SDCPErrorResponse(
-            opcode, transaction_id, cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
+            operation, transaction_id, cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
+        )
+
+    @classmethod
+    def _deserialize_identification_response(
+        cls, transaction_id: int, payload: bytes
+    ) -> SDCPIdentificationResponse:
+        """Deserialize the fixed-width Identification response payload.
+
+        Returns:
+            The parsed Identification response.
+
+        Raises:
+            ValueError: If the payload is not the fixed 13-byte layout.
+
+        """
+        fields = (
+            _SDCPField.PROTOCOL_VERSION,
+            _SDCPField.SERIAL_NUMBER,
+            _SDCPField.PRODUCT_CODE,
+            _SDCPField.REVISION_NUMBER,
+        )
+        cls._validate_payload_size(
+            payload, sum(field.size for field in fields), "Identification response"
+        )
+        protocol_version_end = _SDCPField.PROTOCOL_VERSION.size
+        serial_number_end = protocol_version_end + _SDCPField.SERIAL_NUMBER.size
+        product_code_end = serial_number_end + _SDCPField.PRODUCT_CODE.size
+        return SDCPIdentificationResponse(
+            transaction_id,
+            cls._deserialize_uint(_SDCPField.PROTOCOL_VERSION, payload[:protocol_version_end]),
+            cls._deserialize_uint(
+                _SDCPField.SERIAL_NUMBER, payload[protocol_version_end:serial_number_end]
+            ),
+            cls._deserialize_uint(
+                _SDCPField.PRODUCT_CODE, payload[serial_number_end:product_code_end]
+            ),
+            cls._deserialize_uint(_SDCPField.REVISION_NUMBER, payload[product_code_end:]),
         )
 
     @classmethod

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
-from enum import IntEnum, IntFlag
-from typing import Union
+from enum import Enum, IntEnum, IntFlag
+from typing import Literal, Union
 
 
 class SDCPOpcode(IntEnum):
@@ -32,6 +32,25 @@ class SDCPSubscriptionMode(IntEnum):
     EVENT = 0x02
 
 
+class _SDCPField(Enum):
+    """Sizes in bytes of fixed-width SDCP fields."""
+
+    OPCODE = ("opcode", 1)
+    FLAGS = ("flags", 1)
+    TRANSACTION_ID = ("transaction_id", 2)
+    INDEX = ("index", 2)
+    SUBINDEX = ("subindex", 1)
+    SUBSCRIPTION_ID = ("subscription_id", 2)
+    CYCLIC_TIME_MS = ("cyclic_time_ms", 2)
+    MESSAGE_COUNT = ("message_count", 2)
+    ERROR_CODE = ("error_code", 4)
+
+    @property
+    def size(self) -> int:
+        """Return the fixed size of the protocol field in bytes."""
+        return self.value[1]
+
+
 @dataclass(frozen=True, repr=False)
 class _SDCPMessageRepresentation:
     """Base class for typed SDCP messages."""
@@ -43,24 +62,15 @@ class _SDCPMessageRepresentation:
             The message type and its fields formatted as protocol values.
 
         """
-        field_widths = {
-            "transaction_id": 4,
-            "index": 4,
-            "subindex": 2,
-            "subscription_id": 4,
-            "cyclic_time_ms": 4,
-            "message_count": 4,
-            "opcode": 2,
-            "flags": 2,
-            "error_code": 8,
-        }
         formatted_fields = []
         for message_field in fields(self):
             value = getattr(self, message_field.name)
             if isinstance(value, bytes):
                 formatted_value = f"0x{value.hex().upper()}"
             elif isinstance(value, int):
-                formatted_value = f"0x{value:0{field_widths[message_field.name]}X}"
+                protocol_field = _SDCPField.__members__.get(message_field.name.upper())
+                width = protocol_field.size * 2 if protocol_field else 0
+                formatted_value = f"0x{value:0{width}X}" if width else f"0x{value:X}"
             else:
                 formatted_value = repr(value)
             formatted_fields.append(f"{message_field.name}={formatted_value}")
@@ -205,10 +215,8 @@ class SDCPSerializer:
     preserved as raw bytes because its layout depends on the opcode.
     """
 
-    HEADER_SIZE = 4
-    OPCODE_SIZE = 1
-    FLAGS_SIZE = 1
-    TRANSACTION_ID_SIZE = 2
+    BYTE_ORDER: Literal["big"] = "big"
+    HEADER_SIZE = _SDCPField.OPCODE.size + _SDCPField.FLAGS.size + _SDCPField.TRANSACTION_ID.size
 
     @classmethod
     def serialize_identify_request(cls, transaction_id: int) -> bytes:
@@ -254,9 +262,11 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         Raises:
+            TypeError: If the value is not bytes.
             ValueError: If the value is empty.
 
         """
+        cls._validate_bytes("value", value)
         if not value:
             raise ValueError("Write requests require a value payload")
 
@@ -286,12 +296,12 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         """
-        cls._validate_uint("cyclic_time_ms", cyclic_time_ms, cls.TRANSACTION_ID_SIZE)
-        cls._validate_uint("message_count", message_count, cls.TRANSACTION_ID_SIZE)
+        cls._validate_uint(_SDCPField.CYCLIC_TIME_MS, cyclic_time_ms)
+        cls._validate_uint(_SDCPField.MESSAGE_COUNT, message_count)
         payload = b"".join((
-            SDCPSubscriptionMode.PERIODIC.to_bytes(cls.OPCODE_SIZE, "big"),
-            cyclic_time_ms.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
-            message_count.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+            cls._serialize_uint(_SDCPField.OPCODE, SDCPSubscriptionMode.PERIODIC),
+            cls._serialize_uint(_SDCPField.CYCLIC_TIME_MS, cyclic_time_ms),
+            cls._serialize_uint(_SDCPField.MESSAGE_COUNT, message_count),
         ))
         return cls._serialize_dictionary_request(
             SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
@@ -313,10 +323,9 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         """
-        cls._validate_uint("message_count", message_count, cls.TRANSACTION_ID_SIZE)
-        payload = SDCPSubscriptionMode.EVENT.to_bytes(
-            cls.OPCODE_SIZE, "big"
-        ) + message_count.to_bytes(cls.TRANSACTION_ID_SIZE, "big")
+        payload = cls._serialize_uint(
+            _SDCPField.OPCODE, SDCPSubscriptionMode.EVENT
+        ) + cls._serialize_uint(_SDCPField.MESSAGE_COUNT, message_count)
         return cls._serialize_dictionary_request(
             SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
         )
@@ -333,12 +342,11 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         """
-        cls._validate_uint("subscription_id", subscription_id, cls.TRANSACTION_ID_SIZE)
         return cls._serialize_frame(
             SDCPOpcode.UNSUBSCRIBE,
             SDCPFlag.NONE,
             transaction_id,
-            subscription_id.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+            cls._serialize_uint(_SDCPField.SUBSCRIPTION_ID, subscription_id),
         )
 
     @classmethod
@@ -371,13 +379,11 @@ class SDCPSerializer:
             The big-endian SDCP error response frame.
 
         """
-        error_code_size = 4
-        cls._validate_uint("error_code", error_code, error_code_size)
         return cls._serialize_frame(
             opcode,
             SDCPFlag.REPLY | SDCPFlag.ERROR,
             transaction_id,
-            error_code.to_bytes(error_code_size, "big"),
+            cls._serialize_uint(_SDCPField.ERROR_CODE, error_code),
         )
 
     @classmethod
@@ -395,10 +401,8 @@ class SDCPSerializer:
             The big-endian SDCP request frame.
 
         """
-        cls._validate_uint("index", index, cls.TRANSACTION_ID_SIZE)
-        cls._validate_uint("subindex", subindex, cls.OPCODE_SIZE)
-        address = index.to_bytes(cls.TRANSACTION_ID_SIZE, "big") + subindex.to_bytes(
-            cls.OPCODE_SIZE, "big"
+        address = cls._serialize_uint(_SDCPField.INDEX, index) + cls._serialize_uint(
+            _SDCPField.SUBINDEX, subindex
         )
         return cls._serialize_frame(opcode, SDCPFlag.NONE, transaction_id, address + payload)
 
@@ -412,18 +416,17 @@ class SDCPSerializer:
             The big-endian SDCP frame.
 
         Raises:
+            TypeError: If the payload is not bytes.
             ValueError: If a header field does not fit its protocol-defined size.
 
         """
-        cls._validate_uint("opcode", opcode, cls.OPCODE_SIZE)
-        cls._validate_uint("flags", flags, cls.FLAGS_SIZE)
-        cls._validate_uint("transaction_id", transaction_id, cls.TRANSACTION_ID_SIZE)
-        return b"".join((
-            opcode.to_bytes(cls.OPCODE_SIZE, "big"),
-            flags.to_bytes(cls.FLAGS_SIZE, "big"),
-            transaction_id.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
-            payload,
+        cls._validate_bytes("payload", payload)
+        header = b"".join((
+            cls._serialize_uint(_SDCPField.OPCODE, opcode),
+            cls._serialize_uint(_SDCPField.FLAGS, flags),
+            cls._serialize_uint(_SDCPField.TRANSACTION_ID, transaction_id),
         ))
+        return header + payload
 
     @classmethod
     def deserialize(cls, frame: bytes) -> SDCPMessage:
@@ -446,7 +449,10 @@ class SDCPSerializer:
         opcode = frame[0]
         flags = frame[1]
         payload = frame[cls.HEADER_SIZE :]
-        transaction_id = int.from_bytes(frame[2 : cls.HEADER_SIZE], "big")
+        transaction_id = cls._deserialize_uint(
+            _SDCPField.TRANSACTION_ID,
+            frame[_SDCPField.OPCODE.size + _SDCPField.FLAGS.size : cls.HEADER_SIZE],
+        )
         if flags == SDCPFlag.REPLY | SDCPFlag.ERROR:
             return cls._deserialize_error_response(opcode, transaction_id, payload)
         if flags == SDCPFlag.NONE:
@@ -476,6 +482,7 @@ class SDCPSerializer:
             cls._validate_payload_size(payload, 0, "Identify request")
             return SDCPIdentifyRequest(transaction_id)
         if operation == SDCPOpcode.READ:
+            cls._validate_payload_size(payload, 3, "Read request")
             index, subindex = cls._deserialize_dictionary_address(payload, "Read request", 0)
             return SDCPReadRequest(transaction_id, index, subindex)
         if operation == SDCPOpcode.WRITE:
@@ -484,8 +491,12 @@ class SDCPSerializer:
         if operation == SDCPOpcode.SUBSCRIBE:
             return cls._deserialize_subscription_request(transaction_id, payload)
         if operation == SDCPOpcode.UNSUBSCRIBE:
-            cls._validate_payload_size(payload, cls.TRANSACTION_ID_SIZE, "Unsubscribe request")
-            return SDCPUnsubscribeRequest(transaction_id, int.from_bytes(payload, "big"))
+            cls._validate_payload_size(
+                payload, _SDCPField.SUBSCRIPTION_ID.size, "Unsubscribe request"
+            )
+            return SDCPUnsubscribeRequest(
+                transaction_id, cls._deserialize_uint(_SDCPField.SUBSCRIPTION_ID, payload)
+            )
 
         return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
 
@@ -515,8 +526,13 @@ class SDCPSerializer:
             cls._validate_payload_size(payload, 0, "Write response")
             return SDCPWriteResponse(transaction_id)
         if operation == SDCPOpcode.SUBSCRIBE:
-            cls._validate_payload_size(payload, cls.TRANSACTION_ID_SIZE, "Subscribe response")
-            return SDCPSubscribeResponse(transaction_id, int.from_bytes(payload, "big"))
+            # Notification payloads cannot yet be distinguished from subscription replies.
+            cls._validate_payload_size(
+                payload, _SDCPField.SUBSCRIPTION_ID.size, "Subscribe response"
+            )
+            return SDCPSubscribeResponse(
+                transaction_id, cls._deserialize_uint(_SDCPField.SUBSCRIPTION_ID, payload)
+            )
         if operation == SDCPOpcode.UNSUBSCRIBE:
             cls._validate_payload_size(payload, 0, "Unsubscribe response")
             return SDCPUnsubscribeResponse(transaction_id)
@@ -536,9 +552,10 @@ class SDCPSerializer:
             ValueError: If the error payload is not a 32-bit error code.
 
         """
-        error_code_size = 4
-        cls._validate_payload_size(payload, error_code_size, "Error response")
-        return SDCPErrorResponse(opcode, transaction_id, int.from_bytes(payload, "big"))
+        cls._validate_payload_size(payload, _SDCPField.ERROR_CODE.size, "Error response")
+        return SDCPErrorResponse(
+            opcode, transaction_id, cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
+        )
 
     @classmethod
     def _deserialize_subscription_request(cls, transaction_id: int, payload: bytes) -> SDCPMessage:
@@ -563,8 +580,8 @@ class SDCPSerializer:
                 transaction_id,
                 index,
                 subindex,
-                int.from_bytes(payload[4:6], "big"),
-                int.from_bytes(payload[6:8], "big"),
+                cls._deserialize_uint(_SDCPField.CYCLIC_TIME_MS, payload[4:6]),
+                cls._deserialize_uint(_SDCPField.MESSAGE_COUNT, payload[6:8]),
             )
 
         cls._validate_payload_size(payload, 6, "Event Subscribe request")
@@ -572,7 +589,7 @@ class SDCPSerializer:
             transaction_id,
             index,
             subindex,
-            int.from_bytes(payload[4:6], "big"),
+            cls._deserialize_uint(_SDCPField.MESSAGE_COUNT, payload[4:6]),
         )
 
     @classmethod
@@ -588,10 +605,10 @@ class SDCPSerializer:
             ValueError: If the payload cannot contain the address and trailing fields.
 
         """
-        minimum_size = cls.TRANSACTION_ID_SIZE + cls.OPCODE_SIZE + trailing_payload_size
+        minimum_size = _SDCPField.INDEX.size + _SDCPField.SUBINDEX.size + trailing_payload_size
         if len(payload) < minimum_size:
             raise ValueError(f"{message_name} payload is incomplete")
-        return int.from_bytes(payload[:2], "big"), payload[2]
+        return cls._deserialize_uint(_SDCPField.INDEX, payload[:2]), payload[2]
 
     @staticmethod
     def _validate_payload_size(payload: bytes, expected_size: int, message_name: str) -> None:
@@ -605,13 +622,53 @@ class SDCPSerializer:
             raise ValueError(f"{message_name} payload must contain {expected_size} bytes")
 
     @staticmethod
-    def _validate_uint(field_name: str, value: int, size: int) -> None:
+    def _validate_uint(field: _SDCPField, value: int) -> None:
         """Validate that an integer fits in an unsigned protocol field.
 
         Raises:
+            TypeError: If the value is not an integer or is a boolean.
             ValueError: If the integer cannot fit in the field.
 
         """
-        maximum_value = (1 << (size * 8)) - 1
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"{field.name.lower()} must be an integer")
+        maximum_value = (1 << (field.size * 8)) - 1
         if not 0 <= value <= maximum_value:
-            raise ValueError(f"{field_name} must be in the range 0 to {maximum_value}")
+            raise ValueError(f"{field.name.lower()} must be in the range 0 to {maximum_value}")
+
+    @classmethod
+    def _serialize_uint(cls, field: _SDCPField, value: int) -> bytes:
+        """Serialize an unsigned SDCP field using the protocol byte order.
+
+        Returns:
+            The fixed-width big-endian representation of the field.
+
+        """
+        cls._validate_uint(field, value)
+        return value.to_bytes(field.size, cls.BYTE_ORDER)
+
+    @classmethod
+    def _deserialize_uint(cls, field: _SDCPField, value: bytes) -> int:
+        """Deserialize an unsigned SDCP field using the protocol byte order.
+
+        Returns:
+            The decoded unsigned integer.
+
+        Raises:
+            ValueError: If the byte value is not the field's fixed width.
+
+        """
+        if len(value) != field.size:
+            raise ValueError(f"{field.name.lower()} must contain {field.size} bytes")
+        return int.from_bytes(value, cls.BYTE_ORDER)
+
+    @staticmethod
+    def _validate_bytes(field_name: str, value: bytes) -> None:
+        """Validate a raw protocol byte payload.
+
+        Raises:
+            TypeError: If the value is not bytes.
+
+        """
+        if not isinstance(value, bytes):
+            raise TypeError(f"{field_name} must be bytes")

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from enum import IntEnum, IntFlag
+from typing import Union
 
 
 class SDCPOpcode(IntEnum):
@@ -24,68 +25,176 @@ class SDCPFlag(IntFlag):
     ERROR = 0x02
 
 
-@dataclass(frozen=True)
-class SDCPFrame:
-    """An SDCP acyclic frame split into its header and payload fields.
+class SDCPSubscriptionMode(IntEnum):
+    """Subscription modes defined by the SDCP acyclic communication protocol."""
 
-    Attributes:
-        opcode: Operation identifier.
-        flags: Bitmask that modifies the operation behavior.
-        transaction_id: Request identifier echoed by the response.
-        payload: Operation-specific bytes excluding a parsed dictionary address.
-        index: Dictionary index parsed from a dictionary request, when available.
-        subindex: Dictionary subindex parsed from a dictionary request, when available.
+    PERIODIC = 0x01
+    EVENT = 0x02
 
-    """
+
+@dataclass(frozen=True, repr=False)
+class _SDCPMessageRepresentation:
+    """Base class for typed SDCP messages."""
+
+    def __repr__(self) -> str:
+        """Return a protocol-oriented representation using hexadecimal values.
+
+        Returns:
+            The message type and its fields formatted as protocol values.
+
+        """
+        field_widths = {
+            "transaction_id": 4,
+            "index": 4,
+            "subindex": 2,
+            "subscription_id": 4,
+            "cyclic_time_ms": 4,
+            "message_count": 4,
+            "opcode": 2,
+            "flags": 2,
+            "error_code": 8,
+        }
+        formatted_fields = []
+        for message_field in fields(self):
+            value = getattr(self, message_field.name)
+            if isinstance(value, bytes):
+                formatted_value = f"0x{value.hex().upper()}"
+            elif isinstance(value, int):
+                formatted_value = f"0x{value:0{field_widths[message_field.name]}X}"
+            else:
+                formatted_value = repr(value)
+            formatted_fields.append(f"{message_field.name}={formatted_value}")
+
+        return f"{type(self).__name__}({', '.join(formatted_fields)})"
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPIdentifyRequest(_SDCPMessageRepresentation):
+    """An SDCP Identify request."""
+
+    transaction_id: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPReadRequest(_SDCPMessageRepresentation):
+    """An SDCP Read request."""
+
+    transaction_id: int
+    index: int
+    subindex: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPWriteRequest(_SDCPMessageRepresentation):
+    """An SDCP Write request."""
+
+    transaction_id: int
+    index: int
+    subindex: int
+    value: bytes
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPPeriodicSubscriptionRequest(_SDCPMessageRepresentation):
+    """An SDCP periodic Subscribe request."""
+
+    transaction_id: int
+    index: int
+    subindex: int
+    cyclic_time_ms: int
+    message_count: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPEventSubscriptionRequest(_SDCPMessageRepresentation):
+    """An SDCP event-based Subscribe request."""
+
+    transaction_id: int
+    index: int
+    subindex: int
+    message_count: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPUnsubscribeRequest(_SDCPMessageRepresentation):
+    """An SDCP Unsubscribe request."""
+
+    transaction_id: int
+    subscription_id: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPIdentifyResponse(_SDCPMessageRepresentation):
+    """An SDCP Identify response with raw identification data."""
+
+    transaction_id: int
+    identification: bytes
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPReadResponse(_SDCPMessageRepresentation):
+    """An SDCP Read response with raw register value bytes."""
+
+    transaction_id: int
+    value: bytes
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPWriteResponse(_SDCPMessageRepresentation):
+    """An SDCP Write response."""
+
+    transaction_id: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPSubscribeResponse(_SDCPMessageRepresentation):
+    """An SDCP Subscribe response containing a subscription identifier."""
+
+    transaction_id: int
+    subscription_id: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPUnsubscribeResponse(_SDCPMessageRepresentation):
+    """An SDCP Unsubscribe response."""
+
+    transaction_id: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPErrorResponse(_SDCPMessageRepresentation):
+    """An SDCP error response."""
+
+    opcode: int
+    transaction_id: int
+    error_code: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPUnknownFrame(_SDCPMessageRepresentation):
+    """An SDCP frame whose opcode or flags are not recognized."""
 
     opcode: int
     flags: int
     transaction_id: int
     payload: bytes
-    index: int | None = None
-    subindex: int | None = None
 
-    def __repr__(self) -> str:
-        """Return a protocol-oriented representation of the SDCP frame."""
-        dictionary_address = ""
-        if self.index is not None and self.subindex is not None:
-            dictionary_address = f", index=0x{self.index:04X}, subindex=0x{self.subindex:02X}"
 
-        return (
-            "SDCPFrame("
-            f"opcode={self._format_opcode()}, flags={self._format_flags()}, "
-            f"transaction_id=0x{self.transaction_id:04X}{dictionary_address}, "
-            f"payload=0x{self.payload.hex().upper()})"
-        )
-
-    def _format_opcode(self) -> str:
-        """Format the opcode as its name when it is defined by SDCP.
-
-        Returns:
-            The opcode name or its hexadecimal value when unknown.
-
-        """
-        try:
-            return SDCPOpcode(self.opcode).name
-        except ValueError:
-            return f"0x{self.opcode:02X}"
-
-    def _format_flags(self) -> str:
-        """Format each known flag and retain unknown flag bits in hexadecimal.
-
-        Returns:
-            A pipe-delimited representation of the flag bits.
-
-        """
-        if self.flags == SDCPFlag.NONE:
-            return SDCPFlag.NONE.name or "NONE"
-
-        flag_names = [flag.name or f"0x{flag:02X}" for flag in SDCPFlag if self.flags & flag]
-        known_flags = SDCPFlag.REPLY | SDCPFlag.ERROR
-        unknown_flags = self.flags & ~known_flags
-        if unknown_flags:
-            flag_names.append(f"0x{unknown_flags:02X}")
-        return " | ".join(flag_names) if flag_names else "0"
+SDCPMessage = Union[
+    SDCPIdentifyRequest,
+    SDCPReadRequest,
+    SDCPWriteRequest,
+    SDCPPeriodicSubscriptionRequest,
+    SDCPEventSubscriptionRequest,
+    SDCPUnsubscribeRequest,
+    SDCPIdentifyResponse,
+    SDCPReadResponse,
+    SDCPWriteResponse,
+    SDCPSubscribeResponse,
+    SDCPUnsubscribeResponse,
+    SDCPErrorResponse,
+    SDCPUnknownFrame,
+]
 
 
 class SDCPSerializer:
@@ -102,53 +211,213 @@ class SDCPSerializer:
     TRANSACTION_ID_SIZE = 2
 
     @classmethod
-    def serialize(
-        cls,
-        opcode: int,
-        flags: int,
-        transaction_id: int,
-        index: int | None = None,
-        subindex: int | None = None,
-        payload: bytes = b"",
-    ) -> bytes:
-        """Serialize an SDCP acyclic frame.
+    def serialize_identify_request(cls, transaction_id: int) -> bytes:
+        """Serialize an Identify request.
 
         Args:
-            opcode: Operation identifier in the range 0 to 255.
-            flags: Flag bitmask in the range 0 to 255.
             transaction_id: Request identifier in the range 0 to 65535.
-            index: Dictionary index for Read, Write, and Subscribe requests.
-            subindex: Dictionary subindex for Read, Write, and Subscribe requests.
-            payload: Bytes following the dictionary address, such as a value to
-                write or subscription parameters.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        """
+        return cls._serialize_frame(SDCPOpcode.IDENTIFY, SDCPFlag.NONE, transaction_id)
+
+    @classmethod
+    def serialize_read_request(cls, transaction_id: int, index: int, subindex: int) -> bytes:
+        """Serialize a Read request.
+
+        Args:
+            transaction_id: Request identifier in the range 0 to 65535.
+            index: Dictionary index to read.
+            subindex: Dictionary subindex to read.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        """
+        return cls._serialize_dictionary_request(SDCPOpcode.READ, transaction_id, index, subindex)
+
+    @classmethod
+    def serialize_write_request(
+        cls, transaction_id: int, index: int, subindex: int, value: bytes
+    ) -> bytes:
+        """Serialize a Write request.
+
+        Args:
+            transaction_id: Request identifier in the range 0 to 65535.
+            index: Dictionary index to write.
+            subindex: Dictionary subindex to write.
+            value: Encoded value bytes to write.
 
         Returns:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         Raises:
-            ValueError: If a field does not fit its protocol-defined size or
-                a dictionary request does not include a complete address or a
-                Write request does not include a value payload.
+            ValueError: If the value is empty.
+
+        """
+        if not value:
+            raise ValueError("Write requests require a value payload")
+
+        return cls._serialize_dictionary_request(
+            SDCPOpcode.WRITE, transaction_id, index, subindex, value
+        )
+
+    @classmethod
+    def serialize_periodic_subscription_request(
+        cls,
+        transaction_id: int,
+        index: int,
+        subindex: int,
+        cyclic_time_ms: int,
+        message_count: int,
+    ) -> bytes:
+        """Serialize a periodic Subscribe request.
+
+        Args:
+            transaction_id: Request identifier in the range 0 to 65535.
+            index: Dictionary index to subscribe to.
+            subindex: Dictionary subindex to subscribe to.
+            cyclic_time_ms: Periodic cycle time in milliseconds.
+            message_count: Maximum notifications before expiration.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        """
+        cls._validate_uint("cyclic_time_ms", cyclic_time_ms, cls.TRANSACTION_ID_SIZE)
+        cls._validate_uint("message_count", message_count, cls.TRANSACTION_ID_SIZE)
+        payload = b"".join((
+            SDCPSubscriptionMode.PERIODIC.to_bytes(cls.OPCODE_SIZE, "big"),
+            cyclic_time_ms.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+            message_count.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+        ))
+        return cls._serialize_dictionary_request(
+            SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
+        )
+
+    @classmethod
+    def serialize_event_subscription_request(
+        cls, transaction_id: int, index: int, subindex: int, message_count: int
+    ) -> bytes:
+        """Serialize an event-based Subscribe request.
+
+        Args:
+            transaction_id: Request identifier in the range 0 to 65535.
+            index: Dictionary index to subscribe to.
+            subindex: Dictionary subindex to subscribe to.
+            message_count: Maximum notifications before expiration.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        """
+        cls._validate_uint("message_count", message_count, cls.TRANSACTION_ID_SIZE)
+        payload = SDCPSubscriptionMode.EVENT.to_bytes(
+            cls.OPCODE_SIZE, "big"
+        ) + message_count.to_bytes(cls.TRANSACTION_ID_SIZE, "big")
+        return cls._serialize_dictionary_request(
+            SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
+        )
+
+    @classmethod
+    def serialize_unsubscribe_request(cls, transaction_id: int, subscription_id: int) -> bytes:
+        """Serialize an Unsubscribe request.
+
+        Args:
+            transaction_id: Request identifier in the range 0 to 65535.
+            subscription_id: Identifier of the subscription to cancel.
+
+        Returns:
+            The big-endian SDCP frame ready to send as a UDP payload.
+
+        """
+        cls._validate_uint("subscription_id", subscription_id, cls.TRANSACTION_ID_SIZE)
+        return cls._serialize_frame(
+            SDCPOpcode.UNSUBSCRIBE,
+            SDCPFlag.NONE,
+            transaction_id,
+            subscription_id.to_bytes(cls.TRANSACTION_ID_SIZE, "big"),
+        )
+
+    @classmethod
+    def serialize_success_response(
+        cls, opcode: int, transaction_id: int, payload: bytes = b""
+    ) -> bytes:
+        """Serialize a successful response.
+
+        Args:
+            opcode: Opcode of the request being answered.
+            transaction_id: Identifier of the request being answered.
+            payload: Optional operation-specific response bytes.
+
+        Returns:
+            The big-endian SDCP response frame.
+
+        """
+        return cls._serialize_frame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+
+    @classmethod
+    def serialize_error_response(cls, opcode: int, transaction_id: int, error_code: int) -> bytes:
+        """Serialize an error response.
+
+        Args:
+            opcode: Opcode of the request being answered.
+            transaction_id: Identifier of the request being answered.
+            error_code: Unsigned 32-bit protocol error code.
+
+        Returns:
+            The big-endian SDCP error response frame.
+
+        """
+        error_code_size = 4
+        cls._validate_uint("error_code", error_code, error_code_size)
+        return cls._serialize_frame(
+            opcode,
+            SDCPFlag.REPLY | SDCPFlag.ERROR,
+            transaction_id,
+            error_code.to_bytes(error_code_size, "big"),
+        )
+
+    @classmethod
+    def _serialize_dictionary_request(
+        cls,
+        opcode: SDCPOpcode,
+        transaction_id: int,
+        index: int,
+        subindex: int,
+        payload: bytes = b"",
+    ) -> bytes:
+        """Serialize a request whose payload begins with a dictionary address.
+
+        Returns:
+            The big-endian SDCP request frame.
+
+        """
+        cls._validate_uint("index", index, cls.TRANSACTION_ID_SIZE)
+        cls._validate_uint("subindex", subindex, cls.OPCODE_SIZE)
+        address = index.to_bytes(cls.TRANSACTION_ID_SIZE, "big") + subindex.to_bytes(
+            cls.OPCODE_SIZE, "big"
+        )
+        return cls._serialize_frame(opcode, SDCPFlag.NONE, transaction_id, address + payload)
+
+    @classmethod
+    def _serialize_frame(
+        cls, opcode: int, flags: int, transaction_id: int, payload: bytes = b""
+    ) -> bytes:
+        """Serialize the common SDCP header and raw operation payload.
+
+        Returns:
+            The big-endian SDCP frame.
+
+        Raises:
+            ValueError: If a header field does not fit its protocol-defined size.
 
         """
         cls._validate_uint("opcode", opcode, cls.OPCODE_SIZE)
         cls._validate_uint("flags", flags, cls.FLAGS_SIZE)
         cls._validate_uint("transaction_id", transaction_id, cls.TRANSACTION_ID_SIZE)
-        if (index is None) != (subindex is None):
-            raise ValueError("index and subindex must be provided together")
-        if cls._is_dictionary_request(opcode, flags) and index is None:
-            raise ValueError("dictionary requests require index and subindex")
-        if opcode == SDCPOpcode.WRITE and flags == SDCPFlag.NONE and not payload:
-            raise ValueError("Write requests require a value payload")
-        if index is not None and subindex is not None:
-            cls._validate_uint("index", index, cls.TRANSACTION_ID_SIZE)
-            cls._validate_uint("subindex", subindex, cls.OPCODE_SIZE)
-            payload = (
-                index.to_bytes(cls.TRANSACTION_ID_SIZE, "big")
-                + subindex.to_bytes(cls.OPCODE_SIZE, "big")
-                + payload
-            )
-
         return b"".join((
             opcode.to_bytes(cls.OPCODE_SIZE, "big"),
             flags.to_bytes(cls.FLAGS_SIZE, "big"),
@@ -157,7 +426,7 @@ class SDCPSerializer:
         ))
 
     @classmethod
-    def deserialize(cls, frame: bytes) -> SDCPFrame:
+    def deserialize(cls, frame: bytes) -> SDCPMessage:
         """Deserialize an SDCP acyclic frame.
 
         Args:
@@ -167,7 +436,8 @@ class SDCPSerializer:
             The decoded SDCP frame.
 
         Raises:
-            ValueError: If the frame is shorter than the four-byte SDCP header.
+            ValueError: If the frame is shorter than the four-byte SDCP header
+                or a recognized frame has an invalid payload layout.
 
         """
         if len(frame) < cls.HEADER_SIZE:
@@ -176,44 +446,163 @@ class SDCPSerializer:
         opcode = frame[0]
         flags = frame[1]
         payload = frame[cls.HEADER_SIZE :]
-        index, subindex = cls._deserialize_dictionary_address(opcode, flags, payload)
-        if index is not None and subindex is not None:
-            payload = payload[3:]
+        transaction_id = int.from_bytes(frame[2 : cls.HEADER_SIZE], "big")
+        if flags == SDCPFlag.REPLY | SDCPFlag.ERROR:
+            return cls._deserialize_error_response(opcode, transaction_id, payload)
+        if flags == SDCPFlag.NONE:
+            return cls._deserialize_request(opcode, transaction_id, payload)
+        if flags == SDCPFlag.REPLY:
+            return cls._deserialize_success_response(opcode, transaction_id, payload)
 
-        return SDCPFrame(
-            opcode=opcode,
-            flags=flags,
-            transaction_id=int.from_bytes(frame[2 : cls.HEADER_SIZE], "big"),
-            payload=payload,
-            index=index,
-            subindex=subindex,
-        )
+        return SDCPUnknownFrame(opcode, flags, transaction_id, payload)
 
-    @staticmethod
-    def _deserialize_dictionary_address(
-        opcode: int, flags: int, payload: bytes
-    ) -> tuple[int | None, int | None]:
-        """Deserialize a dictionary address from a dictionary request payload.
+    @classmethod
+    def _deserialize_request(cls, opcode: int, transaction_id: int, payload: bytes) -> SDCPMessage:
+        """Deserialize an SDCP request into its specific message type.
 
         Returns:
-            The parsed index and subindex, or ``None`` values when absent.
+            A specialized request message or an unknown frame.
+
+        Raises:
+            ValueError: If a recognized request payload is malformed.
 
         """
-        if not SDCPSerializer._is_dictionary_request(opcode, flags) or len(payload) < 3:
-            return None, None
+        try:
+            operation = SDCPOpcode(opcode)
+        except ValueError:
+            return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
 
+        if operation == SDCPOpcode.IDENTIFY:
+            cls._validate_payload_size(payload, 0, "Identify request")
+            return SDCPIdentifyRequest(transaction_id)
+        if operation == SDCPOpcode.READ:
+            index, subindex = cls._deserialize_dictionary_address(payload, "Read request", 0)
+            return SDCPReadRequest(transaction_id, index, subindex)
+        if operation == SDCPOpcode.WRITE:
+            index, subindex = cls._deserialize_dictionary_address(payload, "Write request", 1)
+            return SDCPWriteRequest(transaction_id, index, subindex, payload[3:])
+        if operation == SDCPOpcode.SUBSCRIBE:
+            return cls._deserialize_subscription_request(transaction_id, payload)
+        if operation == SDCPOpcode.UNSUBSCRIBE:
+            cls._validate_payload_size(payload, cls.TRANSACTION_ID_SIZE, "Unsubscribe request")
+            return SDCPUnsubscribeRequest(transaction_id, int.from_bytes(payload, "big"))
+
+        return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
+
+    @classmethod
+    def _deserialize_success_response(
+        cls, opcode: int, transaction_id: int, payload: bytes
+    ) -> SDCPMessage:
+        """Deserialize a successful SDCP response into its specific message type.
+
+        Returns:
+            A specialized response message or an unknown frame.
+
+        Raises:
+            ValueError: If a recognized response payload is malformed.
+
+        """
+        try:
+            operation = SDCPOpcode(opcode)
+        except ValueError:
+            return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+
+        if operation == SDCPOpcode.IDENTIFY:
+            return SDCPIdentifyResponse(transaction_id, payload)
+        if operation == SDCPOpcode.READ:
+            return SDCPReadResponse(transaction_id, payload)
+        if operation == SDCPOpcode.WRITE:
+            cls._validate_payload_size(payload, 0, "Write response")
+            return SDCPWriteResponse(transaction_id)
+        if operation == SDCPOpcode.SUBSCRIBE:
+            cls._validate_payload_size(payload, cls.TRANSACTION_ID_SIZE, "Subscribe response")
+            return SDCPSubscribeResponse(transaction_id, int.from_bytes(payload, "big"))
+        if operation == SDCPOpcode.UNSUBSCRIBE:
+            cls._validate_payload_size(payload, 0, "Unsubscribe response")
+            return SDCPUnsubscribeResponse(transaction_id)
+
+        return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+
+    @classmethod
+    def _deserialize_error_response(
+        cls, opcode: int, transaction_id: int, payload: bytes
+    ) -> SDCPErrorResponse:
+        """Deserialize an SDCP error response.
+
+        Returns:
+            The specialized error response.
+
+        Raises:
+            ValueError: If the error payload is not a 32-bit error code.
+
+        """
+        error_code_size = 4
+        cls._validate_payload_size(payload, error_code_size, "Error response")
+        return SDCPErrorResponse(opcode, transaction_id, int.from_bytes(payload, "big"))
+
+    @classmethod
+    def _deserialize_subscription_request(cls, transaction_id: int, payload: bytes) -> SDCPMessage:
+        """Deserialize a Subscribe request into its mode-specific message type.
+
+        Returns:
+            A periodic or event-based subscription request.
+
+        Raises:
+            ValueError: If the subscription payload is malformed.
+
+        """
+        index, subindex = cls._deserialize_dictionary_address(payload, "Subscribe request", 3)
+        try:
+            mode = SDCPSubscriptionMode(payload[3])
+        except ValueError as error:
+            raise ValueError("Subscribe request has an unknown subscription mode") from error
+
+        if mode == SDCPSubscriptionMode.PERIODIC:
+            cls._validate_payload_size(payload, 8, "Periodic Subscribe request")
+            return SDCPPeriodicSubscriptionRequest(
+                transaction_id,
+                index,
+                subindex,
+                int.from_bytes(payload[4:6], "big"),
+                int.from_bytes(payload[6:8], "big"),
+            )
+
+        cls._validate_payload_size(payload, 6, "Event Subscribe request")
+        return SDCPEventSubscriptionRequest(
+            transaction_id,
+            index,
+            subindex,
+            int.from_bytes(payload[4:6], "big"),
+        )
+
+    @classmethod
+    def _deserialize_dictionary_address(
+        cls, payload: bytes, message_name: str, trailing_payload_size: int
+    ) -> tuple[int, int]:
+        """Deserialize an address prefix from a dictionary request payload.
+
+        Returns:
+            The dictionary index and subindex.
+
+        Raises:
+            ValueError: If the payload cannot contain the address and trailing fields.
+
+        """
+        minimum_size = cls.TRANSACTION_ID_SIZE + cls.OPCODE_SIZE + trailing_payload_size
+        if len(payload) < minimum_size:
+            raise ValueError(f"{message_name} payload is incomplete")
         return int.from_bytes(payload[:2], "big"), payload[2]
 
     @staticmethod
-    def _is_dictionary_request(opcode: int, flags: int) -> bool:
-        """Determine whether a frame requires a dictionary address.
+    def _validate_payload_size(payload: bytes, expected_size: int, message_name: str) -> None:
+        """Validate the exact payload size of a fixed-layout message.
 
-        Returns:
-            ``True`` for unflagged Read, Write, and Subscribe requests.
+        Raises:
+            ValueError: If the payload size does not match the message layout.
 
         """
-        dictionary_opcodes = (SDCPOpcode.READ, SDCPOpcode.WRITE, SDCPOpcode.SUBSCRIBE)
-        return opcode in dictionary_opcodes and flags == SDCPFlag.NONE
+        if len(payload) != expected_size:
+            raise ValueError(f"{message_name} payload must contain {expected_size} bytes")
 
     @staticmethod
     def _validate_uint(field_name: str, value: int, size: int) -> None:

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -598,7 +598,7 @@ SDCPMessage = Union[
 ]
 
 
-class SDCPSerializer:
+class SDCPDeserializer:
     """Deserialize SDCP acyclic frames.
 
     SDCP uses a four-byte header with one-byte opcode and flags fields followed

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -131,8 +131,10 @@ class _SDCPPayloadReader:
 
 
 @dataclass(frozen=True, repr=False)
-class _SDCPMessageRepresentation:
+class _SDCPMessage:
     """Base class for typed SDCP messages."""
+
+    transaction_id: int
 
     def __repr__(self) -> str:
         """Return a protocol-oriented representation.
@@ -146,11 +148,6 @@ class _SDCPMessageRepresentation:
             value = getattr(self, message_field.name)
             if isinstance(value, bytes):
                 formatted_value = f"0x{value.hex().upper()}"
-            elif message_field.name == "opcode":
-                try:
-                    formatted_value = f"SDCPOpcode.{SDCPOpcode(value).name}"
-                except ValueError:
-                    formatted_value = f"0x{value:02X}"
             elif isinstance(value, int):
                 protocol_field = getattr(_SDCPFields, message_field.name.upper(), None)
                 width = protocol_field.hex_width if protocol_field else 0
@@ -163,36 +160,31 @@ class _SDCPMessageRepresentation:
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPIdentificationRequest(_SDCPMessageRepresentation):
+class SDCPIdentificationRequest(_SDCPMessage):
     """An SDCP Identification request."""
-
-    transaction_id: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPReadRequest(_SDCPMessageRepresentation):
+class SDCPReadRequest(_SDCPMessage):
     """An SDCP Read request."""
 
-    transaction_id: int
     index: int
     subindex: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPWriteRequest(_SDCPMessageRepresentation):
+class SDCPWriteRequest(_SDCPMessage):
     """An SDCP Write request."""
 
-    transaction_id: int
     index: int
     subindex: int
     value: bytes
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPPeriodicSubscriptionRequest(_SDCPMessageRepresentation):
+class SDCPPeriodicSubscriptionRequest(_SDCPMessage):
     """An SDCP periodic Subscribe request."""
 
-    transaction_id: int
     index: int
     subindex: int
     cyclic_time_ms: int
@@ -200,28 +192,25 @@ class SDCPPeriodicSubscriptionRequest(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPEventSubscriptionRequest(_SDCPMessageRepresentation):
+class SDCPEventSubscriptionRequest(_SDCPMessage):
     """An SDCP event-based Subscribe request."""
 
-    transaction_id: int
     index: int
     subindex: int
     message_count: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPUnsubscribeRequest(_SDCPMessageRepresentation):
+class SDCPUnsubscribeRequest(_SDCPMessage):
     """An SDCP Unsubscribe request."""
 
-    transaction_id: int
     subscription_id: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPIdentificationResponse(_SDCPMessageRepresentation):
+class SDCPIdentificationResponse(_SDCPMessage):
     """An SDCP Identification response."""
 
-    transaction_id: int
     protocol_version: int
     serial_number: int
     product_code: int
@@ -229,40 +218,33 @@ class SDCPIdentificationResponse(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPReadResponse(_SDCPMessageRepresentation):
+class SDCPReadResponse(_SDCPMessage):
     """An SDCP Read response with raw register value bytes."""
 
-    transaction_id: int
     value: bytes
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPWriteResponse(_SDCPMessageRepresentation):
+class SDCPWriteResponse(_SDCPMessage):
     """An SDCP Write response."""
-
-    transaction_id: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPSubscribeResponse(_SDCPMessageRepresentation):
+class SDCPSubscribeResponse(_SDCPMessage):
     """An SDCP Subscribe response containing a subscription identifier."""
 
-    transaction_id: int
     subscription_id: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPUnsubscribeResponse(_SDCPMessageRepresentation):
+class SDCPUnsubscribeResponse(_SDCPMessage):
     """An SDCP Unsubscribe response."""
-
-    transaction_id: int
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPErrorResponse(_SDCPMessageRepresentation):
+class SDCPErrorResponse(_SDCPMessage):
     """Base class for operation-specific SDCP error responses."""
 
-    transaction_id: int
     error_code: int
 
 
@@ -292,12 +274,11 @@ class SDCPUnsubscribeResponseError(SDCPErrorResponse):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPUnknownFrame(_SDCPMessageRepresentation):
+class SDCPUnknownFrame(_SDCPMessage):
     """An SDCP frame whose opcode or flags are not recognized."""
 
     opcode: int
     flags: int
-    transaction_id: int
     payload: bytes
 
 
@@ -580,7 +561,7 @@ class SDCPSerializer:
         if flags == SDCPFlag.REPLY:
             return cls._deserialize_success_response(opcode, transaction_id, payload)
 
-        return SDCPUnknownFrame(opcode, flags, transaction_id, payload)
+        return SDCPUnknownFrame(transaction_id, opcode, flags, payload)
 
     @classmethod
     def _deserialize_request(cls, opcode: int, transaction_id: int, payload: bytes) -> SDCPMessage:
@@ -596,7 +577,7 @@ class SDCPSerializer:
         try:
             operation = SDCPOpcode(opcode)
         except ValueError:
-            return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
+            return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.NONE, payload)
 
         reader = _SDCPPayloadReader(payload)
         if operation == SDCPOpcode.IDENTIFICATION:
@@ -622,7 +603,7 @@ class SDCPSerializer:
                 subscription_id,
             )
 
-        return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
+        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.NONE, payload)
 
     @classmethod
     def _deserialize_success_response(
@@ -640,7 +621,7 @@ class SDCPSerializer:
         try:
             operation = SDCPOpcode(opcode)
         except ValueError:
-            return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+            return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY, payload)
 
         if operation == SDCPOpcode.IDENTIFICATION:
             return cls._deserialize_identification_response(transaction_id, payload)
@@ -654,7 +635,7 @@ class SDCPSerializer:
         if response_type is not None:
             return cls._deserialize_empty_response(transaction_id, payload, response_type)
 
-        return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY, payload)
 
     @classmethod
     def _deserialize_subscribe_response(
@@ -706,7 +687,7 @@ class SDCPSerializer:
             operation = SDCPOpcode(opcode)
         except ValueError:
             return SDCPUnknownFrame(
-                opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, transaction_id, payload
+                transaction_id, opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, payload
             )
 
         reader = _SDCPPayloadReader(payload)

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -38,9 +38,26 @@ _SDCP_BYTE_ORDER: Literal["big"] = "big"
 
 @dataclass(frozen=True)
 class _SDCPField:
-    """Metadata for a fixed-width SDCP field."""
+    """Define and serialize a fixed-width SDCP field."""
 
     size: int
+
+    def serialize(self, value: int) -> bytes:
+        """Serialize an unsigned value using the protocol byte order.
+
+        Returns:
+            The fixed-width big-endian representation of the field.
+
+        Raises:
+            TypeError: If the value is not an integer or is a boolean.
+            ValueError: If the value cannot fit in the field.
+
+        """
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"Value must be an integer for a {self.size}-byte field")
+        if not 0 <= value <= self.maximum_value:
+            raise ValueError(f"Value must be in the range 0 to {self.maximum_value}")
+        return value.to_bytes(self.size, _SDCP_BYTE_ORDER)
 
     @property
     def hex_width(self) -> int:
@@ -135,24 +152,6 @@ class _SDCPCodec:
     """Private SDCP encoding operations shared by message objects."""
 
     @staticmethod
-    def serialize_uint(field: _SDCPField, value: int) -> bytes:
-        """Serialize an unsigned SDCP field using the protocol byte order.
-
-        Returns:
-            The fixed-width big-endian representation of the field.
-
-        Raises:
-            TypeError: If the value is not an integer or is a boolean.
-            ValueError: If the value cannot fit in the field.
-
-        """
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(f"Value must be an integer for a {field.size}-byte field")
-        if not 0 <= value <= field.maximum_value:
-            raise ValueError(f"Value must be in the range 0 to {field.maximum_value}")
-        return value.to_bytes(field.size, _SDCP_BYTE_ORDER)
-
-    @staticmethod
     def serialize_frame(
         opcode: int,
         flags: int,
@@ -171,24 +170,12 @@ class _SDCPCodec:
         """
         if not isinstance(payload, bytes):
             raise TypeError("payload must be bytes")
-        header = b"".join((
-            _SDCPCodec.serialize_uint(_SDCPFields.OPCODE, opcode),
-            _SDCPCodec.serialize_uint(_SDCPFields.FLAGS, flags),
-            _SDCPCodec.serialize_uint(_SDCPFields.TRANSACTION_ID, transaction_id),
-        ))
-        return header + payload
-
-    @staticmethod
-    def serialize_dictionary_address(index: int, subindex: int) -> bytes:
-        """Serialize a dictionary index and subindex.
-
-        Returns:
-            The fixed-width dictionary address bytes.
-
-        """
-        return _SDCPCodec.serialize_uint(_SDCPFields.INDEX, index) + _SDCPCodec.serialize_uint(
-            _SDCPFields.SUBINDEX, subindex
+        header = (
+            _SDCPFields.OPCODE.serialize(opcode)
+            + _SDCPFields.FLAGS.serialize(flags)
+            + _SDCPFields.TRANSACTION_ID.serialize(transaction_id)
         )
+        return header + payload
 
 
 @dataclass(frozen=True, repr=False)
@@ -255,7 +242,9 @@ class SDCPReadRequest(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex)
+        payload = _SDCPFields.INDEX.serialize(self.index) + _SDCPFields.SUBINDEX.serialize(
+            self.subindex
+        )
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.READ, SDCPFlag.NONE, self.transaction_id, payload
         )
@@ -284,7 +273,11 @@ class SDCPWriteRequest(_SDCPMessage):
             raise TypeError("value must be bytes")
         if not self.value:
             raise ValueError("Write requests require a value payload")
-        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + self.value
+        payload = (
+            _SDCPFields.INDEX.serialize(self.index)
+            + _SDCPFields.SUBINDEX.serialize(self.subindex)
+            + self.value
+        )
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.WRITE,
             SDCPFlag.NONE,
@@ -309,11 +302,13 @@ class SDCPPeriodicSubscriptionRequest(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + b"".join((
-            _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.PERIODIC),
-            _SDCPCodec.serialize_uint(_SDCPFields.CYCLIC_TIME_MS, self.cyclic_time_ms),
-            _SDCPCodec.serialize_uint(_SDCPFields.MESSAGE_COUNT, self.message_count),
-        ))
+        payload = (
+            _SDCPFields.INDEX.serialize(self.index)
+            + _SDCPFields.SUBINDEX.serialize(self.subindex)
+            + _SDCPFields.SUBSCRIPTION_MODE.serialize(SDCPSubscriptionMode.PERIODIC)
+            + _SDCPFields.CYCLIC_TIME_MS.serialize(self.cyclic_time_ms)
+            + _SDCPFields.MESSAGE_COUNT.serialize(self.message_count)
+        )
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.SUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
         )
@@ -334,10 +329,12 @@ class SDCPEventSubscriptionRequest(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + b"".join((
-            _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.EVENT),
-            _SDCPCodec.serialize_uint(_SDCPFields.MESSAGE_COUNT, self.message_count),
-        ))
+        payload = (
+            _SDCPFields.INDEX.serialize(self.index)
+            + _SDCPFields.SUBINDEX.serialize(self.subindex)
+            + _SDCPFields.SUBSCRIPTION_MODE.serialize(SDCPSubscriptionMode.EVENT)
+            + _SDCPFields.MESSAGE_COUNT.serialize(self.message_count)
+        )
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.SUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
         )
@@ -356,7 +353,7 @@ class SDCPUnsubscribeRequest(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_ID, self.subscription_id)
+        payload = _SDCPFields.SUBSCRIPTION_ID.serialize(self.subscription_id)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.UNSUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
         )
@@ -378,12 +375,12 @@ class SDCPIdentificationResponse(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = b"".join((
-            _SDCPCodec.serialize_uint(_SDCPFields.PROTOCOL_VERSION, self.protocol_version),
-            _SDCPCodec.serialize_uint(_SDCPFields.SERIAL_NUMBER, self.serial_number),
-            _SDCPCodec.serialize_uint(_SDCPFields.PRODUCT_CODE, self.product_code),
-            _SDCPCodec.serialize_uint(_SDCPFields.REVISION_NUMBER, self.revision_number),
-        ))
+        payload = (
+            _SDCPFields.PROTOCOL_VERSION.serialize(self.protocol_version)
+            + _SDCPFields.SERIAL_NUMBER.serialize(self.serial_number)
+            + _SDCPFields.PRODUCT_CODE.serialize(self.product_code)
+            + _SDCPFields.REVISION_NUMBER.serialize(self.revision_number)
+        )
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.IDENTIFICATION, SDCPFlag.REPLY, self.transaction_id, payload
         )
@@ -442,7 +439,7 @@ class SDCPSubscribeResponse(_SDCPMessage):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_ID, self.subscription_id)
+        payload = _SDCPFields.SUBSCRIPTION_ID.serialize(self.subscription_id)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.SUBSCRIBE, SDCPFlag.REPLY, self.transaction_id, payload
         )
@@ -482,7 +479,7 @@ class SDCPIdentificationResponseError(SDCPErrorResponse):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        payload = _SDCPFields.ERROR_CODE.serialize(self.error_code)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.IDENTIFICATION,
             SDCPFlag.REPLY | SDCPFlag.ERROR,
@@ -502,7 +499,7 @@ class SDCPReadResponseError(SDCPErrorResponse):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        payload = _SDCPFields.ERROR_CODE.serialize(self.error_code)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.READ, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
         )
@@ -519,7 +516,7 @@ class SDCPWriteResponseError(SDCPErrorResponse):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        payload = _SDCPFields.ERROR_CODE.serialize(self.error_code)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.WRITE, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
         )
@@ -536,7 +533,7 @@ class SDCPSubscribeResponseError(SDCPErrorResponse):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        payload = _SDCPFields.ERROR_CODE.serialize(self.error_code)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.SUBSCRIBE, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
         )
@@ -553,7 +550,7 @@ class SDCPUnsubscribeResponseError(SDCPErrorResponse):
             The binary SDCP frame.
 
         """
-        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        payload = _SDCPFields.ERROR_CODE.serialize(self.error_code)
         return _SDCPCodec.serialize_frame(
             SDCPOpcode.UNSUBSCRIBE,
             SDCPFlag.REPLY | SDCPFlag.ERROR,
@@ -663,11 +660,13 @@ class SDCPDeserializer:
             reader.ensure_end()
             return SDCPIdentificationRequest(transaction_id)
         if operation == SDCPOpcode.READ:
-            index, subindex = cls._deserialize_dictionary_address(reader)
+            index = reader.read_uint(_SDCPFields.INDEX)
+            subindex = reader.read_uint(_SDCPFields.SUBINDEX)
             reader.ensure_end()
             return SDCPReadRequest(transaction_id, index, subindex)
         if operation == SDCPOpcode.WRITE:
-            index, subindex = cls._deserialize_dictionary_address(reader)
+            index = reader.read_uint(_SDCPFields.INDEX)
+            subindex = reader.read_uint(_SDCPFields.SUBINDEX)
             value = reader.read_remaining()
             if not value:
                 raise ValueError("Write requests require a value payload")
@@ -681,8 +680,6 @@ class SDCPDeserializer:
                 transaction_id,
                 subscription_id,
             )
-
-        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.NONE, payload)
 
     @classmethod
     def _deserialize_success_response(
@@ -716,8 +713,6 @@ class SDCPDeserializer:
         if operation == SDCPOpcode.UNSUBSCRIBE:
             _SDCPPayloadReader(payload).ensure_end()
             return SDCPUnsubscribeResponse(transaction_id)
-
-        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY, payload)
 
     @classmethod
     def _deserialize_subscribe_response(
@@ -768,8 +763,6 @@ class SDCPDeserializer:
         if operation == SDCPOpcode.UNSUBSCRIBE:
             return SDCPUnsubscribeResponseError(transaction_id, error_code)
 
-        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, payload)
-
     @classmethod
     def _deserialize_identification_response(
         cls, transaction_id: int, payload: bytes
@@ -809,7 +802,8 @@ class SDCPDeserializer:
             ValueError: If the subscription payload is malformed.
 
         """
-        index, subindex = cls._deserialize_dictionary_address(reader)
+        index = reader.read_uint(_SDCPFields.INDEX)
+        subindex = reader.read_uint(_SDCPFields.SUBINDEX)
         mode_value = reader.read_uint(_SDCPFields.SUBSCRIPTION_MODE)
         try:
             mode = SDCPSubscriptionMode(mode_value)
@@ -837,16 +831,3 @@ class SDCPDeserializer:
             )
         reader.ensure_end()
         return request
-
-    @staticmethod
-    def _deserialize_dictionary_address(reader: _SDCPPayloadReader) -> tuple[int, int]:
-        """Deserialize a dictionary address from the current payload position.
-
-        Returns:
-            The dictionary index and subindex.
-
-        Raises:
-            ValueError: If the payload cannot contain the address.
-
-        """
-        return reader.read_uint(_SDCPFields.INDEX), reader.read_uint(_SDCPFields.SUBINDEX)

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields
 from enum import IntEnum, IntFlag
-from typing import ClassVar, Literal, Union
+from typing import Literal, Union
 
 
 class SDCPOpcode(IntEnum):
@@ -130,11 +131,78 @@ class _SDCPPayloadReader:
             raise ValueError(f"Payload contains {trailing_bytes} unexpected trailing bytes")
 
 
+class _SDCPCodec:
+    """Private SDCP encoding operations shared by message objects."""
+
+    @staticmethod
+    def serialize_uint(field: _SDCPField, value: int) -> bytes:
+        """Serialize an unsigned SDCP field using the protocol byte order.
+
+        Returns:
+            The fixed-width big-endian representation of the field.
+
+        Raises:
+            TypeError: If the value is not an integer or is a boolean.
+            ValueError: If the value cannot fit in the field.
+
+        """
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(f"Value must be an integer for a {field.size}-byte field")
+        if not 0 <= value <= field.maximum_value:
+            raise ValueError(f"Value must be in the range 0 to {field.maximum_value}")
+        return value.to_bytes(field.size, _SDCP_BYTE_ORDER)
+
+    @staticmethod
+    def serialize_frame(
+        opcode: int,
+        flags: int,
+        transaction_id: int,
+        payload: bytes = b"",
+        *,
+        payload_name: str = "payload",
+    ) -> bytes:
+        """Serialize the common SDCP header and raw operation payload.
+
+        Returns:
+            The big-endian SDCP frame.
+
+        Raises:
+            TypeError: If the payload is not bytes.
+            ValueError: If a header field does not fit its protocol-defined size.
+
+        """
+        if not isinstance(payload, bytes):
+            raise TypeError(f"{payload_name} must be bytes")
+        header = b"".join((
+            _SDCPCodec.serialize_uint(_SDCPFields.OPCODE, opcode),
+            _SDCPCodec.serialize_uint(_SDCPFields.FLAGS, flags),
+            _SDCPCodec.serialize_uint(_SDCPFields.TRANSACTION_ID, transaction_id),
+        ))
+        return header + payload
+
+    @staticmethod
+    def serialize_dictionary_address(index: int, subindex: int) -> bytes:
+        """Serialize a dictionary index and subindex.
+
+        Returns:
+            The fixed-width dictionary address bytes.
+
+        """
+        return _SDCPCodec.serialize_uint(_SDCPFields.INDEX, index) + _SDCPCodec.serialize_uint(
+            _SDCPFields.SUBINDEX, subindex
+        )
+
+
 @dataclass(frozen=True, repr=False)
-class _SDCPMessage:
+class _SDCPMessage(ABC):
     """Base class for typed SDCP messages."""
 
     transaction_id: int
+
+    @abstractmethod
+    def __bytes__(self) -> bytes:
+        """Serialize this message into an SDCP frame."""
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         """Return a protocol-oriented representation.
@@ -163,6 +231,17 @@ class _SDCPMessage:
 class SDCPIdentificationRequest(_SDCPMessage):
     """An SDCP Identification request."""
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Identification request.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.IDENTIFICATION, SDCPFlag.NONE, self.transaction_id
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPReadRequest(_SDCPMessage):
@@ -170,6 +249,18 @@ class SDCPReadRequest(_SDCPMessage):
 
     index: int
     subindex: int
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Read request.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.READ, SDCPFlag.NONE, self.transaction_id, payload
+        )
 
 
 @dataclass(frozen=True, repr=False)
@@ -179,6 +270,30 @@ class SDCPWriteRequest(_SDCPMessage):
     index: int
     subindex: int
     value: bytes
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Write request.
+
+        Returns:
+            The binary SDCP frame.
+
+        Raises:
+            TypeError: If the value payload is not bytes.
+            ValueError: If the value payload is empty.
+
+        """
+        if not isinstance(self.value, bytes):
+            raise TypeError("value must be bytes")
+        if not self.value:
+            raise ValueError("Write requests require a value payload")
+        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + self.value
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.WRITE,
+            SDCPFlag.NONE,
+            self.transaction_id,
+            payload,
+            payload_name="value",
+        )
 
 
 @dataclass(frozen=True, repr=False)
@@ -190,6 +305,22 @@ class SDCPPeriodicSubscriptionRequest(_SDCPMessage):
     cyclic_time_ms: int
     message_count: int
 
+    def __bytes__(self) -> bytes:
+        """Serialize this periodic Subscribe request.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + b"".join((
+            _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.PERIODIC),
+            _SDCPCodec.serialize_uint(_SDCPFields.CYCLIC_TIME_MS, self.cyclic_time_ms),
+            _SDCPCodec.serialize_uint(_SDCPFields.MESSAGE_COUNT, self.message_count),
+        ))
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.SUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPEventSubscriptionRequest(_SDCPMessage):
@@ -199,12 +330,39 @@ class SDCPEventSubscriptionRequest(_SDCPMessage):
     subindex: int
     message_count: int
 
+    def __bytes__(self) -> bytes:
+        """Serialize this event-based Subscribe request.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_dictionary_address(self.index, self.subindex) + b"".join((
+            _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.EVENT),
+            _SDCPCodec.serialize_uint(_SDCPFields.MESSAGE_COUNT, self.message_count),
+        ))
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.SUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPUnsubscribeRequest(_SDCPMessage):
     """An SDCP Unsubscribe request."""
 
     subscription_id: int
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Unsubscribe request.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_ID, self.subscription_id)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.UNSUBSCRIBE, SDCPFlag.NONE, self.transaction_id, payload
+        )
 
 
 @dataclass(frozen=True, repr=False)
@@ -216,6 +374,23 @@ class SDCPIdentificationResponse(_SDCPMessage):
     product_code: int
     revision_number: int
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Identification response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = b"".join((
+            _SDCPCodec.serialize_uint(_SDCPFields.PROTOCOL_VERSION, self.protocol_version),
+            _SDCPCodec.serialize_uint(_SDCPFields.SERIAL_NUMBER, self.serial_number),
+            _SDCPCodec.serialize_uint(_SDCPFields.PRODUCT_CODE, self.product_code),
+            _SDCPCodec.serialize_uint(_SDCPFields.REVISION_NUMBER, self.revision_number),
+        ))
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.IDENTIFICATION, SDCPFlag.REPLY, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPReadResponse(_SDCPMessage):
@@ -223,10 +398,34 @@ class SDCPReadResponse(_SDCPMessage):
 
     value: bytes
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Read response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.READ,
+            SDCPFlag.REPLY,
+            self.transaction_id,
+            self.value,
+            payload_name="value",
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPWriteResponse(_SDCPMessage):
     """An SDCP Write response."""
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Write response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        return _SDCPCodec.serialize_frame(SDCPOpcode.WRITE, SDCPFlag.REPLY, self.transaction_id)
 
 
 @dataclass(frozen=True, repr=False)
@@ -235,10 +434,33 @@ class SDCPSubscribeResponse(_SDCPMessage):
 
     subscription_id: int
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Subscribe response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.SUBSCRIPTION_ID, self.subscription_id)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.SUBSCRIBE, SDCPFlag.REPLY, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPUnsubscribeResponse(_SDCPMessage):
     """An SDCP Unsubscribe response."""
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Unsubscribe response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.UNSUBSCRIBE, SDCPFlag.REPLY, self.transaction_id
+        )
 
 
 @dataclass(frozen=True, repr=False)
@@ -252,25 +474,91 @@ class SDCPErrorResponse(_SDCPMessage):
 class SDCPIdentificationResponseError(SDCPErrorResponse):
     """An SDCP Identification error response."""
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Identification error response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.IDENTIFICATION,
+            SDCPFlag.REPLY | SDCPFlag.ERROR,
+            self.transaction_id,
+            payload,
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPReadResponseError(SDCPErrorResponse):
     """An SDCP Read error response."""
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Read error response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.READ, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
+        )
 
 
 @dataclass(frozen=True, repr=False)
 class SDCPWriteResponseError(SDCPErrorResponse):
     """An SDCP Write error response."""
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Write error response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.WRITE, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPSubscribeResponseError(SDCPErrorResponse):
     """An SDCP Subscribe error response."""
 
+    def __bytes__(self) -> bytes:
+        """Serialize this Subscribe error response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.SUBSCRIBE, SDCPFlag.REPLY | SDCPFlag.ERROR, self.transaction_id, payload
+        )
+
 
 @dataclass(frozen=True, repr=False)
 class SDCPUnsubscribeResponseError(SDCPErrorResponse):
     """An SDCP Unsubscribe error response."""
+
+    def __bytes__(self) -> bytes:
+        """Serialize this Unsubscribe error response.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        payload = _SDCPCodec.serialize_uint(_SDCPFields.ERROR_CODE, self.error_code)
+        return _SDCPCodec.serialize_frame(
+            SDCPOpcode.UNSUBSCRIBE,
+            SDCPFlag.REPLY | SDCPFlag.ERROR,
+            self.transaction_id,
+            payload,
+        )
 
 
 @dataclass(frozen=True, repr=False)
@@ -280,6 +568,17 @@ class SDCPUnknownFrame(_SDCPMessage):
     opcode: int
     flags: int
     payload: bytes
+
+    def __bytes__(self) -> bytes:
+        """Serialize this unknown frame without altering its fields.
+
+        Returns:
+            The binary SDCP frame.
+
+        """
+        return _SDCPCodec.serialize_frame(
+            self.opcode, self.flags, self.transaction_id, self.payload
+        )
 
 
 SDCPMessage = Union[
@@ -300,7 +599,7 @@ SDCPMessage = Union[
 
 
 class SDCPSerializer:
-    """Serialize and deserialize SDCP acyclic frames.
+    """Deserialize SDCP acyclic frames.
 
     SDCP uses a four-byte header with one-byte opcode and flags fields followed
     by a two-byte big-endian transaction ID. The operation-specific payload is
@@ -308,227 +607,6 @@ class SDCPSerializer:
     """
 
     HEADER_SIZE = _SDCPFields.OPCODE.size + _SDCPFields.FLAGS.size + _SDCPFields.TRANSACTION_ID.size
-    _EMPTY_RESPONSE_TYPES: ClassVar[
-        dict[SDCPOpcode, type[SDCPWriteResponse] | type[SDCPUnsubscribeResponse]]
-    ] = {
-        SDCPOpcode.WRITE: SDCPWriteResponse,
-        SDCPOpcode.UNSUBSCRIBE: SDCPUnsubscribeResponse,
-    }
-    _ERROR_RESPONSE_TYPES: ClassVar[dict[SDCPOpcode, type[SDCPErrorResponse]]] = {
-        SDCPOpcode.IDENTIFICATION: SDCPIdentificationResponseError,
-        SDCPOpcode.READ: SDCPReadResponseError,
-        SDCPOpcode.WRITE: SDCPWriteResponseError,
-        SDCPOpcode.SUBSCRIBE: SDCPSubscribeResponseError,
-        SDCPOpcode.UNSUBSCRIBE: SDCPUnsubscribeResponseError,
-    }
-
-    @classmethod
-    def serialize_identification_request(cls, transaction_id: int) -> bytes:
-        """Serialize an Identification request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        """
-        return cls._serialize_frame(SDCPOpcode.IDENTIFICATION, SDCPFlag.NONE, transaction_id)
-
-    @classmethod
-    def serialize_read_request(cls, transaction_id: int, index: int, subindex: int) -> bytes:
-        """Serialize a Read request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-            index: Dictionary index to read.
-            subindex: Dictionary subindex to read.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        """
-        return cls._serialize_dictionary_request(SDCPOpcode.READ, transaction_id, index, subindex)
-
-    @classmethod
-    def serialize_write_request(
-        cls, transaction_id: int, index: int, subindex: int, value: bytes
-    ) -> bytes:
-        """Serialize a Write request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-            index: Dictionary index to write.
-            subindex: Dictionary subindex to write.
-            value: Encoded value bytes to write.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        Raises:
-            TypeError: If the value is not bytes.
-            ValueError: If the value is empty.
-
-        """
-        cls._validate_bytes("value", value)
-        if not value:
-            raise ValueError("Write requests require a value payload")
-
-        return cls._serialize_dictionary_request(
-            SDCPOpcode.WRITE, transaction_id, index, subindex, value
-        )
-
-    @classmethod
-    def serialize_periodic_subscription_request(
-        cls,
-        transaction_id: int,
-        index: int,
-        subindex: int,
-        cyclic_time_ms: int,
-        message_count: int,
-    ) -> bytes:
-        """Serialize a periodic Subscribe request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-            index: Dictionary index to subscribe to.
-            subindex: Dictionary subindex to subscribe to.
-            cyclic_time_ms: Periodic cycle time in milliseconds.
-            message_count: Maximum notifications before expiration.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        """
-        payload = b"".join((
-            cls._serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.PERIODIC),
-            cls._serialize_uint(_SDCPFields.CYCLIC_TIME_MS, cyclic_time_ms),
-            cls._serialize_uint(_SDCPFields.MESSAGE_COUNT, message_count),
-        ))
-        return cls._serialize_dictionary_request(
-            SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
-        )
-
-    @classmethod
-    def serialize_event_subscription_request(
-        cls, transaction_id: int, index: int, subindex: int, message_count: int
-    ) -> bytes:
-        """Serialize an event-based Subscribe request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-            index: Dictionary index to subscribe to.
-            subindex: Dictionary subindex to subscribe to.
-            message_count: Maximum notifications before expiration.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        """
-        payload = cls._serialize_uint(
-            _SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.EVENT
-        ) + cls._serialize_uint(_SDCPFields.MESSAGE_COUNT, message_count)
-        return cls._serialize_dictionary_request(
-            SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
-        )
-
-    @classmethod
-    def serialize_unsubscribe_request(cls, transaction_id: int, subscription_id: int) -> bytes:
-        """Serialize an Unsubscribe request.
-
-        Args:
-            transaction_id: Request identifier in the range 0 to 65535.
-            subscription_id: Identifier of the subscription to cancel.
-
-        Returns:
-            The big-endian SDCP frame ready to send as a UDP payload.
-
-        """
-        return cls._serialize_frame(
-            SDCPOpcode.UNSUBSCRIBE,
-            SDCPFlag.NONE,
-            transaction_id,
-            cls._serialize_uint(_SDCPFields.SUBSCRIPTION_ID, subscription_id),
-        )
-
-    @classmethod
-    def serialize_success_response(
-        cls, opcode: int, transaction_id: int, payload: bytes = b""
-    ) -> bytes:
-        """Serialize a successful response.
-
-        Args:
-            opcode: Opcode of the request being answered.
-            transaction_id: Identifier of the request being answered.
-            payload: Optional operation-specific response bytes.
-
-        Returns:
-            The big-endian SDCP response frame.
-
-        """
-        return cls._serialize_frame(opcode, SDCPFlag.REPLY, transaction_id, payload)
-
-    @classmethod
-    def serialize_error_response(cls, opcode: int, transaction_id: int, error_code: int) -> bytes:
-        """Serialize an error response.
-
-        Args:
-            opcode: Opcode of the request being answered.
-            transaction_id: Identifier of the request being answered.
-            error_code: Unsigned 32-bit protocol error code.
-
-        Returns:
-            The big-endian SDCP error response frame.
-
-        """
-        return cls._serialize_frame(
-            opcode,
-            SDCPFlag.REPLY | SDCPFlag.ERROR,
-            transaction_id,
-            cls._serialize_uint(_SDCPFields.ERROR_CODE, error_code),
-        )
-
-    @classmethod
-    def _serialize_dictionary_request(
-        cls,
-        opcode: SDCPOpcode,
-        transaction_id: int,
-        index: int,
-        subindex: int,
-        payload: bytes = b"",
-    ) -> bytes:
-        """Serialize a request whose payload begins with a dictionary address.
-
-        Returns:
-            The big-endian SDCP request frame.
-
-        """
-        address = cls._serialize_uint(_SDCPFields.INDEX, index) + cls._serialize_uint(
-            _SDCPFields.SUBINDEX, subindex
-        )
-        return cls._serialize_frame(opcode, SDCPFlag.NONE, transaction_id, address + payload)
-
-    @classmethod
-    def _serialize_frame(
-        cls, opcode: int, flags: int, transaction_id: int, payload: bytes = b""
-    ) -> bytes:
-        """Serialize the common SDCP header and raw operation payload.
-
-        Returns:
-            The big-endian SDCP frame.
-
-        Raises:
-            TypeError: If the payload is not bytes.
-            ValueError: If a header field does not fit its protocol-defined size.
-
-        """
-        cls._validate_bytes("payload", payload)
-        header = b"".join((
-            cls._serialize_uint(_SDCPFields.OPCODE, opcode),
-            cls._serialize_uint(_SDCPFields.FLAGS, flags),
-            cls._serialize_uint(_SDCPFields.TRANSACTION_ID, transaction_id),
-        ))
-        return header + payload
 
     @classmethod
     def deserialize(cls, frame: bytes) -> SDCPMessage:
@@ -631,9 +709,12 @@ class SDCPSerializer:
             # Subscribe notifications cannot yet be distinguished from initial Subscribe replies.
             return cls._deserialize_subscribe_response(transaction_id, payload)
 
-        response_type = cls._EMPTY_RESPONSE_TYPES.get(operation)
-        if response_type is not None:
-            return cls._deserialize_empty_response(transaction_id, payload, response_type)
+        if operation == SDCPOpcode.WRITE:
+            _SDCPPayloadReader(payload).ensure_end()
+            return SDCPWriteResponse(transaction_id)
+        if operation == SDCPOpcode.UNSUBSCRIBE:
+            _SDCPPayloadReader(payload).ensure_end()
+            return SDCPUnsubscribeResponse(transaction_id)
 
         return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY, payload)
 
@@ -651,24 +732,6 @@ class SDCPSerializer:
         subscription_id = reader.read_uint(_SDCPFields.SUBSCRIPTION_ID)
         reader.ensure_end()
         return SDCPSubscribeResponse(transaction_id, subscription_id)
-
-    @staticmethod
-    def _deserialize_empty_response(
-        transaction_id: int,
-        payload: bytes,
-        response_type: type[SDCPWriteResponse] | type[SDCPUnsubscribeResponse],
-    ) -> SDCPWriteResponse | SDCPUnsubscribeResponse:
-        """Deserialize a response whose payload must be empty.
-
-        Returns:
-            The parsed empty response.
-
-        Raises:
-            ValueError: If the response contains a payload.
-
-        """
-        _SDCPPayloadReader(payload).ensure_end()
-        return response_type(transaction_id)
 
     @classmethod
     def _deserialize_error_response(
@@ -693,8 +756,18 @@ class SDCPSerializer:
         reader = _SDCPPayloadReader(payload)
         error_code = reader.read_uint(_SDCPFields.ERROR_CODE)
         reader.ensure_end()
-        response_type = cls._ERROR_RESPONSE_TYPES[operation]
-        return response_type(transaction_id, error_code)
+        if operation == SDCPOpcode.IDENTIFICATION:
+            return SDCPIdentificationResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.READ:
+            return SDCPReadResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.WRITE:
+            return SDCPWriteResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.SUBSCRIBE:
+            return SDCPSubscribeResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.UNSUBSCRIBE:
+            return SDCPUnsubscribeResponseError(transaction_id, error_code)
+
+        return SDCPUnknownFrame(transaction_id, opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, payload)
 
     @classmethod
     def _deserialize_identification_response(
@@ -776,39 +849,3 @@ class SDCPSerializer:
 
         """
         return reader.read_uint(_SDCPFields.INDEX), reader.read_uint(_SDCPFields.SUBINDEX)
-
-    @staticmethod
-    def _validate_uint(field: _SDCPField, value: int) -> None:
-        """Validate that an integer fits in an unsigned protocol field.
-
-        Raises:
-            TypeError: If the value is not an integer or is a boolean.
-            ValueError: If the integer cannot fit in the field.
-
-        """
-        if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(f"Value must be an integer for a {field.size}-byte field")
-        if not 0 <= value <= field.maximum_value:
-            raise ValueError(f"Value must be in the range 0 to {field.maximum_value}")
-
-    @classmethod
-    def _serialize_uint(cls, field: _SDCPField, value: int) -> bytes:
-        """Serialize an unsigned SDCP field using the protocol byte order.
-
-        Returns:
-            The fixed-width big-endian representation of the field.
-
-        """
-        cls._validate_uint(field, value)
-        return value.to_bytes(field.size, _SDCP_BYTE_ORDER)
-
-    @staticmethod
-    def _validate_bytes(field_name: str, value: bytes) -> None:
-        """Validate a raw protocol byte payload.
-
-        Raises:
-            TypeError: If the value is not bytes.
-
-        """
-        if not isinstance(value, bytes):
-            raise TypeError(f"{field_name} must be bytes")

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, fields
+from dataclasses import dataclass, fields
 from enum import IntEnum, IntFlag
-from typing import Literal, Union
+from typing import ClassVar, Literal, Union
 
 
 class SDCPOpcode(IntEnum):
@@ -32,17 +32,24 @@ class SDCPSubscriptionMode(IntEnum):
     EVENT = 0x02
 
 
+_SDCP_BYTE_ORDER: Literal["big"] = "big"
+
+
 @dataclass(frozen=True)
 class _SDCPField:
     """Metadata for a fixed-width SDCP field."""
 
     size: int
-    hex_width: int = field(init=False)
-    maximum_value: int = field(init=False)
 
-    def __post_init__(self) -> None:
-        object.__setattr__(self, "hex_width", self.size * 2)
-        object.__setattr__(self, "maximum_value", (1 << (self.size * 8)) - 1)
+    @property
+    def hex_width(self) -> int:
+        """Return the field's hexadecimal display width."""
+        return self.size * 2
+
+    @property
+    def maximum_value(self) -> int:
+        """Return the largest unsigned value that fits in the field."""
+        return (1 << (self.size * 8)) - 1
 
 
 class _SDCPFields:
@@ -62,6 +69,65 @@ class _SDCPFields:
     PRODUCT_CODE = _SDCPField(4)
     REVISION_NUMBER = _SDCPField(4)
     SUBSCRIPTION_MODE = _SDCPField(1)
+
+
+class _SDCPPayloadReader:
+    """Read sequential values from an SDCP payload."""
+
+    def __init__(self, payload: bytes) -> None:
+        if not isinstance(payload, bytes):
+            raise TypeError("Payload must be bytes")
+        self._payload = payload
+        self._offset = 0
+
+    def read_uint(self, field: _SDCPField) -> int:
+        """Read a fixed-width unsigned integer.
+
+        Returns:
+            The decoded big-endian unsigned integer.
+
+        """
+        return int.from_bytes(self.read_bytes(field.size), _SDCP_BYTE_ORDER)
+
+    def read_bytes(self, size: int) -> bytes:
+        """Read a fixed number of bytes from the current offset.
+
+        Returns:
+            The requested payload bytes.
+
+        Raises:
+            ValueError: If the payload does not contain enough bytes.
+
+        """
+        if size < 0:
+            raise ValueError("Payload read size cannot be negative")
+        end = self._offset + size
+        if end > len(self._payload):
+            remaining = len(self._payload) - self._offset
+            raise ValueError(f"Payload read requested {size} bytes, but only {remaining} remain")
+        value = self._payload[self._offset : end]
+        self._offset = end
+        return value
+
+    def read_remaining(self) -> bytes:
+        """Read all bytes remaining in the payload.
+
+        Returns:
+            The unread payload bytes.
+
+        """
+        return self.read_bytes(len(self._payload) - self._offset)
+
+    def ensure_end(self) -> None:
+        """Ensure that the payload has been consumed completely.
+
+        Raises:
+            ValueError: If the payload contains unread bytes.
+
+        """
+        if self._offset != len(self._payload):
+            trailing_bytes = len(self._payload) - self._offset
+            raise ValueError(f"Payload contains {trailing_bytes} unexpected trailing bytes")
 
 
 @dataclass(frozen=True, repr=False)
@@ -193,7 +259,7 @@ class SDCPUnsubscribeResponse(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class _SDCPErrorResponse(_SDCPMessageRepresentation):
+class SDCPErrorResponse(_SDCPMessageRepresentation):
     """Base class for operation-specific SDCP error responses."""
 
     transaction_id: int
@@ -201,27 +267,27 @@ class _SDCPErrorResponse(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPIdentificationResponseError(_SDCPErrorResponse):
+class SDCPIdentificationResponseError(SDCPErrorResponse):
     """An SDCP Identification error response."""
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPReadResponseError(_SDCPErrorResponse):
+class SDCPReadResponseError(SDCPErrorResponse):
     """An SDCP Read error response."""
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPWriteResponseError(_SDCPErrorResponse):
+class SDCPWriteResponseError(SDCPErrorResponse):
     """An SDCP Write error response."""
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPSubscribeResponseError(_SDCPErrorResponse):
+class SDCPSubscribeResponseError(SDCPErrorResponse):
     """An SDCP Subscribe error response."""
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPUnsubscribeResponseError(_SDCPErrorResponse):
+class SDCPUnsubscribeResponseError(SDCPErrorResponse):
     """An SDCP Unsubscribe error response."""
 
 
@@ -247,11 +313,7 @@ SDCPMessage = Union[
     SDCPWriteResponse,
     SDCPSubscribeResponse,
     SDCPUnsubscribeResponse,
-    SDCPIdentificationResponseError,
-    SDCPReadResponseError,
-    SDCPWriteResponseError,
-    SDCPSubscribeResponseError,
-    SDCPUnsubscribeResponseError,
+    SDCPErrorResponse,
     SDCPUnknownFrame,
 ]
 
@@ -264,8 +326,20 @@ class SDCPSerializer:
     preserved as raw bytes because its layout depends on the opcode.
     """
 
-    BYTE_ORDER: Literal["big"] = "big"
     HEADER_SIZE = _SDCPFields.OPCODE.size + _SDCPFields.FLAGS.size + _SDCPFields.TRANSACTION_ID.size
+    _EMPTY_RESPONSE_TYPES: ClassVar[
+        dict[SDCPOpcode, type[SDCPWriteResponse] | type[SDCPUnsubscribeResponse]]
+    ] = {
+        SDCPOpcode.WRITE: SDCPWriteResponse,
+        SDCPOpcode.UNSUBSCRIBE: SDCPUnsubscribeResponse,
+    }
+    _ERROR_RESPONSE_TYPES: ClassVar[dict[SDCPOpcode, type[SDCPErrorResponse]]] = {
+        SDCPOpcode.IDENTIFICATION: SDCPIdentificationResponseError,
+        SDCPOpcode.READ: SDCPReadResponseError,
+        SDCPOpcode.WRITE: SDCPWriteResponseError,
+        SDCPOpcode.SUBSCRIBE: SDCPSubscribeResponseError,
+        SDCPOpcode.UNSUBSCRIBE: SDCPUnsubscribeResponseError,
+    }
 
     @classmethod
     def serialize_identification_request(cls, transaction_id: int) -> bytes:
@@ -486,20 +560,19 @@ class SDCPSerializer:
             The decoded SDCP frame.
 
         Raises:
+            TypeError: If the frame is not bytes.
             ValueError: If the frame is shorter than the four-byte SDCP header
                 or a recognized frame has an invalid payload layout.
 
         """
+        reader = _SDCPPayloadReader(frame)
         if len(frame) < cls.HEADER_SIZE:
             raise ValueError("SDCP frame must include a four-byte header")
 
-        opcode = frame[0]
-        flags = frame[1]
-        payload = frame[cls.HEADER_SIZE :]
-        transaction_id = cls._deserialize_uint(
-            _SDCPFields.TRANSACTION_ID,
-            frame[_SDCPFields.OPCODE.size + _SDCPFields.FLAGS.size : cls.HEADER_SIZE],
-        )
+        opcode = reader.read_uint(_SDCPFields.OPCODE)
+        flags = reader.read_uint(_SDCPFields.FLAGS)
+        transaction_id = reader.read_uint(_SDCPFields.TRANSACTION_ID)
+        payload = reader.read_remaining()
         if flags == SDCPFlag.REPLY | SDCPFlag.ERROR:
             return cls._deserialize_error_response(opcode, transaction_id, payload)
         if flags == SDCPFlag.NONE:
@@ -525,25 +598,28 @@ class SDCPSerializer:
         except ValueError:
             return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
 
+        reader = _SDCPPayloadReader(payload)
         if operation == SDCPOpcode.IDENTIFICATION:
-            cls._validate_payload_size(payload, 0, "Identification request")
+            reader.ensure_end()
             return SDCPIdentificationRequest(transaction_id)
         if operation == SDCPOpcode.READ:
-            cls._validate_payload_size(payload, 3, "Read request")
-            index, subindex = cls._deserialize_dictionary_address(payload, "Read request", 0)
+            index, subindex = cls._deserialize_dictionary_address(reader)
+            reader.ensure_end()
             return SDCPReadRequest(transaction_id, index, subindex)
         if operation == SDCPOpcode.WRITE:
-            index, subindex = cls._deserialize_dictionary_address(payload, "Write request", 1)
-            return SDCPWriteRequest(transaction_id, index, subindex, payload[3:])
+            index, subindex = cls._deserialize_dictionary_address(reader)
+            value = reader.read_remaining()
+            if not value:
+                raise ValueError("Write requests require a value payload")
+            return SDCPWriteRequest(transaction_id, index, subindex, value)
         if operation == SDCPOpcode.SUBSCRIBE:
-            return cls._deserialize_subscription_request(transaction_id, payload)
+            return cls._deserialize_subscription_request(transaction_id, reader)
         if operation == SDCPOpcode.UNSUBSCRIBE:
-            cls._validate_payload_size(
-                payload, _SDCPFields.SUBSCRIPTION_ID.size, "Unsubscribe request"
-            )
+            subscription_id = reader.read_uint(_SDCPFields.SUBSCRIPTION_ID)
+            reader.ensure_end()
             return SDCPUnsubscribeRequest(
                 transaction_id,
-                cls._deserialize_uint(_SDCPFields.SUBSCRIPTION_ID, payload),
+                subscription_id,
             )
 
         return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
@@ -570,23 +646,48 @@ class SDCPSerializer:
             return cls._deserialize_identification_response(transaction_id, payload)
         if operation == SDCPOpcode.READ:
             return SDCPReadResponse(transaction_id, payload)
-        if operation == SDCPOpcode.WRITE:
-            cls._validate_payload_size(payload, 0, "Write response")
-            return SDCPWriteResponse(transaction_id)
         if operation == SDCPOpcode.SUBSCRIBE:
-            # Notification payloads cannot yet be distinguished from subscription replies.
-            cls._validate_payload_size(
-                payload, _SDCPFields.SUBSCRIPTION_ID.size, "Subscribe response"
-            )
-            return SDCPSubscribeResponse(
-                transaction_id,
-                cls._deserialize_uint(_SDCPFields.SUBSCRIPTION_ID, payload),
-            )
-        if operation == SDCPOpcode.UNSUBSCRIBE:
-            cls._validate_payload_size(payload, 0, "Unsubscribe response")
-            return SDCPUnsubscribeResponse(transaction_id)
+            # Subscribe notifications cannot yet be distinguished from initial Subscribe replies.
+            return cls._deserialize_subscribe_response(transaction_id, payload)
+
+        response_type = cls._EMPTY_RESPONSE_TYPES.get(operation)
+        if response_type is not None:
+            return cls._deserialize_empty_response(transaction_id, payload, response_type)
 
         return SDCPUnknownFrame(opcode, SDCPFlag.REPLY, transaction_id, payload)
+
+    @classmethod
+    def _deserialize_subscribe_response(
+        cls, transaction_id: int, payload: bytes
+    ) -> SDCPSubscribeResponse:
+        """Deserialize a Subscribe response containing a subscription identifier.
+
+        Returns:
+            The parsed Subscribe response.
+
+        """
+        reader = _SDCPPayloadReader(payload)
+        subscription_id = reader.read_uint(_SDCPFields.SUBSCRIPTION_ID)
+        reader.ensure_end()
+        return SDCPSubscribeResponse(transaction_id, subscription_id)
+
+    @staticmethod
+    def _deserialize_empty_response(
+        transaction_id: int,
+        payload: bytes,
+        response_type: type[SDCPWriteResponse] | type[SDCPUnsubscribeResponse],
+    ) -> SDCPWriteResponse | SDCPUnsubscribeResponse:
+        """Deserialize a response whose payload must be empty.
+
+        Returns:
+            The parsed empty response.
+
+        Raises:
+            ValueError: If the response contains a payload.
+
+        """
+        _SDCPPayloadReader(payload).ensure_end()
+        return response_type(transaction_id)
 
     @classmethod
     def _deserialize_error_response(
@@ -599,7 +700,6 @@ class SDCPSerializer:
 
         Raises:
             ValueError: If the error payload is not a 32-bit error code.
-            AssertionError: If the opcode is not a defined SDCP operation.
 
         """
         try:
@@ -609,19 +709,11 @@ class SDCPSerializer:
                 opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, transaction_id, payload
             )
 
-        cls._validate_payload_size(payload, _SDCPFields.ERROR_CODE.size, "Error response")
-        error_code = cls._deserialize_uint(_SDCPFields.ERROR_CODE, payload)
-        if operation == SDCPOpcode.IDENTIFICATION:
-            return SDCPIdentificationResponseError(transaction_id, error_code)
-        if operation == SDCPOpcode.READ:
-            return SDCPReadResponseError(transaction_id, error_code)
-        if operation == SDCPOpcode.WRITE:
-            return SDCPWriteResponseError(transaction_id, error_code)
-        if operation == SDCPOpcode.SUBSCRIBE:
-            return SDCPSubscribeResponseError(transaction_id, error_code)
-        if operation == SDCPOpcode.UNSUBSCRIBE:
-            return SDCPUnsubscribeResponseError(transaction_id, error_code)
-        raise AssertionError(f"Unsupported SDCP opcode: {operation}")
+        reader = _SDCPPayloadReader(payload)
+        error_code = reader.read_uint(_SDCPFields.ERROR_CODE)
+        reader.ensure_end()
+        response_type = cls._ERROR_RESPONSE_TYPES[operation]
+        return response_type(transaction_id, error_code)
 
     @classmethod
     def _deserialize_identification_response(
@@ -633,37 +725,26 @@ class SDCPSerializer:
             The parsed Identification response.
 
         Raises:
-            ValueError: If the payload is not the fixed 13-byte layout.
+            ValueError: If the payload is not the fixed 13-byte layout. SDCP
+                Identification responses with a 9-byte firmware layout are not
+                supported because the public message requires a revision number.
 
         """
-        fields = (
-            _SDCPFields.PROTOCOL_VERSION,
-            _SDCPFields.SERIAL_NUMBER,
-            _SDCPFields.PRODUCT_CODE,
-            _SDCPFields.REVISION_NUMBER,
-        )
-        cls._validate_payload_size(
-            payload, sum(field.size for field in fields), "Identification response"
-        )
-        protocol_version_end = _SDCPFields.PROTOCOL_VERSION.size
-        serial_number_end = protocol_version_end + _SDCPFields.SERIAL_NUMBER.size
-        product_code_end = serial_number_end + _SDCPFields.PRODUCT_CODE.size
-        return SDCPIdentificationResponse(
+        reader = _SDCPPayloadReader(payload)
+        response = SDCPIdentificationResponse(
             transaction_id,
-            cls._deserialize_uint(_SDCPFields.PROTOCOL_VERSION, payload[:protocol_version_end]),
-            cls._deserialize_uint(
-                _SDCPFields.SERIAL_NUMBER,
-                payload[protocol_version_end:serial_number_end],
-            ),
-            cls._deserialize_uint(
-                _SDCPFields.PRODUCT_CODE,
-                payload[serial_number_end:product_code_end],
-            ),
-            cls._deserialize_uint(_SDCPFields.REVISION_NUMBER, payload[product_code_end:]),
+            reader.read_uint(_SDCPFields.PROTOCOL_VERSION),
+            reader.read_uint(_SDCPFields.SERIAL_NUMBER),
+            reader.read_uint(_SDCPFields.PRODUCT_CODE),
+            reader.read_uint(_SDCPFields.REVISION_NUMBER),
         )
+        reader.ensure_end()
+        return response
 
     @classmethod
-    def _deserialize_subscription_request(cls, transaction_id: int, payload: bytes) -> SDCPMessage:
+    def _deserialize_subscription_request(
+        cls, transaction_id: int, reader: _SDCPPayloadReader
+    ) -> SDCPMessage:
         """Deserialize a Subscribe request into its mode-specific message type.
 
         Returns:
@@ -673,58 +754,47 @@ class SDCPSerializer:
             ValueError: If the subscription payload is malformed.
 
         """
-        index, subindex = cls._deserialize_dictionary_address(payload, "Subscribe request", 3)
+        index, subindex = cls._deserialize_dictionary_address(reader)
+        mode_value = reader.read_uint(_SDCPFields.SUBSCRIPTION_MODE)
         try:
-            mode = SDCPSubscriptionMode(payload[3])
+            mode = SDCPSubscriptionMode(mode_value)
         except ValueError as error:
-            raise ValueError("Subscribe request has an unknown subscription mode") from error
+            raise ValueError(
+                f"Subscribe request has an unknown subscription mode: 0x{mode_value:02X}"
+            ) from error
 
         if mode == SDCPSubscriptionMode.PERIODIC:
-            cls._validate_payload_size(payload, 8, "Periodic Subscribe request")
-            return SDCPPeriodicSubscriptionRequest(
+            request: SDCPPeriodicSubscriptionRequest | SDCPEventSubscriptionRequest = (
+                SDCPPeriodicSubscriptionRequest(
+                    transaction_id,
+                    index,
+                    subindex,
+                    reader.read_uint(_SDCPFields.CYCLIC_TIME_MS),
+                    reader.read_uint(_SDCPFields.MESSAGE_COUNT),
+                )
+            )
+        else:
+            request = SDCPEventSubscriptionRequest(
                 transaction_id,
                 index,
                 subindex,
-                cls._deserialize_uint(_SDCPFields.CYCLIC_TIME_MS, payload[4:6]),
-                cls._deserialize_uint(_SDCPFields.MESSAGE_COUNT, payload[6:8]),
+                reader.read_uint(_SDCPFields.MESSAGE_COUNT),
             )
+        reader.ensure_end()
+        return request
 
-        cls._validate_payload_size(payload, 6, "Event Subscribe request")
-        return SDCPEventSubscriptionRequest(
-            transaction_id,
-            index,
-            subindex,
-            cls._deserialize_uint(_SDCPFields.MESSAGE_COUNT, payload[4:6]),
-        )
-
-    @classmethod
-    def _deserialize_dictionary_address(
-        cls, payload: bytes, message_name: str, trailing_payload_size: int
-    ) -> tuple[int, int]:
-        """Deserialize an address prefix from a dictionary request payload.
+    @staticmethod
+    def _deserialize_dictionary_address(reader: _SDCPPayloadReader) -> tuple[int, int]:
+        """Deserialize a dictionary address from the current payload position.
 
         Returns:
             The dictionary index and subindex.
 
         Raises:
-            ValueError: If the payload cannot contain the address and trailing fields.
+            ValueError: If the payload cannot contain the address.
 
         """
-        minimum_size = _SDCPFields.INDEX.size + _SDCPFields.SUBINDEX.size + trailing_payload_size
-        if len(payload) < minimum_size:
-            raise ValueError(f"{message_name} payload is incomplete")
-        return cls._deserialize_uint(_SDCPFields.INDEX, payload[:2]), payload[2]
-
-    @staticmethod
-    def _validate_payload_size(payload: bytes, expected_size: int, message_name: str) -> None:
-        """Validate the exact payload size of a fixed-layout message.
-
-        Raises:
-            ValueError: If the payload size does not match the message layout.
-
-        """
-        if len(payload) != expected_size:
-            raise ValueError(f"{message_name} payload must contain {expected_size} bytes")
+        return reader.read_uint(_SDCPFields.INDEX), reader.read_uint(_SDCPFields.SUBINDEX)
 
     @staticmethod
     def _validate_uint(field: _SDCPField, value: int) -> None:
@@ -749,22 +819,7 @@ class SDCPSerializer:
 
         """
         cls._validate_uint(field, value)
-        return value.to_bytes(field.size, cls.BYTE_ORDER)
-
-    @classmethod
-    def _deserialize_uint(cls, field: _SDCPField, value: bytes) -> int:
-        """Deserialize an unsigned SDCP field using the protocol byte order.
-
-        Returns:
-            The decoded unsigned integer.
-
-        Raises:
-            ValueError: If the byte value is not the field's fixed width.
-
-        """
-        if len(value) != field.size:
-            raise ValueError(f"Value must contain {field.size} bytes")
-        return int.from_bytes(value, cls.BYTE_ORDER)
+        return value.to_bytes(field.size, _SDCP_BYTE_ORDER)
 
     @staticmethod
     def _validate_bytes(field_name: str, value: bytes) -> None:

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, fields
-from enum import Enum, IntEnum, IntFlag
+from dataclasses import dataclass, field, fields
+from enum import IntEnum, IntFlag
 from typing import Literal, Union
 
 
@@ -32,27 +32,36 @@ class SDCPSubscriptionMode(IntEnum):
     EVENT = 0x02
 
 
-class _SDCPField(Enum):
-    """Sizes in bytes of fixed-width SDCP fields."""
+@dataclass(frozen=True)
+class _SDCPField:
+    """Metadata for a fixed-width SDCP field."""
 
-    OPCODE = ("opcode", 1)
-    FLAGS = ("flags", 1)
-    TRANSACTION_ID = ("transaction_id", 2)
-    INDEX = ("index", 2)
-    SUBINDEX = ("subindex", 1)
-    SUBSCRIPTION_ID = ("subscription_id", 2)
-    CYCLIC_TIME_MS = ("cyclic_time_ms", 2)
-    MESSAGE_COUNT = ("message_count", 2)
-    ERROR_CODE = ("error_code", 4)
-    PROTOCOL_VERSION = ("protocol_version", 1)
-    SERIAL_NUMBER = ("serial_number", 4)
-    PRODUCT_CODE = ("product_code", 4)
-    REVISION_NUMBER = ("revision_number", 4)
+    size: int
+    hex_width: int = field(init=False)
+    maximum_value: int = field(init=False)
 
-    @property
-    def size(self) -> int:
-        """Return the fixed size of the protocol field in bytes."""
-        return self.value[1]
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "hex_width", self.size * 2)
+        object.__setattr__(self, "maximum_value", (1 << (self.size * 8)) - 1)
+
+
+class _SDCPFields:
+    """Fixed-width SDCP field definitions."""
+
+    OPCODE = _SDCPField(1)
+    FLAGS = _SDCPField(1)
+    TRANSACTION_ID = _SDCPField(2)
+    INDEX = _SDCPField(2)
+    SUBINDEX = _SDCPField(1)
+    SUBSCRIPTION_ID = _SDCPField(2)
+    CYCLIC_TIME_MS = _SDCPField(2)
+    MESSAGE_COUNT = _SDCPField(2)
+    ERROR_CODE = _SDCPField(4)
+    PROTOCOL_VERSION = _SDCPField(1)
+    SERIAL_NUMBER = _SDCPField(4)
+    PRODUCT_CODE = _SDCPField(4)
+    REVISION_NUMBER = _SDCPField(4)
+    SUBSCRIPTION_MODE = _SDCPField(1)
 
 
 @dataclass(frozen=True, repr=False)
@@ -77,8 +86,8 @@ class _SDCPMessageRepresentation:
                 except ValueError:
                     formatted_value = f"0x{value:02X}"
             elif isinstance(value, int):
-                protocol_field = _SDCPField.__members__.get(message_field.name.upper())
-                width = protocol_field.size * 2 if protocol_field else 0
+                protocol_field = getattr(_SDCPFields, message_field.name.upper(), None)
+                width = protocol_field.hex_width if protocol_field else 0
                 formatted_value = f"0x{value:0{width}X}" if width else f"0x{value:X}"
             else:
                 formatted_value = repr(value)
@@ -256,7 +265,7 @@ class SDCPSerializer:
     """
 
     BYTE_ORDER: Literal["big"] = "big"
-    HEADER_SIZE = _SDCPField.OPCODE.size + _SDCPField.FLAGS.size + _SDCPField.TRANSACTION_ID.size
+    HEADER_SIZE = _SDCPFields.OPCODE.size + _SDCPFields.FLAGS.size + _SDCPFields.TRANSACTION_ID.size
 
     @classmethod
     def serialize_identification_request(cls, transaction_id: int) -> bytes:
@@ -336,12 +345,10 @@ class SDCPSerializer:
             The big-endian SDCP frame ready to send as a UDP payload.
 
         """
-        cls._validate_uint(_SDCPField.CYCLIC_TIME_MS, cyclic_time_ms)
-        cls._validate_uint(_SDCPField.MESSAGE_COUNT, message_count)
         payload = b"".join((
-            cls._serialize_uint(_SDCPField.OPCODE, SDCPSubscriptionMode.PERIODIC),
-            cls._serialize_uint(_SDCPField.CYCLIC_TIME_MS, cyclic_time_ms),
-            cls._serialize_uint(_SDCPField.MESSAGE_COUNT, message_count),
+            cls._serialize_uint(_SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.PERIODIC),
+            cls._serialize_uint(_SDCPFields.CYCLIC_TIME_MS, cyclic_time_ms),
+            cls._serialize_uint(_SDCPFields.MESSAGE_COUNT, message_count),
         ))
         return cls._serialize_dictionary_request(
             SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
@@ -364,8 +371,8 @@ class SDCPSerializer:
 
         """
         payload = cls._serialize_uint(
-            _SDCPField.OPCODE, SDCPSubscriptionMode.EVENT
-        ) + cls._serialize_uint(_SDCPField.MESSAGE_COUNT, message_count)
+            _SDCPFields.SUBSCRIPTION_MODE, SDCPSubscriptionMode.EVENT
+        ) + cls._serialize_uint(_SDCPFields.MESSAGE_COUNT, message_count)
         return cls._serialize_dictionary_request(
             SDCPOpcode.SUBSCRIBE, transaction_id, index, subindex, payload
         )
@@ -386,7 +393,7 @@ class SDCPSerializer:
             SDCPOpcode.UNSUBSCRIBE,
             SDCPFlag.NONE,
             transaction_id,
-            cls._serialize_uint(_SDCPField.SUBSCRIPTION_ID, subscription_id),
+            cls._serialize_uint(_SDCPFields.SUBSCRIPTION_ID, subscription_id),
         )
 
     @classmethod
@@ -423,7 +430,7 @@ class SDCPSerializer:
             opcode,
             SDCPFlag.REPLY | SDCPFlag.ERROR,
             transaction_id,
-            cls._serialize_uint(_SDCPField.ERROR_CODE, error_code),
+            cls._serialize_uint(_SDCPFields.ERROR_CODE, error_code),
         )
 
     @classmethod
@@ -441,8 +448,8 @@ class SDCPSerializer:
             The big-endian SDCP request frame.
 
         """
-        address = cls._serialize_uint(_SDCPField.INDEX, index) + cls._serialize_uint(
-            _SDCPField.SUBINDEX, subindex
+        address = cls._serialize_uint(_SDCPFields.INDEX, index) + cls._serialize_uint(
+            _SDCPFields.SUBINDEX, subindex
         )
         return cls._serialize_frame(opcode, SDCPFlag.NONE, transaction_id, address + payload)
 
@@ -462,9 +469,9 @@ class SDCPSerializer:
         """
         cls._validate_bytes("payload", payload)
         header = b"".join((
-            cls._serialize_uint(_SDCPField.OPCODE, opcode),
-            cls._serialize_uint(_SDCPField.FLAGS, flags),
-            cls._serialize_uint(_SDCPField.TRANSACTION_ID, transaction_id),
+            cls._serialize_uint(_SDCPFields.OPCODE, opcode),
+            cls._serialize_uint(_SDCPFields.FLAGS, flags),
+            cls._serialize_uint(_SDCPFields.TRANSACTION_ID, transaction_id),
         ))
         return header + payload
 
@@ -490,8 +497,8 @@ class SDCPSerializer:
         flags = frame[1]
         payload = frame[cls.HEADER_SIZE :]
         transaction_id = cls._deserialize_uint(
-            _SDCPField.TRANSACTION_ID,
-            frame[_SDCPField.OPCODE.size + _SDCPField.FLAGS.size : cls.HEADER_SIZE],
+            _SDCPFields.TRANSACTION_ID,
+            frame[_SDCPFields.OPCODE.size + _SDCPFields.FLAGS.size : cls.HEADER_SIZE],
         )
         if flags == SDCPFlag.REPLY | SDCPFlag.ERROR:
             return cls._deserialize_error_response(opcode, transaction_id, payload)
@@ -532,10 +539,11 @@ class SDCPSerializer:
             return cls._deserialize_subscription_request(transaction_id, payload)
         if operation == SDCPOpcode.UNSUBSCRIBE:
             cls._validate_payload_size(
-                payload, _SDCPField.SUBSCRIPTION_ID.size, "Unsubscribe request"
+                payload, _SDCPFields.SUBSCRIPTION_ID.size, "Unsubscribe request"
             )
             return SDCPUnsubscribeRequest(
-                transaction_id, cls._deserialize_uint(_SDCPField.SUBSCRIPTION_ID, payload)
+                transaction_id,
+                cls._deserialize_uint(_SDCPFields.SUBSCRIPTION_ID, payload),
             )
 
         return SDCPUnknownFrame(opcode, SDCPFlag.NONE, transaction_id, payload)
@@ -568,10 +576,11 @@ class SDCPSerializer:
         if operation == SDCPOpcode.SUBSCRIBE:
             # Notification payloads cannot yet be distinguished from subscription replies.
             cls._validate_payload_size(
-                payload, _SDCPField.SUBSCRIPTION_ID.size, "Subscribe response"
+                payload, _SDCPFields.SUBSCRIPTION_ID.size, "Subscribe response"
             )
             return SDCPSubscribeResponse(
-                transaction_id, cls._deserialize_uint(_SDCPField.SUBSCRIPTION_ID, payload)
+                transaction_id,
+                cls._deserialize_uint(_SDCPFields.SUBSCRIPTION_ID, payload),
             )
         if operation == SDCPOpcode.UNSUBSCRIBE:
             cls._validate_payload_size(payload, 0, "Unsubscribe response")
@@ -600,8 +609,8 @@ class SDCPSerializer:
                 opcode, SDCPFlag.REPLY | SDCPFlag.ERROR, transaction_id, payload
             )
 
-        cls._validate_payload_size(payload, _SDCPField.ERROR_CODE.size, "Error response")
-        error_code = cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
+        cls._validate_payload_size(payload, _SDCPFields.ERROR_CODE.size, "Error response")
+        error_code = cls._deserialize_uint(_SDCPFields.ERROR_CODE, payload)
         if operation == SDCPOpcode.IDENTIFICATION:
             return SDCPIdentificationResponseError(transaction_id, error_code)
         if operation == SDCPOpcode.READ:
@@ -628,27 +637,29 @@ class SDCPSerializer:
 
         """
         fields = (
-            _SDCPField.PROTOCOL_VERSION,
-            _SDCPField.SERIAL_NUMBER,
-            _SDCPField.PRODUCT_CODE,
-            _SDCPField.REVISION_NUMBER,
+            _SDCPFields.PROTOCOL_VERSION,
+            _SDCPFields.SERIAL_NUMBER,
+            _SDCPFields.PRODUCT_CODE,
+            _SDCPFields.REVISION_NUMBER,
         )
         cls._validate_payload_size(
             payload, sum(field.size for field in fields), "Identification response"
         )
-        protocol_version_end = _SDCPField.PROTOCOL_VERSION.size
-        serial_number_end = protocol_version_end + _SDCPField.SERIAL_NUMBER.size
-        product_code_end = serial_number_end + _SDCPField.PRODUCT_CODE.size
+        protocol_version_end = _SDCPFields.PROTOCOL_VERSION.size
+        serial_number_end = protocol_version_end + _SDCPFields.SERIAL_NUMBER.size
+        product_code_end = serial_number_end + _SDCPFields.PRODUCT_CODE.size
         return SDCPIdentificationResponse(
             transaction_id,
-            cls._deserialize_uint(_SDCPField.PROTOCOL_VERSION, payload[:protocol_version_end]),
+            cls._deserialize_uint(_SDCPFields.PROTOCOL_VERSION, payload[:protocol_version_end]),
             cls._deserialize_uint(
-                _SDCPField.SERIAL_NUMBER, payload[protocol_version_end:serial_number_end]
+                _SDCPFields.SERIAL_NUMBER,
+                payload[protocol_version_end:serial_number_end],
             ),
             cls._deserialize_uint(
-                _SDCPField.PRODUCT_CODE, payload[serial_number_end:product_code_end]
+                _SDCPFields.PRODUCT_CODE,
+                payload[serial_number_end:product_code_end],
             ),
-            cls._deserialize_uint(_SDCPField.REVISION_NUMBER, payload[product_code_end:]),
+            cls._deserialize_uint(_SDCPFields.REVISION_NUMBER, payload[product_code_end:]),
         )
 
     @classmethod
@@ -674,8 +685,8 @@ class SDCPSerializer:
                 transaction_id,
                 index,
                 subindex,
-                cls._deserialize_uint(_SDCPField.CYCLIC_TIME_MS, payload[4:6]),
-                cls._deserialize_uint(_SDCPField.MESSAGE_COUNT, payload[6:8]),
+                cls._deserialize_uint(_SDCPFields.CYCLIC_TIME_MS, payload[4:6]),
+                cls._deserialize_uint(_SDCPFields.MESSAGE_COUNT, payload[6:8]),
             )
 
         cls._validate_payload_size(payload, 6, "Event Subscribe request")
@@ -683,7 +694,7 @@ class SDCPSerializer:
             transaction_id,
             index,
             subindex,
-            cls._deserialize_uint(_SDCPField.MESSAGE_COUNT, payload[4:6]),
+            cls._deserialize_uint(_SDCPFields.MESSAGE_COUNT, payload[4:6]),
         )
 
     @classmethod
@@ -699,10 +710,10 @@ class SDCPSerializer:
             ValueError: If the payload cannot contain the address and trailing fields.
 
         """
-        minimum_size = _SDCPField.INDEX.size + _SDCPField.SUBINDEX.size + trailing_payload_size
+        minimum_size = _SDCPFields.INDEX.size + _SDCPFields.SUBINDEX.size + trailing_payload_size
         if len(payload) < minimum_size:
             raise ValueError(f"{message_name} payload is incomplete")
-        return cls._deserialize_uint(_SDCPField.INDEX, payload[:2]), payload[2]
+        return cls._deserialize_uint(_SDCPFields.INDEX, payload[:2]), payload[2]
 
     @staticmethod
     def _validate_payload_size(payload: bytes, expected_size: int, message_name: str) -> None:
@@ -725,10 +736,9 @@ class SDCPSerializer:
 
         """
         if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(f"{field.name.lower()} must be an integer")
-        maximum_value = (1 << (field.size * 8)) - 1
-        if not 0 <= value <= maximum_value:
-            raise ValueError(f"{field.name.lower()} must be in the range 0 to {maximum_value}")
+            raise TypeError(f"Value must be an integer for a {field.size}-byte field")
+        if not 0 <= value <= field.maximum_value:
+            raise ValueError(f"Value must be in the range 0 to {field.maximum_value}")
 
     @classmethod
     def _serialize_uint(cls, field: _SDCPField, value: int) -> bytes:
@@ -753,7 +763,7 @@ class SDCPSerializer:
 
         """
         if len(value) != field.size:
-            raise ValueError(f"{field.name.lower()} must contain {field.size} bytes")
+            raise ValueError(f"Value must contain {field.size} bytes")
         return int.from_bytes(value, cls.BYTE_ORDER)
 
     @staticmethod

--- a/ingenialink/utils/sdcp.py
+++ b/ingenialink/utils/sdcp.py
@@ -54,11 +54,6 @@ class _SDCPField(Enum):
         """Return the fixed size of the protocol field in bytes."""
         return self.value[1]
 
-    @property
-    def display_as_hex(self) -> bool:
-        """Return whether the field should use hexadecimal representation."""
-        return self not in {_SDCPField.CYCLIC_TIME_MS, _SDCPField.MESSAGE_COUNT}
-
 
 @dataclass(frozen=True, repr=False)
 class _SDCPMessageRepresentation:
@@ -83,10 +78,8 @@ class _SDCPMessageRepresentation:
                     formatted_value = f"0x{value:02X}"
             elif isinstance(value, int):
                 protocol_field = _SDCPField.__members__.get(message_field.name.upper())
-                if protocol_field and protocol_field.display_as_hex:
-                    formatted_value = f"0x{value:0{protocol_field.size * 2}X}"
-                else:
-                    formatted_value = str(value)
+                width = protocol_field.size * 2 if protocol_field else 0
+                formatted_value = f"0x{value:0{width}X}" if width else f"0x{value:X}"
             else:
                 formatted_value = repr(value)
             formatted_fields.append(f"{message_field.name}={formatted_value}")
@@ -191,12 +184,36 @@ class SDCPUnsubscribeResponse(_SDCPMessageRepresentation):
 
 
 @dataclass(frozen=True, repr=False)
-class SDCPErrorResponse(_SDCPMessageRepresentation):
-    """An SDCP error response."""
+class _SDCPErrorResponse(_SDCPMessageRepresentation):
+    """Base class for operation-specific SDCP error responses."""
 
-    opcode: SDCPOpcode
     transaction_id: int
     error_code: int
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPIdentificationResponseError(_SDCPErrorResponse):
+    """An SDCP Identification error response."""
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPReadResponseError(_SDCPErrorResponse):
+    """An SDCP Read error response."""
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPWriteResponseError(_SDCPErrorResponse):
+    """An SDCP Write error response."""
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPSubscribeResponseError(_SDCPErrorResponse):
+    """An SDCP Subscribe error response."""
+
+
+@dataclass(frozen=True, repr=False)
+class SDCPUnsubscribeResponseError(_SDCPErrorResponse):
+    """An SDCP Unsubscribe error response."""
 
 
 @dataclass(frozen=True, repr=False)
@@ -221,7 +238,11 @@ SDCPMessage = Union[
     SDCPWriteResponse,
     SDCPSubscribeResponse,
     SDCPUnsubscribeResponse,
-    SDCPErrorResponse,
+    SDCPIdentificationResponseError,
+    SDCPReadResponseError,
+    SDCPWriteResponseError,
+    SDCPSubscribeResponseError,
+    SDCPUnsubscribeResponseError,
     SDCPUnknownFrame,
 ]
 
@@ -569,6 +590,7 @@ class SDCPSerializer:
 
         Raises:
             ValueError: If the error payload is not a 32-bit error code.
+            AssertionError: If the opcode is not a defined SDCP operation.
 
         """
         try:
@@ -579,9 +601,18 @@ class SDCPSerializer:
             )
 
         cls._validate_payload_size(payload, _SDCPField.ERROR_CODE.size, "Error response")
-        return SDCPErrorResponse(
-            operation, transaction_id, cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
-        )
+        error_code = cls._deserialize_uint(_SDCPField.ERROR_CODE, payload)
+        if operation == SDCPOpcode.IDENTIFICATION:
+            return SDCPIdentificationResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.READ:
+            return SDCPReadResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.WRITE:
+            return SDCPWriteResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.SUBSCRIBE:
+            return SDCPSubscribeResponseError(transaction_id, error_code)
+        if operation == SDCPOpcode.UNSUBSCRIBE:
+            return SDCPUnsubscribeResponseError(transaction_id, error_code)
+        raise AssertionError(f"Unsupported SDCP opcode: {operation}")
 
     @classmethod
     def _deserialize_identification_response(

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -86,6 +86,10 @@ def test_serialize_responses() -> None:
         ("040012342E4D000207D0", SDCPEventSubscriptionRequest(0x1234, 0x2E4D, 0x00, 2000)),
         ("050012345678", SDCPUnsubscribeRequest(0x1234, 0x5678)),
         (
+            "01011234001234567890ABCDEF",
+            SDCPIdentifyResponse(0x1234, bytes.fromhex("001234567890ABCDEF")),
+        ),
+        (
             "01011234001234567890ABCDEF00000000",
             SDCPIdentifyResponse(0x1234, bytes.fromhex("001234567890ABCDEF00000000")),
         ),
@@ -93,7 +97,7 @@ def test_serialize_responses() -> None:
         ("03011234", SDCPWriteResponse(0x1234)),
         ("040112345678", SDCPSubscribeResponse(0x1234, 0x5678)),
         ("05011234", SDCPUnsubscribeResponse(0x1234)),
-        ("02031236FFFF0001", SDCPErrorResponse(0x02, 0x1236, 0xFFFF0001)),
+        ("02031234FFFF0001", SDCPErrorResponse(0x02, 0x1234, 0xFFFF0001)),
     ],
 )
 def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
@@ -101,11 +105,18 @@ def test_deserialize_frame_matches_expected_message(frame: str, expected_message
     assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_message
 
 
-def test_deserialize_unknown_frame() -> None:
-    """Preserve unrecognized opcode and flag combinations without guessing their layout."""
-    decoded_message = SDCPSerializer.deserialize(bytes.fromhex("FF801234ABCD"))
+@pytest.mark.parametrize(
+    "frame, expected_message",
+    [
+        ("FF001234ABCD", SDCPUnknownFrame(0xFF, 0x00, 0x1234, bytes.fromhex("ABCD"))),
+        ("02801234ABCD", SDCPUnknownFrame(0x02, 0x80, 0x1234, bytes.fromhex("ABCD"))),
+    ],
+)
+def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFrame) -> None:
+    """Preserve unsupported opcodes and flags without guessing their layout."""
+    decoded_message = SDCPSerializer.deserialize(bytes.fromhex(frame))
 
-    assert decoded_message == SDCPUnknownFrame(0xFF, 0x80, 0x1234, bytes.fromhex("ABCD"))
+    assert decoded_message == expected_message
 
 
 def test_message_representation_uses_hexadecimal_values() -> None:
@@ -129,6 +140,7 @@ def test_message_representation_uses_hexadecimal_values() -> None:
         "01",
         "010012",
         "02001234",  # Read request is missing its dictionary address.
+        "0200123426E60000",  # Read request cannot contain trailing payload bytes.
         "0301123400",  # Write success responses cannot contain payload bytes.
         "02031234FFFF",  # Error responses require a 32-bit error code.
         "04001234203100010064",  # Periodic subscription is missing its message count.
@@ -147,6 +159,8 @@ def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
         (SDCPSerializer.serialize_read_request, (0x1234, 0x1_0000, 0x00)),
         (SDCPSerializer.serialize_read_request, (0x1234, 0x100B, 0x100)),
         (SDCPSerializer.serialize_unsubscribe_request, (0x1234, 0x1_0000)),
+        (SDCPSerializer.serialize_error_response, (0x02, 0x1234, 0x1_0000_0000)),
+        (SDCPSerializer.serialize_periodic_subscription_request, (-1, 0x2031, 0x00, 100, 2000)),
     ],
 )
 def test_serialize_rejects_out_of_range_fields(
@@ -155,6 +169,38 @@ def test_serialize_rejects_out_of_range_fields(
     """Reject public-builder fields that cannot fit their protocol positions."""
     with pytest.raises(ValueError):
         serializer(*arguments)  # type: ignore[operator]
+
+
+@pytest.mark.parametrize(
+    "serializer, arguments",
+    [
+        (SDCPSerializer.serialize_identify_request, (True,)),
+        (SDCPSerializer.serialize_read_request, (0x1234, "0x100B", 0x00)),
+        (SDCPSerializer.serialize_unsubscribe_request, (0x1234, False)),
+        (SDCPSerializer.serialize_error_response, (0x02, 0x1234, 1.0)),
+    ],
+)
+def test_serialize_rejects_invalid_uint_types(
+    serializer: object, arguments: tuple[object, ...]
+) -> None:
+    """Reject non-integer and boolean values for unsigned protocol fields."""
+    with pytest.raises(TypeError):
+        serializer(*arguments)  # type: ignore[operator]
+
+
+@pytest.mark.parametrize("value", [b"", "value", bytearray(b"value")])
+def test_serialize_rejects_invalid_write_values(value: object) -> None:
+    """Require a non-empty bytes value payload for a Write request."""
+    expected_exception = ValueError if value == b"" else TypeError
+    with pytest.raises(expected_exception):
+        SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("payload", ["payload", bytearray(b"payload")])
+def test_serialize_rejects_invalid_response_payload_types(payload: object) -> None:
+    """Require raw response payloads to be immutable bytes."""
+    with pytest.raises(TypeError):
+        SDCPSerializer.serialize_success_response(0x02, 0x1234, payload)  # type: ignore[arg-type]
 
 
 def test_serialize_rejects_empty_write_value() -> None:

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -1,190 +1,163 @@
-"""Tests for SDCP acyclic frame serialization."""
+"""Tests for SDCP message serialization and deserialization."""
 
 from __future__ import annotations
 
 import pytest
 
-from ingenialink.utils.sdcp import SDCPFlag, SDCPFrame, SDCPOpcode, SDCPSerializer
+from ingenialink.utils.sdcp import (
+    SDCPErrorResponse,
+    SDCPEventSubscriptionRequest,
+    SDCPIdentifyRequest,
+    SDCPIdentifyResponse,
+    SDCPPeriodicSubscriptionRequest,
+    SDCPReadRequest,
+    SDCPReadResponse,
+    SDCPSerializer,
+    SDCPSubscribeResponse,
+    SDCPUnknownFrame,
+    SDCPUnsubscribeRequest,
+    SDCPUnsubscribeResponse,
+    SDCPWriteRequest,
+    SDCPWriteResponse,
+)
+
+
+def test_serialize_identify_request() -> None:
+    """Serialize the Identify request from the SDCP protocol specification."""
+    assert SDCPSerializer.serialize_identify_request(0x1234) == bytes.fromhex("01001234")
 
 
 def test_serialize_read_request() -> None:
-    """Serialize the read request from the SDCP protocol specification."""
-    frame = SDCPSerializer.serialize(
-        SDCPOpcode.READ,
-        SDCPFlag.NONE,
-        0x1234,
-        0x26E6,
-        0x00,
+    """Serialize the Read request from the SDCP protocol specification."""
+    assert SDCPSerializer.serialize_read_request(0x1234, 0x26E6, 0x00) == bytes.fromhex(
+        "0200123426E600"
     )
-
-    # The transaction ID is encoded as the big-endian bytes 12 34.
-    assert frame == bytes.fromhex("0200123426E600")
 
 
 def test_serialize_write_request() -> None:
     """Serialize the Write request from the SDCP protocol specification."""
-    frame = SDCPSerializer.serialize(
-        SDCPOpcode.WRITE,
-        SDCPFlag.NONE,
-        0x1234,
-        0x2821,
-        0x00,
-        bytes.fromhex("42C80000"),
-    )
+    frame = SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
 
-    # The value bytes follow the index and subindex fields.
     assert frame == bytes.fromhex("0300123428210042C80000")
 
 
-def test_deserialize_read_response() -> None:
-    """Deserialize the successful read response from the specification."""
-    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("0201123412345678"))
+def test_serialize_subscription_requests() -> None:
+    """Serialize both subscription request layouts from the specification."""
+    periodic_frame = SDCPSerializer.serialize_periodic_subscription_request(
+        0x1234, 0x2031, 0x00, 100, 2000
+    )
+    event_frame = SDCPSerializer.serialize_event_subscription_request(0x1234, 0x2E4D, 0x00, 2000)
 
-    assert decoded_frame.opcode == SDCPOpcode.READ
-    assert decoded_frame.flags == SDCPFlag.REPLY
-    assert decoded_frame.transaction_id == 0x1234
-    assert decoded_frame.payload == bytes.fromhex("12345678")
-    assert decoded_frame.index is None
-    assert decoded_frame.subindex is None
+    assert periodic_frame == bytes.fromhex("0400123420310001006407D0")
+    assert event_frame == bytes.fromhex("040012342E4D000207D0")
+
+
+def test_serialize_unsubscribe_request() -> None:
+    """Serialize the Unsubscribe request using its dedicated opcode."""
+    assert SDCPSerializer.serialize_unsubscribe_request(0x1234, 0x5678) == bytes.fromhex(
+        "050012345678"
+    )
+
+
+def test_serialize_responses() -> None:
+    """Serialize successful and error responses with their dedicated builders."""
+    success_frame = SDCPSerializer.serialize_success_response(
+        0x02, 0x1234, bytes.fromhex("12345678")
+    )
+    error_frame = SDCPSerializer.serialize_error_response(0x02, 0x1234, 0x06020000)
+
+    assert success_frame == bytes.fromhex("0201123412345678")
+    assert error_frame == bytes.fromhex("0203123406020000")
 
 
 @pytest.mark.parametrize(
-    "frame, expected_frame",
+    "frame, expected_message",
     [
-        # Read requests contain only the dictionary address after the header.
-        (
-            "02001236100B00",
-            SDCPFrame(SDCPOpcode.READ, SDCPFlag.NONE, 0x1236, b"", 0x100B, 0x00),
-        ),
-        # Write requests retain only the value after their dictionary address.
+        ("01001234", SDCPIdentifyRequest(0x1234)),
+        ("02001236100B00", SDCPReadRequest(0x1236, 0x100B, 0x00)),
         (
             "0300123428210042C80000",
-            SDCPFrame(
-                SDCPOpcode.WRITE, SDCPFlag.NONE, 0x1234, bytes.fromhex("42C80000"), 0x2821, 0x00
-            ),
+            SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000")),
         ),
-        # Error replies do not contain a dictionary address.
         (
-            "02031236FFFF0001",
-            SDCPFrame(
-                SDCPOpcode.READ, SDCPFlag.REPLY | SDCPFlag.ERROR, 0x1236, bytes.fromhex("FFFF0001")
-            ),
+            "0400123420310001006407D0",
+            SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000),
         ),
+        ("040012342E4D000207D0", SDCPEventSubscriptionRequest(0x1234, 0x2E4D, 0x00, 2000)),
+        ("050012345678", SDCPUnsubscribeRequest(0x1234, 0x5678)),
+        (
+            "01011234001234567890ABCDEF00000000",
+            SDCPIdentifyResponse(0x1234, bytes.fromhex("001234567890ABCDEF00000000")),
+        ),
+        ("0201123412345678", SDCPReadResponse(0x1234, bytes.fromhex("12345678"))),
+        ("03011234", SDCPWriteResponse(0x1234)),
+        ("040112345678", SDCPSubscribeResponse(0x1234, 0x5678)),
+        ("05011234", SDCPUnsubscribeResponse(0x1234)),
+        ("02031236FFFF0001", SDCPErrorResponse(0x02, 0x1236, 0xFFFF0001)),
     ],
 )
-def test_deserialize_frame_matches_expected_frame(frame: str, expected_frame: SDCPFrame) -> None:
-    """Deserialize a protocol frame into its complete expected frame object."""
-    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_frame
+def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
+    """Deserialize every documented frame layout into its specialized message."""
+    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_message
 
 
-def test_round_trip_error_response() -> None:
-    """Keep an error reply payload unchanged through a serialize round trip."""
-    received_frame = bytes.fromhex("0203123406020000")
-    decoded_frame = SDCPSerializer.deserialize(received_frame)
+def test_deserialize_unknown_frame() -> None:
+    """Preserve unrecognized opcode and flag combinations without guessing their layout."""
+    decoded_message = SDCPSerializer.deserialize(bytes.fromhex("FF801234ABCD"))
 
-    # Error details are opcode-specific, so the serializer preserves raw payload bytes.
-    serialized_frame = SDCPSerializer.serialize(
-        decoded_frame.opcode,
-        decoded_frame.flags,
-        decoded_frame.transaction_id,
-        payload=decoded_frame.payload,
+    assert decoded_message == SDCPUnknownFrame(0xFF, 0x80, 0x1234, bytes.fromhex("ABCD"))
+
+
+def test_message_representation_uses_hexadecimal_values() -> None:
+    """Display every protocol value in hexadecimal instead of decimal."""
+    write_request = SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
+    periodic_subscription = SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000)
+
+    assert repr(write_request) == (
+        "SDCPWriteRequest(transaction_id=0x1234, index=0x2821, subindex=0x00, value=0x42C80000)"
     )
-
-    assert serialized_frame == received_frame
-
-
-def test_frame_representation_uses_protocol_names() -> None:
-    """Display the opcode, flags, and transaction ID in protocol-friendly form."""
-    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("02031236FFFF0001"))
-
-    # An error reply includes both the reply and error flag bits.
-    assert repr(decoded_frame) == (
-        "SDCPFrame(opcode=READ, flags=REPLY | ERROR, transaction_id=0x1236, payload=0xFFFF0001)"
-    )
-
-
-def test_frame_representation_uses_none_for_a_request_without_flags() -> None:
-    """Display an unflagged read request with its dictionary address fields."""
-    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("02001236100B00"))
-
-    assert decoded_frame.index == 0x100B
-    assert decoded_frame.subindex == 0x00
-    assert decoded_frame.payload == b""
-    assert (
-        repr(decoded_frame) == "SDCPFrame(opcode=READ, flags=NONE, transaction_id=0x1236, "
-        "index=0x100B, subindex=0x00, payload=0x)"
+    assert repr(periodic_subscription) == (
+        "SDCPPeriodicSubscriptionRequest(transaction_id=0x1234, index=0x2031, subindex=0x00, "
+        "cyclic_time_ms=0x0064, message_count=0x07D0)"
     )
 
 
 @pytest.mark.parametrize(
-    "frame, expected_index, expected_subindex, expected_payload",
+    "frame",
     [
-        # Write requests append the value after the index and subindex.
-        ("0300123428210042C80000", 0x2821, 0x00, bytes.fromhex("42C80000")),
-        # Subscribe requests append mode, period, and message count.
-        ("0400123420310001006407D0", 0x2031, 0x00, bytes.fromhex("01006407D0")),
+        "",
+        "01",
+        "010012",
+        "02001234",  # Read request is missing its dictionary address.
+        "0301123400",  # Write success responses cannot contain payload bytes.
+        "02031234FFFF",  # Error responses require a 32-bit error code.
+        "04001234203100010064",  # Periodic subscription is missing its message count.
     ],
 )
-def test_deserialize_dictionary_request_address(
-    frame: str, expected_index: int, expected_subindex: int, expected_payload: bytes
-) -> None:
-    """Parse the address before the operation-specific request parameters."""
-    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex(frame))
-
-    assert decoded_frame.index == expected_index
-    assert decoded_frame.subindex == expected_subindex
-    assert decoded_frame.payload == expected_payload
-
-
-@pytest.mark.parametrize(
-    "opcode, flags, transaction_id",
-    [
-        (0x100, 0, 0),
-        (0, 0x100, 0),
-        (0, 0, 0x1_0000),
-    ],
-)
-def test_serialize_rejects_oversized_header_fields(
-    opcode: int, flags: int, transaction_id: int
-) -> None:
-    """Reject fields that cannot fit in their SDCP header positions."""
+def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
+    """Reject known message types whose payload does not match the protocol layout."""
     with pytest.raises(ValueError):
-        SDCPSerializer.serialize(opcode, flags, transaction_id)
+        SDCPSerializer.deserialize(bytes.fromhex(frame))
 
 
 @pytest.mark.parametrize(
-    "index, subindex",
+    "serializer, arguments",
     [
-        (0x100B, None),
-        (None, 0x00),
-        (0x1_0000, 0x00),
-        (0x100B, 0x100),
+        (SDCPSerializer.serialize_identify_request, (0x1_0000,)),
+        (SDCPSerializer.serialize_read_request, (0x1234, 0x1_0000, 0x00)),
+        (SDCPSerializer.serialize_read_request, (0x1234, 0x100B, 0x100)),
+        (SDCPSerializer.serialize_unsubscribe_request, (0x1234, 0x1_0000)),
     ],
 )
-def test_serialize_rejects_invalid_dictionary_address(
-    index: int | None, subindex: int | None
+def test_serialize_rejects_out_of_range_fields(
+    serializer: object, arguments: tuple[int, ...]
 ) -> None:
-    """Require a complete dictionary address that fits the protocol fields."""
+    """Reject public-builder fields that cannot fit their protocol positions."""
     with pytest.raises(ValueError):
-        SDCPSerializer.serialize(
-            SDCPOpcode.READ, SDCPFlag.NONE, 0x1234, index=index, subindex=subindex
-        )
+        serializer(*arguments)  # type: ignore[operator]
 
 
-def test_serialize_rejects_dictionary_request_without_address() -> None:
-    """Require an index and subindex for a dictionary request."""
-    with pytest.raises(ValueError, match="require index and subindex"):
-        SDCPSerializer.serialize(SDCPOpcode.READ, SDCPFlag.NONE, 0x1234)
-
-
-def test_serialize_rejects_write_request_without_value() -> None:
-    """Require a value payload for a Write request after its dictionary address."""
+def test_serialize_rejects_empty_write_value() -> None:
+    """Require a value payload for a Write request."""
     with pytest.raises(ValueError, match="require a value payload"):
-        SDCPSerializer.serialize(SDCPOpcode.WRITE, SDCPFlag.NONE, 0x1234, 0x2821, 0x00)
-
-
-@pytest.mark.parametrize("frame", [b"", b"\x01", b"\x01\x00\x12"])
-def test_deserialize_rejects_incomplete_header(frame: bytes) -> None:
-    """Reject a datagram that does not contain the full SDCP header."""
-    with pytest.raises(ValueError, match="four-byte header"):
-        SDCPSerializer.deserialize(frame)
+        SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, b"")

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -2,19 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 from ingenialink.utils.sdcp import (
     SDCPErrorResponse,
     SDCPEventSubscriptionRequest,
+    SDCPFlag,
     SDCPIdentificationRequest,
     SDCPIdentificationResponse,
     SDCPIdentificationResponseError,
+    SDCPOpcode,
     SDCPPeriodicSubscriptionRequest,
     SDCPReadRequest,
     SDCPReadResponse,
@@ -30,56 +27,135 @@ from ingenialink.utils.sdcp import (
     SDCPWriteResponse,
     SDCPWriteResponseError,
     _SDCPFields,
+    _SDCPMessage,
     _SDCPPayloadReader,
 )
 
 
-def test_serialize_identification_request() -> None:
-    """Serialize the Identification request from the SDCP protocol specification."""
-    assert SDCPSerializer.serialize_identification_request(0x1234) == bytes.fromhex("01001234")
+@pytest.mark.parametrize(
+    "message, expected_frame",
+    [
+        (
+            SDCPIdentificationRequest(0x1234),
+            bytes.fromhex("01001234"),
+        ),
+        (
+            SDCPReadRequest(0x1234, 0x26E6, 0x00),
+            bytes.fromhex("0200123426E600"),
+        ),
+        (
+            SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000")),
+            bytes.fromhex("0300123428210042C80000"),
+        ),
+        (
+            SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000),
+            bytes.fromhex("0400123420310001006407D0"),
+        ),
+        (
+            SDCPEventSubscriptionRequest(0x1234, 0x2E4D, 0x00, 2000),
+            bytes.fromhex("040012342E4D000207D0"),
+        ),
+        (
+            SDCPUnsubscribeRequest(0x1234, 0x5678),
+            bytes.fromhex("050012345678"),
+        ),
+        (
+            SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0),
+            bytes.fromhex("01011234001234567890ABCDEF00000000"),
+        ),
+        (
+            SDCPReadResponse(0x1234, bytes.fromhex("12345678")),
+            bytes.fromhex("0201123412345678"),
+        ),
+        (
+            SDCPWriteResponse(0x1234),
+            bytes.fromhex("03011234"),
+        ),
+        (
+            SDCPSubscribeResponse(0x1234, 0x5678),
+            bytes.fromhex("040112345678"),
+        ),
+        (
+            SDCPUnsubscribeResponse(0x1234),
+            bytes.fromhex("05011234"),
+        ),
+        (
+            SDCPIdentificationResponseError(0x1234, 0xFFFF0001),
+            bytes.fromhex("01031234FFFF0001"),
+        ),
+        (
+            SDCPReadResponseError(0x1234, 0xFFFF0001),
+            bytes.fromhex("02031234FFFF0001"),
+        ),
+        (
+            SDCPWriteResponseError(0x1234, 0xFFFF0001),
+            bytes.fromhex("03031234FFFF0001"),
+        ),
+        (
+            SDCPSubscribeResponseError(0x1234, 0xFFFF0001),
+            bytes.fromhex("04031234FFFF0001"),
+        ),
+        (
+            SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001),
+            bytes.fromhex("05031234FFFF0001"),
+        ),
+        (
+            SDCPUnknownFrame(0x1234, 0xFF, 0x80, bytes.fromhex("ABCD")),
+            bytes.fromhex("FF801234ABCD"),
+        ),
+    ],
+)
+def test_serialize_message_objects(message: _SDCPMessage, expected_frame: bytes) -> None:
+    """Serialize every supported typed message into its specification frame."""
+    assert bytes(message) == expected_frame
+    assert SDCPSerializer.deserialize(bytes(message)) == message
 
 
-def test_serialize_read_request() -> None:
-    """Serialize the Read request from the SDCP protocol specification."""
-    assert SDCPSerializer.serialize_read_request(0x1234, 0x26E6, 0x00) == bytes.fromhex(
-        "0200123426E600"
-    )
+@pytest.mark.parametrize(
+    "message, expected_opcode",
+    [
+        (SDCPIdentificationResponseError(0x1234, 0xFFFF0001), SDCPOpcode.IDENTIFICATION),
+        (SDCPReadResponseError(0x1234, 0xFFFF0001), SDCPOpcode.READ),
+        (SDCPWriteResponseError(0x1234, 0xFFFF0001), SDCPOpcode.WRITE),
+        (SDCPSubscribeResponseError(0x1234, 0xFFFF0001), SDCPOpcode.SUBSCRIBE),
+        (SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001), SDCPOpcode.UNSUBSCRIBE),
+    ],
+)
+def test_serialize_error_response_uses_opcode_and_error_flags(
+    message: SDCPErrorResponse, expected_opcode: SDCPOpcode
+) -> None:
+    """Encode each concrete error response with its operation opcode and flags."""
+    frame = bytes(message)
+
+    assert frame[:2] == bytes((expected_opcode, SDCPFlag.REPLY | SDCPFlag.ERROR))
+    assert SDCPSerializer.deserialize(frame) == message
 
 
-def test_serialize_write_request() -> None:
-    """Serialize the Write request from the SDCP protocol specification."""
-    frame = SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
-
-    assert frame == bytes.fromhex("0300123428210042C80000")
-
-
-def test_serialize_subscription_requests() -> None:
-    """Serialize both subscription request layouts from the specification."""
-    periodic_frame = SDCPSerializer.serialize_periodic_subscription_request(
-        0x1234, 0x2031, 0x00, 100, 2000
-    )
-    event_frame = SDCPSerializer.serialize_event_subscription_request(0x1234, 0x2E4D, 0x00, 2000)
-
-    assert periodic_frame == bytes.fromhex("0400123420310001006407D0")
-    assert event_frame == bytes.fromhex("040012342E4D000207D0")
+def test_serialize_rejects_base_error_response() -> None:
+    """Keep the base error response abstract and non-serializable."""
+    with pytest.raises(TypeError, match="abstract method"):
+        SDCPErrorResponse(0x1234, 0xFFFF0001)
 
 
-def test_serialize_unsubscribe_request() -> None:
-    """Serialize the Unsubscribe request using its dedicated opcode."""
-    assert SDCPSerializer.serialize_unsubscribe_request(0x1234, 0x5678) == bytes.fromhex(
-        "050012345678"
-    )
+def test_message_base_is_abstract() -> None:
+    """Require concrete message types to implement the byte interface."""
+    with pytest.raises(TypeError, match="abstract method"):
+        _SDCPMessage(0x1234)
 
 
-def test_serialize_responses() -> None:
-    """Serialize successful and error responses with their dedicated builders."""
-    success_frame = SDCPSerializer.serialize_success_response(
-        0x02, 0x1234, bytes.fromhex("12345678")
-    )
-    error_frame = SDCPSerializer.serialize_error_response(0x02, 0x1234, 0x06020000)
-
-    assert success_frame == bytes.fromhex("0201123412345678")
-    assert error_frame == bytes.fromhex("0203123406020000")
+@pytest.mark.parametrize(
+    "message, expected_message",
+    [
+        (SDCPReadResponse(0x1234, "value"), "value must be bytes"),
+        (SDCPUnknownFrame(0x1234, 0xFF, 0x00, bytearray(b"payload")), "payload must be bytes"),
+    ],
+)
+def test_serialize_rejects_invalid_raw_response_payloads(
+    message: _SDCPMessage, expected_message: str
+) -> None:
+    """Require immutable bytes for raw payloads on typed response objects."""
+    with pytest.raises(TypeError, match=expected_message):
+        bytes(message)
 
 
 def test_payload_reader_tracks_offset_and_remaining_bytes() -> None:
@@ -311,39 +387,35 @@ def test_deserialize_rejects_malformed_frames(frame: str, message: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "serializer, arguments",
+    "message",
     [
-        (SDCPSerializer.serialize_identification_request, (0x1_0000,)),
-        (SDCPSerializer.serialize_read_request, (0x1234, 0x1_0000, 0x00)),
-        (SDCPSerializer.serialize_read_request, (0x1234, 0x100B, 0x100)),
-        (SDCPSerializer.serialize_unsubscribe_request, (0x1234, 0x1_0000)),
-        (SDCPSerializer.serialize_error_response, (0x02, 0x1234, 0x1_0000_0000)),
-        (SDCPSerializer.serialize_periodic_subscription_request, (-1, 0x2031, 0x00, 100, 2000)),
+        SDCPIdentificationRequest(0x1_0000),
+        SDCPReadRequest(0x1234, 0x1_0000, 0x00),
+        SDCPReadRequest(0x1234, 0x100B, 0x100),
+        SDCPUnsubscribeRequest(0x1234, 0x1_0000),
+        SDCPReadResponseError(0x1234, 0x1_0000_0000),
+        SDCPPeriodicSubscriptionRequest(-1, 0x2031, 0x00, 100, 2000),
     ],
 )
-def test_serialize_rejects_out_of_range_fields(
-    serializer: Callable[..., bytes], arguments: tuple[int, ...]
-) -> None:
-    """Reject public-builder fields that cannot fit their protocol positions."""
+def test_serialize_rejects_out_of_range_fields(message: _SDCPMessage) -> None:
+    """Reject message fields that cannot fit their protocol positions."""
     with pytest.raises(ValueError):
-        serializer(*arguments)
+        bytes(message)
 
 
 @pytest.mark.parametrize(
-    "serializer, arguments",
+    "message",
     [
-        (SDCPSerializer.serialize_identification_request, (True,)),
-        (SDCPSerializer.serialize_read_request, (0x1234, "0x100B", 0x00)),
-        (SDCPSerializer.serialize_unsubscribe_request, (0x1234, False)),
-        (SDCPSerializer.serialize_error_response, (0x02, 0x1234, 1.0)),
+        SDCPIdentificationRequest(True),
+        SDCPReadRequest(0x1234, "0x100B", 0x00),
+        SDCPUnsubscribeRequest(0x1234, False),
+        SDCPReadResponseError(0x1234, 1.0),
     ],
 )
-def test_serialize_rejects_invalid_uint_types(
-    serializer: Callable[..., bytes], arguments: tuple[object, ...]
-) -> None:
+def test_serialize_rejects_invalid_uint_types(message: _SDCPMessage) -> None:
     """Reject non-integer and boolean values for unsigned protocol fields."""
     with pytest.raises(TypeError):
-        serializer(*arguments)
+        bytes(message)
 
 
 @pytest.mark.parametrize(
@@ -355,11 +427,4 @@ def test_serialize_rejects_invalid_write_values(
 ) -> None:
     """Require a non-empty bytes value payload for a Write request."""
     with pytest.raises(expected_exception):
-        SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, value)  # type: ignore[arg-type]
-
-
-@pytest.mark.parametrize("payload", ["payload", bytearray(b"payload")])
-def test_serialize_rejects_invalid_response_payload_types(payload: object) -> None:
-    """Require raw response payloads to be immutable bytes."""
-    with pytest.raises(TypeError):
-        SDCPSerializer.serialize_success_response(0x02, 0x1234, payload)  # type: ignore[arg-type]
+        bytes(SDCPWriteRequest(0x1234, 0x2821, 0x00, value))  # type: ignore[arg-type]

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -176,8 +176,8 @@ def test_deserialize_frame_matches_expected_message(frame: str, expected_message
 @pytest.mark.parametrize(
     "frame, expected_message",
     [
-        ("FF001234ABCD", SDCPUnknownFrame(0xFF, 0x00, 0x1234, bytes.fromhex("ABCD"))),
-        ("02801234ABCD", SDCPUnknownFrame(0x02, 0x80, 0x1234, bytes.fromhex("ABCD"))),
+        ("FF001234ABCD", SDCPUnknownFrame(0x1234, 0xFF, 0x00, bytes.fromhex("ABCD"))),
+        ("02801234ABCD", SDCPUnknownFrame(0x1234, 0x02, 0x80, bytes.fromhex("ABCD"))),
     ],
 )
 def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFrame) -> None:

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -1,0 +1,141 @@
+"""Tests for SDCP acyclic frame serialization."""
+
+import pytest
+
+from ingenialink.utils.sdcp import SDCPFlag, SDCPFrame, SDCPOpcode, SDCPSerializer
+
+
+def test_serialize_read_request() -> None:
+    """Serialize the read request from the SDCP protocol specification."""
+    frame = SDCPSerializer.serialize(
+        SDCPOpcode.READ,
+        SDCPFlag.NONE,
+        0x1234,
+        bytes.fromhex("26E600"),
+    )
+
+    # The transaction ID is encoded as the big-endian bytes 12 34.
+    assert frame == bytes.fromhex("0200123426E600")
+
+
+def test_deserialize_read_response() -> None:
+    """Deserialize the successful read response from the specification."""
+    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("0201123412345678"))
+
+    assert decoded_frame.opcode == SDCPOpcode.READ
+    assert decoded_frame.flags == SDCPFlag.REPLY
+    assert decoded_frame.transaction_id == 0x1234
+    assert decoded_frame.payload == bytes.fromhex("12345678")
+    assert decoded_frame.index is None
+    assert decoded_frame.subindex is None
+
+
+@pytest.mark.parametrize(
+    "frame, expected_frame",
+    [
+        # Read requests contain only the dictionary address after the header.
+        (
+            "02001236100B00",
+            SDCPFrame(SDCPOpcode.READ, SDCPFlag.NONE, 0x1236, b"", 0x100B, 0x00),
+        ),
+        # Write requests retain only the value after their dictionary address.
+        (
+            "0300123428210042C80000",
+            SDCPFrame(
+                SDCPOpcode.WRITE, SDCPFlag.NONE, 0x1234, bytes.fromhex("42C80000"), 0x2821, 0x00
+            ),
+        ),
+        # Error replies do not contain a dictionary address.
+        (
+            "02031236FFFF0001",
+            SDCPFrame(
+                SDCPOpcode.READ, SDCPFlag.REPLY | SDCPFlag.ERROR, 0x1236, bytes.fromhex("FFFF0001")
+            ),
+        ),
+    ],
+)
+def test_deserialize_frame_matches_expected_frame(frame: str, expected_frame: SDCPFrame) -> None:
+    """Deserialize a protocol frame into its complete expected frame object."""
+    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_frame
+
+
+def test_round_trip_error_response() -> None:
+    """Keep an error reply payload unchanged through a serialize round trip."""
+    received_frame = bytes.fromhex("0203123406020000")
+    decoded_frame = SDCPSerializer.deserialize(received_frame)
+
+    # Error details are opcode-specific, so the serializer preserves raw payload bytes.
+    serialized_frame = SDCPSerializer.serialize(
+        decoded_frame.opcode,
+        decoded_frame.flags,
+        decoded_frame.transaction_id,
+        decoded_frame.payload,
+    )
+
+    assert serialized_frame == received_frame
+
+
+def test_frame_representation_uses_protocol_names() -> None:
+    """Display the opcode, flags, and transaction ID in protocol-friendly form."""
+    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("02031236FFFF0001"))
+
+    # An error reply includes both the reply and error flag bits.
+    assert repr(decoded_frame) == (
+        "SDCPFrame(opcode=READ, flags=REPLY | ERROR, transaction_id=0x1236, payload=0xFFFF0001)"
+    )
+
+
+def test_frame_representation_uses_none_for_a_request_without_flags() -> None:
+    """Display an unflagged read request with its dictionary address fields."""
+    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex("02001236100B00"))
+
+    assert decoded_frame.index == 0x100B
+    assert decoded_frame.subindex == 0x00
+    assert decoded_frame.payload == b""
+    assert (
+        repr(decoded_frame) == "SDCPFrame(opcode=READ, flags=NONE, transaction_id=0x1236, "
+        "index=0x100B, subindex=0x00, payload=0x)"
+    )
+
+
+@pytest.mark.parametrize(
+    "frame, expected_index, expected_subindex, expected_payload",
+    [
+        # Write requests append the value after the index and subindex.
+        ("0300123428210042C80000", 0x2821, 0x00, bytes.fromhex("42C80000")),
+        # Subscribe requests append mode, period, and message count.
+        ("0400123420310001006407D0", 0x2031, 0x00, bytes.fromhex("01006407D0")),
+    ],
+)
+def test_deserialize_dictionary_request_address(
+    frame: str, expected_index: int, expected_subindex: int, expected_payload: bytes
+) -> None:
+    """Parse the address before the operation-specific request parameters."""
+    decoded_frame = SDCPSerializer.deserialize(bytes.fromhex(frame))
+
+    assert decoded_frame.index == expected_index
+    assert decoded_frame.subindex == expected_subindex
+    assert decoded_frame.payload == expected_payload
+
+
+@pytest.mark.parametrize(
+    "opcode, flags, transaction_id",
+    [
+        (0x100, 0, 0),
+        (0, 0x100, 0),
+        (0, 0, 0x1_0000),
+    ],
+)
+def test_serialize_rejects_oversized_header_fields(
+    opcode: int, flags: int, transaction_id: int
+) -> None:
+    """Reject fields that cannot fit in their SDCP header positions."""
+    with pytest.raises(ValueError):
+        SDCPSerializer.serialize(opcode, flags, transaction_id)
+
+
+@pytest.mark.parametrize("frame", [b"", b"\x01", b"\x01\x00\x12"])
+def test_deserialize_rejects_incomplete_header(frame: bytes) -> None:
+    """Reject a datagram that does not contain the full SDCP header."""
+    with pytest.raises(ValueError, match="four-byte header"):
+        SDCPSerializer.deserialize(frame)

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 from ingenialink.utils.sdcp import (
+    SDCPErrorResponse,
     SDCPEventSubscriptionRequest,
     SDCPIdentificationRequest,
     SDCPIdentificationResponse,
@@ -23,6 +29,8 @@ from ingenialink.utils.sdcp import (
     SDCPWriteRequest,
     SDCPWriteResponse,
     SDCPWriteResponseError,
+    _SDCPFields,
+    _SDCPPayloadReader,
 )
 
 
@@ -74,6 +82,67 @@ def test_serialize_responses() -> None:
     assert error_frame == bytes.fromhex("0203123406020000")
 
 
+def test_payload_reader_tracks_offset_and_remaining_bytes() -> None:
+    """Read fixed-width and raw payload values sequentially."""
+    reader = _SDCPPayloadReader(bytes.fromhex("123456ABCD"))
+
+    assert reader.read_uint(_SDCPFields.TRANSACTION_ID) == 0x1234
+    assert reader.read_bytes(1) == b"V"
+    assert reader.read_remaining() == bytes.fromhex("ABCD")
+    reader.ensure_end()
+
+
+def test_payload_reader_rejects_incomplete_fixed_width_values() -> None:
+    """Reject fixed-width reads when the payload is too short."""
+    with pytest.raises(ValueError):
+        _SDCPPayloadReader(b"\x12").read_uint(_SDCPFields.TRANSACTION_ID)
+
+
+def test_payload_reader_reports_trailing_byte_count() -> None:
+    """Report the number of unexpected trailing payload bytes."""
+    reader = _SDCPPayloadReader(b"\x12\x34")
+
+    with pytest.raises(ValueError, match="2 unexpected trailing bytes"):
+        reader.ensure_end()
+
+
+@pytest.mark.parametrize("payload", ["payload", bytearray(b"payload")])
+def test_payload_reader_requires_bytes(payload: object) -> None:
+    """Require the cursor reader input to be immutable bytes."""
+    with pytest.raises(TypeError, match="Payload must be bytes"):
+        _SDCPPayloadReader(payload)  # type: ignore[arg-type]
+
+
+def test_deserialize_requires_bytes() -> None:
+    """Require complete SDCP frames to be immutable bytes."""
+    with pytest.raises(TypeError, match="Payload must be bytes"):
+        SDCPSerializer.deserialize("01001234")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "frame, message",
+    [
+        ("040012345678", "requested 1 bytes.*only 0 remain"),
+        ("04001234203100", "requested 1 bytes.*only 0 remain"),
+        ("0400123420310001006407D000", "1 unexpected trailing bytes"),
+        ("04001234203100010064", "requested 2 bytes.*only 0 remain"),
+        ("0400123420310003006407D0", "unknown subscription mode: 0x03"),
+    ],
+)
+def test_deserialize_subscription_requests_reject_invalid_payloads(
+    frame: str, message: str
+) -> None:
+    """Reject trailing, truncated, and unknown-mode Subscribe payloads."""
+    with pytest.raises(ValueError, match=message):
+        SDCPSerializer.deserialize(bytes.fromhex(frame))
+
+
+def test_identification_response_requires_revision_number() -> None:
+    """Keep Identification responses strict at the documented 13-byte layout."""
+    with pytest.raises(ValueError, match="requested 4 bytes.*only 0 remain"):
+        SDCPSerializer.deserialize(bytes.fromhex("01011234001234567890ABCDEF"))
+
+
 @pytest.mark.parametrize(
     "frame, expected_message",
     [
@@ -97,7 +166,6 @@ def test_serialize_responses() -> None:
         ("03011234", SDCPWriteResponse(0x1234)),
         ("040112345678", SDCPSubscribeResponse(0x1234, 0x5678)),
         ("05011234", SDCPUnsubscribeResponse(0x1234)),
-        ("02031234FFFF0001", SDCPReadResponseError(0x1234, 0xFFFF0001)),
     ],
 )
 def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
@@ -122,20 +190,37 @@ def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFram
 @pytest.mark.parametrize(
     "frame, expected_message",
     [
-        ("01031234FFFF0001", SDCPIdentificationResponseError(0x1234, 0xFFFF0001)),
+        (
+            "01031234FFFF0001",
+            SDCPIdentificationResponseError(0x1234, 0xFFFF0001),
+        ),
         ("02031234FFFF0001", SDCPReadResponseError(0x1234, 0xFFFF0001)),
-        ("03031234FFFF0001", SDCPWriteResponseError(0x1234, 0xFFFF0001)),
-        ("04031234FFFF0001", SDCPSubscribeResponseError(0x1234, 0xFFFF0001)),
-        ("05031234FFFF0001", SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001)),
+        (
+            "03031234FFFF0001",
+            SDCPWriteResponseError(0x1234, 0xFFFF0001),
+        ),
+        (
+            "04031234FFFF0001",
+            SDCPSubscribeResponseError(0x1234, 0xFFFF0001),
+        ),
+        (
+            "05031234FFFF0001",
+            SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001),
+        ),
     ],
 )
-def test_deserialize_specialized_error_responses(frame: str, expected_message: object) -> None:
+def test_deserialize_specialized_error_responses(
+    frame: str, expected_message: SDCPErrorResponse
+) -> None:
     """Decode each known operation's error response into its specific type."""
-    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_message
+    decoded_message = SDCPSerializer.deserialize(bytes.fromhex(frame))
+
+    assert decoded_message == expected_message
+    assert isinstance(decoded_message, SDCPErrorResponse)
 
 
 def test_message_representation_uses_protocol_field_formats() -> None:
-    """Display all fields in hexadecimal except timing and message counts."""
+    """Fixed-width protocol fields use hexadecimal formatting."""
     write_request = SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
     periodic_subscription = SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000)
     identification_response = SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0)
@@ -168,13 +253,19 @@ def test_message_representation_uses_protocol_field_formats() -> None:
         "",
         "01",
         "010012",
+        "0100123400",  # Identification requests cannot contain trailing bytes.
         "02001234",  # Read request is missing its dictionary address.
         "0200123426E60000",  # Read request cannot contain trailing payload bytes.
-        "040012345678",  # Subscribe requests require an address, mode, and message count.
+        "03001234282100",  # Write requests require a non-empty value.
+        "05001234",  # Unsubscribe requests require a subscription identifier.
         "0301123400",  # Write success responses cannot contain payload bytes.
-        "01011234001234567890ABCDEF",  # Identification responses require 13 payload bytes.
+        "04011234",  # Subscribe responses require a subscription identifier.
+        "04011234567800",  # Subscribe responses cannot contain trailing payload bytes.
+        "0501123400",  # Unsubscribe responses cannot contain payload bytes.
+        # Identification responses cannot contain trailing bytes.
+        "01011234001234567890ABCDEF0000000000",
         "02031234FFFF",  # Error responses require a 32-bit error code.
-        "04001234203100010064",  # Periodic subscription is missing its message count.
+        "02031234FFFF0001FF",  # Error responses cannot contain trailing bytes.
     ],
 )
 def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
@@ -195,11 +286,11 @@ def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
     ],
 )
 def test_serialize_rejects_out_of_range_fields(
-    serializer: object, arguments: tuple[int, ...]
+    serializer: Callable[..., bytes], arguments: tuple[int, ...]
 ) -> None:
     """Reject public-builder fields that cannot fit their protocol positions."""
     with pytest.raises(ValueError):
-        serializer(*arguments)  # type: ignore[operator]
+        serializer(*arguments)
 
 
 @pytest.mark.parametrize(
@@ -212,17 +303,21 @@ def test_serialize_rejects_out_of_range_fields(
     ],
 )
 def test_serialize_rejects_invalid_uint_types(
-    serializer: object, arguments: tuple[object, ...]
+    serializer: Callable[..., bytes], arguments: tuple[object, ...]
 ) -> None:
     """Reject non-integer and boolean values for unsigned protocol fields."""
     with pytest.raises(TypeError):
-        serializer(*arguments)  # type: ignore[operator]
+        serializer(*arguments)
 
 
-@pytest.mark.parametrize("value", [b"", "value", bytearray(b"value")])
-def test_serialize_rejects_invalid_write_values(value: object) -> None:
+@pytest.mark.parametrize(
+    "value, expected_exception",
+    [(b"", ValueError), ("value", TypeError), (bytearray(b"value"), TypeError)],
+)
+def test_serialize_rejects_invalid_write_values(
+    value: object, expected_exception: type[BaseException]
+) -> None:
     """Require a non-empty bytes value payload for a Write request."""
-    expected_exception = ValueError if value == b"" else TypeError
     with pytest.raises(expected_exception):
         SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, value)  # type: ignore[arg-type]
 
@@ -232,9 +327,3 @@ def test_serialize_rejects_invalid_response_payload_types(payload: object) -> No
     """Require raw response payloads to be immutable bytes."""
     with pytest.raises(TypeError):
         SDCPSerializer.serialize_success_response(0x02, 0x1234, payload)  # type: ignore[arg-type]
-
-
-def test_serialize_rejects_empty_write_value() -> None:
-    """Require a value payload for a Write request."""
-    with pytest.raises(ValueError, match="require a value payload"):
-        SDCPSerializer.serialize_write_request(0x1234, 0x2821, 0x00, b"")

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -108,6 +108,32 @@ from ingenialink.utils.sdcp import (
 def test_serialize_message_objects(message: _SDCPMessage, expected_frame: bytes) -> None:
     """Serialize every supported typed message into its specification frame."""
     assert bytes(message) == expected_frame
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        SDCPIdentificationRequest(0x1234),
+        SDCPReadRequest(0x1234, 0x26E6, 0x00),
+        SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000")),
+        SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000),
+        SDCPEventSubscriptionRequest(0x1234, 0x2E4D, 0x00, 2000),
+        SDCPUnsubscribeRequest(0x1234, 0x5678),
+        SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0),
+        SDCPReadResponse(0x1234, bytes.fromhex("12345678")),
+        SDCPWriteResponse(0x1234),
+        SDCPSubscribeResponse(0x1234, 0x5678),
+        SDCPUnsubscribeResponse(0x1234),
+        SDCPIdentificationResponseError(0x1234, 0xFFFF0001),
+        SDCPReadResponseError(0x1234, 0xFFFF0001),
+        SDCPWriteResponseError(0x1234, 0xFFFF0001),
+        SDCPSubscribeResponseError(0x1234, 0xFFFF0001),
+        SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001),
+        SDCPUnknownFrame(0x1234, 0xFF, 0x80, bytes.fromhex("ABCD")),
+    ],
+)
+def test_deserialize_serialized_message(message: _SDCPMessage) -> None:
+    """Round-trip every concrete message through SDCP frame deserialization."""
     assert SDCPDeserializer.deserialize(bytes(message)) == message
 
 

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -26,6 +26,7 @@ from ingenialink.utils.sdcp import (
     SDCPWriteRequest,
     SDCPWriteResponse,
     SDCPWriteResponseError,
+    _SDCPField,
     _SDCPFields,
     _SDCPMessage,
     _SDCPPayloadReader,
@@ -167,6 +168,31 @@ def test_message_base_is_abstract() -> None:
     """Require concrete message types to implement the byte interface."""
     with pytest.raises(TypeError, match="abstract method"):
         _SDCPMessage(0x1234)
+
+
+def test_sdcp_field_serializes_fixed_width_big_endian_values() -> None:
+    """Serialize unsigned values using the field width and protocol byte order."""
+    field = _SDCPField(2)
+
+    assert field.size == 2
+    assert field.hex_width == 4
+    assert field.maximum_value == 0xFFFF
+    assert field.serialize(0x1234) == bytes.fromhex("1234")
+    assert field.serialize(field.maximum_value) == bytes.fromhex("FFFF")
+
+
+@pytest.mark.parametrize("value", [True, False, "0x1234", 1.0])
+def test_sdcp_field_rejects_non_integer_values(value: object) -> None:
+    """Reject booleans and other non-integer values before encoding."""
+    with pytest.raises(TypeError, match="Value must be an integer for a 2-byte field"):
+        _SDCPField(2).serialize(value)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("value", [-1, 0x1_0000])
+def test_sdcp_field_rejects_values_outside_unsigned_range(value: int) -> None:
+    """Reject values outside the field's unsigned range."""
+    with pytest.raises(ValueError, match="Value must be in the range 0 to 65535"):
+        _SDCPField(2).serialize(value)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -5,21 +5,24 @@ from __future__ import annotations
 import pytest
 
 from ingenialink.utils.sdcp import (
-    SDCPErrorResponse,
     SDCPEventSubscriptionRequest,
     SDCPIdentificationRequest,
     SDCPIdentificationResponse,
-    SDCPOpcode,
+    SDCPIdentificationResponseError,
     SDCPPeriodicSubscriptionRequest,
     SDCPReadRequest,
     SDCPReadResponse,
+    SDCPReadResponseError,
     SDCPSerializer,
     SDCPSubscribeResponse,
+    SDCPSubscribeResponseError,
     SDCPUnknownFrame,
     SDCPUnsubscribeRequest,
     SDCPUnsubscribeResponse,
+    SDCPUnsubscribeResponseError,
     SDCPWriteRequest,
     SDCPWriteResponse,
+    SDCPWriteResponseError,
 )
 
 
@@ -94,7 +97,7 @@ def test_serialize_responses() -> None:
         ("03011234", SDCPWriteResponse(0x1234)),
         ("040112345678", SDCPSubscribeResponse(0x1234, 0x5678)),
         ("05011234", SDCPUnsubscribeResponse(0x1234)),
-        ("02031234FFFF0001", SDCPErrorResponse(SDCPOpcode.READ, 0x1234, 0xFFFF0001)),
+        ("02031234FFFF0001", SDCPReadResponseError(0x1234, 0xFFFF0001)),
     ],
 )
 def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
@@ -116,20 +119,35 @@ def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFram
     assert decoded_message == expected_message
 
 
+@pytest.mark.parametrize(
+    "frame, expected_message",
+    [
+        ("01031234FFFF0001", SDCPIdentificationResponseError(0x1234, 0xFFFF0001)),
+        ("02031234FFFF0001", SDCPReadResponseError(0x1234, 0xFFFF0001)),
+        ("03031234FFFF0001", SDCPWriteResponseError(0x1234, 0xFFFF0001)),
+        ("04031234FFFF0001", SDCPSubscribeResponseError(0x1234, 0xFFFF0001)),
+        ("05031234FFFF0001", SDCPUnsubscribeResponseError(0x1234, 0xFFFF0001)),
+    ],
+)
+def test_deserialize_specialized_error_responses(frame: str, expected_message: object) -> None:
+    """Decode each known operation's error response into its specific type."""
+    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_message
+
+
 def test_message_representation_uses_protocol_field_formats() -> None:
     """Display all fields in hexadecimal except timing and message counts."""
     write_request = SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
     periodic_subscription = SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000)
     identification_response = SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0)
     unsubscribe_request = SDCPUnsubscribeRequest(0x1234, 0x5678)
-    error_response = SDCPErrorResponse(SDCPOpcode.READ, 0x1234, 0xFFFF0001)
+    error_response = SDCPReadResponseError(0x1234, 0xFFFF0001)
 
     assert repr(write_request) == (
         "SDCPWriteRequest(transaction_id=0x1234, index=0x2821, subindex=0x00, value=0x42C80000)"
     )
     assert repr(periodic_subscription) == (
         "SDCPPeriodicSubscriptionRequest(transaction_id=0x1234, index=0x2031, subindex=0x00, "
-        "cyclic_time_ms=100, message_count=2000)"
+        "cyclic_time_ms=0x0064, message_count=0x07D0)"
     )
     assert repr(identification_response) == (
         "SDCPIdentificationResponse(transaction_id=0x1234, protocol_version=0x00, "
@@ -138,8 +156,9 @@ def test_message_representation_uses_protocol_field_formats() -> None:
     assert repr(unsubscribe_request) == (
         "SDCPUnsubscribeRequest(transaction_id=0x1234, subscription_id=0x5678)"
     )
-    assert repr(error_response) == (
-        "SDCPErrorResponse(opcode=SDCPOpcode.READ, transaction_id=0x1234, error_code=0xFFFF0001)"
+    assert (
+        repr(error_response)
+        == "SDCPReadResponseError(transaction_id=0x1234, error_code=0xFFFF0001)"
     )
 
 

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -7,8 +7,9 @@ import pytest
 from ingenialink.utils.sdcp import (
     SDCPErrorResponse,
     SDCPEventSubscriptionRequest,
-    SDCPIdentifyRequest,
-    SDCPIdentifyResponse,
+    SDCPIdentificationRequest,
+    SDCPIdentificationResponse,
+    SDCPOpcode,
     SDCPPeriodicSubscriptionRequest,
     SDCPReadRequest,
     SDCPReadResponse,
@@ -22,9 +23,9 @@ from ingenialink.utils.sdcp import (
 )
 
 
-def test_serialize_identify_request() -> None:
-    """Serialize the Identify request from the SDCP protocol specification."""
-    assert SDCPSerializer.serialize_identify_request(0x1234) == bytes.fromhex("01001234")
+def test_serialize_identification_request() -> None:
+    """Serialize the Identification request from the SDCP protocol specification."""
+    assert SDCPSerializer.serialize_identification_request(0x1234) == bytes.fromhex("01001234")
 
 
 def test_serialize_read_request() -> None:
@@ -73,7 +74,7 @@ def test_serialize_responses() -> None:
 @pytest.mark.parametrize(
     "frame, expected_message",
     [
-        ("01001234", SDCPIdentifyRequest(0x1234)),
+        ("01001234", SDCPIdentificationRequest(0x1234)),
         ("02001236100B00", SDCPReadRequest(0x1236, 0x100B, 0x00)),
         (
             "0300123428210042C80000",
@@ -86,18 +87,14 @@ def test_serialize_responses() -> None:
         ("040012342E4D000207D0", SDCPEventSubscriptionRequest(0x1234, 0x2E4D, 0x00, 2000)),
         ("050012345678", SDCPUnsubscribeRequest(0x1234, 0x5678)),
         (
-            "01011234001234567890ABCDEF",
-            SDCPIdentifyResponse(0x1234, bytes.fromhex("001234567890ABCDEF")),
-        ),
-        (
             "01011234001234567890ABCDEF00000000",
-            SDCPIdentifyResponse(0x1234, bytes.fromhex("001234567890ABCDEF00000000")),
+            SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0),
         ),
         ("0201123412345678", SDCPReadResponse(0x1234, bytes.fromhex("12345678"))),
         ("03011234", SDCPWriteResponse(0x1234)),
         ("040112345678", SDCPSubscribeResponse(0x1234, 0x5678)),
         ("05011234", SDCPUnsubscribeResponse(0x1234)),
-        ("02031234FFFF0001", SDCPErrorResponse(0x02, 0x1234, 0xFFFF0001)),
+        ("02031234FFFF0001", SDCPErrorResponse(SDCPOpcode.READ, 0x1234, 0xFFFF0001)),
     ],
 )
 def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
@@ -119,17 +116,30 @@ def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFram
     assert decoded_message == expected_message
 
 
-def test_message_representation_uses_hexadecimal_values() -> None:
-    """Display every protocol value in hexadecimal instead of decimal."""
+def test_message_representation_uses_protocol_field_formats() -> None:
+    """Display all fields in hexadecimal except timing and message counts."""
     write_request = SDCPWriteRequest(0x1234, 0x2821, 0x00, bytes.fromhex("42C80000"))
     periodic_subscription = SDCPPeriodicSubscriptionRequest(0x1234, 0x2031, 0x00, 100, 2000)
+    identification_response = SDCPIdentificationResponse(0x1234, 0, 0x12345678, 0x90ABCDEF, 0)
+    unsubscribe_request = SDCPUnsubscribeRequest(0x1234, 0x5678)
+    error_response = SDCPErrorResponse(SDCPOpcode.READ, 0x1234, 0xFFFF0001)
 
     assert repr(write_request) == (
         "SDCPWriteRequest(transaction_id=0x1234, index=0x2821, subindex=0x00, value=0x42C80000)"
     )
     assert repr(periodic_subscription) == (
         "SDCPPeriodicSubscriptionRequest(transaction_id=0x1234, index=0x2031, subindex=0x00, "
-        "cyclic_time_ms=0x0064, message_count=0x07D0)"
+        "cyclic_time_ms=100, message_count=2000)"
+    )
+    assert repr(identification_response) == (
+        "SDCPIdentificationResponse(transaction_id=0x1234, protocol_version=0x00, "
+        "serial_number=0x12345678, product_code=0x90ABCDEF, revision_number=0x00000000)"
+    )
+    assert repr(unsubscribe_request) == (
+        "SDCPUnsubscribeRequest(transaction_id=0x1234, subscription_id=0x5678)"
+    )
+    assert repr(error_response) == (
+        "SDCPErrorResponse(opcode=SDCPOpcode.READ, transaction_id=0x1234, error_code=0xFFFF0001)"
     )
 
 
@@ -141,7 +151,9 @@ def test_message_representation_uses_hexadecimal_values() -> None:
         "010012",
         "02001234",  # Read request is missing its dictionary address.
         "0200123426E60000",  # Read request cannot contain trailing payload bytes.
+        "040012345678",  # Subscribe requests require an address, mode, and message count.
         "0301123400",  # Write success responses cannot contain payload bytes.
+        "01011234001234567890ABCDEF",  # Identification responses require 13 payload bytes.
         "02031234FFFF",  # Error responses require a 32-bit error code.
         "04001234203100010064",  # Periodic subscription is missing its message count.
     ],
@@ -155,7 +167,7 @@ def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
 @pytest.mark.parametrize(
     "serializer, arguments",
     [
-        (SDCPSerializer.serialize_identify_request, (0x1_0000,)),
+        (SDCPSerializer.serialize_identification_request, (0x1_0000,)),
         (SDCPSerializer.serialize_read_request, (0x1234, 0x1_0000, 0x00)),
         (SDCPSerializer.serialize_read_request, (0x1234, 0x100B, 0x100)),
         (SDCPSerializer.serialize_unsubscribe_request, (0x1234, 0x1_0000)),
@@ -174,7 +186,7 @@ def test_serialize_rejects_out_of_range_fields(
 @pytest.mark.parametrize(
     "serializer, arguments",
     [
-        (SDCPSerializer.serialize_identify_request, (True,)),
+        (SDCPSerializer.serialize_identification_request, (True,)),
         (SDCPSerializer.serialize_read_request, (0x1234, "0x100B", 0x00)),
         (SDCPSerializer.serialize_unsubscribe_request, (0x1234, False)),
         (SDCPSerializer.serialize_error_response, (0x02, 0x1234, 1.0)),

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -119,24 +119,6 @@ def test_deserialize_requires_bytes() -> None:
         SDCPSerializer.deserialize("01001234")  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize(
-    "frame, message",
-    [
-        ("040012345678", "requested 1 bytes.*only 0 remain"),
-        ("04001234203100", "requested 1 bytes.*only 0 remain"),
-        ("0400123420310001006407D000", "1 unexpected trailing bytes"),
-        ("04001234203100010064", "requested 2 bytes.*only 0 remain"),
-        ("0400123420310003006407D0", "unknown subscription mode: 0x03"),
-    ],
-)
-def test_deserialize_subscription_requests_reject_invalid_payloads(
-    frame: str, message: str
-) -> None:
-    """Reject trailing, truncated, and unknown-mode Subscribe payloads."""
-    with pytest.raises(ValueError, match=message):
-        SDCPSerializer.deserialize(bytes.fromhex(frame))
-
-
 def test_identification_response_requires_revision_number() -> None:
     """Keep Identification responses strict at the documented 13-byte layout."""
     with pytest.raises(ValueError, match="requested 4 bytes.*only 0 remain"):
@@ -248,29 +230,83 @@ def test_message_representation_uses_protocol_field_formats() -> None:
 
 
 @pytest.mark.parametrize(
-    "frame",
+    "frame, message",
     [
-        "",
-        "01",
-        "010012",
-        "0100123400",  # Identification requests cannot contain trailing bytes.
-        "02001234",  # Read request is missing its dictionary address.
-        "0200123426E60000",  # Read request cannot contain trailing payload bytes.
-        "03001234282100",  # Write requests require a non-empty value.
-        "05001234",  # Unsubscribe requests require a subscription identifier.
-        "0301123400",  # Write success responses cannot contain payload bytes.
-        "04011234",  # Subscribe responses require a subscription identifier.
-        "04011234567800",  # Subscribe responses cannot contain trailing payload bytes.
-        "0501123400",  # Unsubscribe responses cannot contain payload bytes.
-        # Identification responses cannot contain trailing bytes.
-        "01011234001234567890ABCDEF0000000000",
-        "02031234FFFF",  # Error responses require a 32-bit error code.
-        "02031234FFFF0001FF",  # Error responses cannot contain trailing bytes.
+        pytest.param("", "four-byte header", id="truncated-header"),
+        pytest.param("01", "four-byte header", id="truncated-header-opcode"),
+        pytest.param("010012", "four-byte header", id="truncated-header-transaction-id"),
+        pytest.param(
+            "0100123400", "1 unexpected trailing bytes", id="identification-request-trailing"
+        ),
+        pytest.param(
+            "01011234001234567890ABCDEF0000000000",
+            "1 unexpected trailing bytes",
+            id="identification-response-trailing",
+        ),
+        pytest.param(
+            "02001234", "requested 2 bytes.*only 0 remain", id="read-request-truncated-address"
+        ),
+        pytest.param("0200123426E60000", "1 unexpected trailing bytes", id="read-request-trailing"),
+        pytest.param(
+            "03001234282100", "Write requests require a value payload", id="write-request-empty"
+        ),
+        pytest.param(
+            "040012345678",
+            "requested 1 bytes.*only 0 remain",
+            id="subscribe-request-truncated-address",
+        ),
+        pytest.param(
+            "04001234203100",
+            "requested 1 bytes.*only 0 remain",
+            id="subscribe-request-truncated-mode",
+        ),
+        pytest.param(
+            "0400123420310001006407D000",
+            "1 unexpected trailing bytes",
+            id="subscribe-request-trailing",
+        ),
+        pytest.param(
+            "04001234203100010064",
+            "requested 2 bytes.*only 0 remain",
+            id="subscribe-request-truncated-message-count",
+        ),
+        pytest.param(
+            "0400123420310003006407D0",
+            "unknown subscription mode: 0x03",
+            id="subscribe-request-unknown-mode",
+        ),
+        pytest.param(
+            "05001234",
+            "requested 2 bytes.*only 0 remain",
+            id="unsubscribe-request-truncated-id",
+        ),
+        pytest.param("0301123400", "1 unexpected trailing bytes", id="write-response-trailing"),
+        pytest.param(
+            "04011234",
+            "requested 2 bytes.*only 0 remain",
+            id="subscribe-response-truncated-id",
+        ),
+        pytest.param(
+            "04011234567800", "1 unexpected trailing bytes", id="subscribe-response-trailing"
+        ),
+        pytest.param(
+            "0501123400", "1 unexpected trailing bytes", id="unsubscribe-response-trailing"
+        ),
+        pytest.param(
+            "02031234FFFF",
+            "requested 4 bytes.*only 2 remain",
+            id="error-response-truncated-code",
+        ),
+        pytest.param(
+            "02031234FFFF0001FF",
+            "1 unexpected trailing bytes",
+            id="error-response-trailing",
+        ),
     ],
 )
-def test_deserialize_rejects_malformed_known_frames(frame: str) -> None:
-    """Reject known message types whose payload does not match the protocol layout."""
-    with pytest.raises(ValueError):
+def test_deserialize_rejects_malformed_frames(frame: str, message: str) -> None:
+    """Reject malformed SDCP headers and message payloads for their expected reasons."""
+    with pytest.raises(ValueError, match=message):
         SDCPSerializer.deserialize(bytes.fromhex(frame))
 
 

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from ingenialink.utils.sdcp import (
+    SDCPDeserializer,
     SDCPErrorResponse,
     SDCPEventSubscriptionRequest,
     SDCPFlag,
@@ -16,7 +17,6 @@ from ingenialink.utils.sdcp import (
     SDCPReadRequest,
     SDCPReadResponse,
     SDCPReadResponseError,
-    SDCPSerializer,
     SDCPSubscribeResponse,
     SDCPSubscribeResponseError,
     SDCPUnknownFrame,
@@ -108,7 +108,7 @@ from ingenialink.utils.sdcp import (
 def test_serialize_message_objects(message: _SDCPMessage, expected_frame: bytes) -> None:
     """Serialize every supported typed message into its specification frame."""
     assert bytes(message) == expected_frame
-    assert SDCPSerializer.deserialize(bytes(message)) == message
+    assert SDCPDeserializer.deserialize(bytes(message)) == message
 
 
 @pytest.mark.parametrize(
@@ -128,7 +128,7 @@ def test_serialize_error_response_uses_opcode_and_error_flags(
     frame = bytes(message)
 
     assert frame[:2] == bytes((expected_opcode, SDCPFlag.REPLY | SDCPFlag.ERROR))
-    assert SDCPSerializer.deserialize(frame) == message
+    assert SDCPDeserializer.deserialize(frame) == message
 
 
 def test_serialize_rejects_base_error_response() -> None:
@@ -192,13 +192,13 @@ def test_payload_reader_requires_bytes(payload: object) -> None:
 def test_deserialize_requires_bytes() -> None:
     """Require complete SDCP frames to be immutable bytes."""
     with pytest.raises(TypeError, match="Payload must be bytes"):
-        SDCPSerializer.deserialize("01001234")  # type: ignore[arg-type]
+        SDCPDeserializer.deserialize("01001234")  # type: ignore[arg-type]
 
 
 def test_identification_response_requires_revision_number() -> None:
     """Keep Identification responses strict at the documented 13-byte layout."""
     with pytest.raises(ValueError, match="requested 4 bytes.*only 0 remain"):
-        SDCPSerializer.deserialize(bytes.fromhex("01011234001234567890ABCDEF"))
+        SDCPDeserializer.deserialize(bytes.fromhex("01011234001234567890ABCDEF"))
 
 
 @pytest.mark.parametrize(
@@ -228,7 +228,7 @@ def test_identification_response_requires_revision_number() -> None:
 )
 def test_deserialize_frame_matches_expected_message(frame: str, expected_message: object) -> None:
     """Deserialize every documented frame layout into its specialized message."""
-    assert SDCPSerializer.deserialize(bytes.fromhex(frame)) == expected_message
+    assert SDCPDeserializer.deserialize(bytes.fromhex(frame)) == expected_message
 
 
 @pytest.mark.parametrize(
@@ -240,7 +240,7 @@ def test_deserialize_frame_matches_expected_message(frame: str, expected_message
 )
 def test_deserialize_unknown_frame(frame: str, expected_message: SDCPUnknownFrame) -> None:
     """Preserve unsupported opcodes and flags without guessing their layout."""
-    decoded_message = SDCPSerializer.deserialize(bytes.fromhex(frame))
+    decoded_message = SDCPDeserializer.deserialize(bytes.fromhex(frame))
 
     assert decoded_message == expected_message
 
@@ -271,7 +271,7 @@ def test_deserialize_specialized_error_responses(
     frame: str, expected_message: SDCPErrorResponse
 ) -> None:
     """Decode each known operation's error response into its specific type."""
-    decoded_message = SDCPSerializer.deserialize(bytes.fromhex(frame))
+    decoded_message = SDCPDeserializer.deserialize(bytes.fromhex(frame))
 
     assert decoded_message == expected_message
     assert isinstance(decoded_message, SDCPErrorResponse)
@@ -383,7 +383,7 @@ def test_message_representation_uses_protocol_field_formats() -> None:
 def test_deserialize_rejects_malformed_frames(frame: str, message: str) -> None:
     """Reject malformed SDCP headers and message payloads for their expected reasons."""
     with pytest.raises(ValueError, match=message):
-        SDCPSerializer.deserialize(bytes.fromhex(frame))
+        SDCPDeserializer.deserialize(bytes.fromhex(frame))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_sdcp.py
+++ b/tests/test_sdcp.py
@@ -1,5 +1,7 @@
 """Tests for SDCP acyclic frame serialization."""
 
+from __future__ import annotations
+
 import pytest
 
 from ingenialink.utils.sdcp import SDCPFlag, SDCPFrame, SDCPOpcode, SDCPSerializer
@@ -11,11 +13,27 @@ def test_serialize_read_request() -> None:
         SDCPOpcode.READ,
         SDCPFlag.NONE,
         0x1234,
-        bytes.fromhex("26E600"),
+        0x26E6,
+        0x00,
     )
 
     # The transaction ID is encoded as the big-endian bytes 12 34.
     assert frame == bytes.fromhex("0200123426E600")
+
+
+def test_serialize_write_request() -> None:
+    """Serialize the Write request from the SDCP protocol specification."""
+    frame = SDCPSerializer.serialize(
+        SDCPOpcode.WRITE,
+        SDCPFlag.NONE,
+        0x1234,
+        0x2821,
+        0x00,
+        bytes.fromhex("42C80000"),
+    )
+
+    # The value bytes follow the index and subindex fields.
+    assert frame == bytes.fromhex("0300123428210042C80000")
 
 
 def test_deserialize_read_response() -> None:
@@ -69,7 +87,7 @@ def test_round_trip_error_response() -> None:
         decoded_frame.opcode,
         decoded_frame.flags,
         decoded_frame.transaction_id,
-        decoded_frame.payload,
+        payload=decoded_frame.payload,
     )
 
     assert serialized_frame == received_frame
@@ -132,6 +150,37 @@ def test_serialize_rejects_oversized_header_fields(
     """Reject fields that cannot fit in their SDCP header positions."""
     with pytest.raises(ValueError):
         SDCPSerializer.serialize(opcode, flags, transaction_id)
+
+
+@pytest.mark.parametrize(
+    "index, subindex",
+    [
+        (0x100B, None),
+        (None, 0x00),
+        (0x1_0000, 0x00),
+        (0x100B, 0x100),
+    ],
+)
+def test_serialize_rejects_invalid_dictionary_address(
+    index: int | None, subindex: int | None
+) -> None:
+    """Require a complete dictionary address that fits the protocol fields."""
+    with pytest.raises(ValueError):
+        SDCPSerializer.serialize(
+            SDCPOpcode.READ, SDCPFlag.NONE, 0x1234, index=index, subindex=subindex
+        )
+
+
+def test_serialize_rejects_dictionary_request_without_address() -> None:
+    """Require an index and subindex for a dictionary request."""
+    with pytest.raises(ValueError, match="require index and subindex"):
+        SDCPSerializer.serialize(SDCPOpcode.READ, SDCPFlag.NONE, 0x1234)
+
+
+def test_serialize_rejects_write_request_without_value() -> None:
+    """Require a value payload for a Write request after its dictionary address."""
+    with pytest.raises(ValueError, match="require a value payload"):
+        SDCPSerializer.serialize(SDCPOpcode.WRITE, SDCPFlag.NONE, 0x1234, 0x2821, 0x00)
 
 
 @pytest.mark.parametrize("frame", [b"", b"\x01", b"\x01\x00\x12"])


### PR DESCRIPTION
This pull request implements typed SDCP message encoding and frame deserialization, together with comprehensive protocol test coverage.

## SDCP message encoding

- Added typed message classes for all supported SDCP requests, successful responses, error responses, and unknown frames.
- Added self-serialization through `bytes(message)`.

## SDCP frame deserialization

- Added `SDCPDeserializer` to parse incoming frames into their corresponding typed message objects.


## Tests

- Added tests for encoding every supported SDCP request, response, and error-message type.
- Verified generated frames against the SDCP protocol examples.
- Added deserialization tests for all supported message layouts.
- Added round-trip tests using `SDCPDeserializer.deserialize(bytes(message))`.
- Added tests for malformed and incomplete frames with expected error messages.
- Added parameterized tests for invalid types and out-of-range field values.
- Added tests for unknown-frame preservation and lossless serialization.
- Added tests for protocol-oriented hexadecimal message representations.

## Validation

- Validated SDCP frame encoding and deserialization against a servo drive by reading the registers currently available in the bootloader.
- Application-level validation is not yet possible because the drive application is still under development.