### PR TITLE
INGM-791 Replace ClassVars for Final

### DIFF
--- a/ingenialink/pdo.py
+++ b/ingenialink/pdo.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 from collections import OrderedDict
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Callable, ClassVar, Literal, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, Final, Literal, Optional, TypeVar, Union
 
 import bitarray
 from typing_extensions import override
@@ -55,7 +55,7 @@ class PDOMapItem:
     __SUBINDEX_BITFIELD = "SUBINDEX"
     __INDEX_BITFIELD = "INDEX"
 
-    __ITEM_BITFIELDS: ClassVar[dict[str, BitField]] = {
+    __ITEM_BITFIELDS: Final[dict[str, BitField]] = {
         __LENGTH_BITFIELD: BitField(0, 7),
         __SUBINDEX_BITFIELD: BitField(8, 15),
         __INDEX_BITFIELD: BitField(16, 31),

--- a/tests/test_configuration_file.py
+++ b/tests/test_configuration_file.py
@@ -1,5 +1,5 @@
 import logging
-from typing import ClassVar
+from typing import Final
 from xml.etree import ElementTree
 
 import pytest
@@ -19,7 +19,7 @@ from ingenialink.register import Register
 
 
 class RegisterXCFElementFactory:
-    DEFAULT_ATTRIBUTES: ClassVar[dict] = {
+    DEFAULT_ATTRIBUTES: Final[dict] = {
         ConfigRegister._ConfigRegister__ID_ATTR: "PROF_MAX_VEL",
         ConfigRegister._ConfigRegister__SUBNODE_ATTR: "1",
         ConfigRegister._ConfigRegister__DTYPE_ATTR: "float",


### PR DESCRIPTION
This pull request refactors type annotations in both the main code and tests to use `Final` instead of `ClassVar` for certain constant class attributes. This change clarifies that these attributes are intended to be immutable constants rather than just class-level variables.