### PR TITLE
INGK-1292 Separate shared and concrete ethernet network responsibilities

### DIFF
--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -113,7 +113,7 @@ class NetStatusListener(Thread, Generic[EthernetServoT]):
         self.__stop = True
 
 
-class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT, SDCPServo]]):
+class EthernetNetworkBase(Generic[EthernetServoT], Network[Servo]):
     """Base class  for all Ethernet communications."""
 
     def __init__(

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -83,11 +83,6 @@ class NetStatusListener(Thread, Generic[EthernetServoT]):
         subscribers of any state changes (connection/disconnection).
         """
         for servo in self.__network.servos:
-            if not isinstance(servo, (EthernetServo, SDCPServo)):
-                # Virtual ethernet servos do not yet implement ip address attr
-                # https://novantamotion.atlassian.net/browse/INGK-1286
-                continue
-
             servo_state = self.__network.get_servo_state(servo)
             is_servo_alive = servo.is_alive(attemps=MAX_NUM_UNSUCCESSFUL_PINGS)
             if servo_state == NetState.CONNECTED and not is_servo_alive:
@@ -189,6 +184,31 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Servo]):
         if net_status_listener:
             self.start_status_listener()
         return servo
+
+    def disconnect_from_slave(self, servo: EthernetServoT) -> None:  # type: ignore [override]
+        """Disconnects the slave from the network.
+
+        Args:
+            servo: Instance of the servo connected.
+
+        Raises:
+            ValueError: If the provided servo is not an Ethernet servo.
+
+        """
+        servo.stop_status_listener()
+        self._close_socket(servo.socket)
+        self._set_servo_state(servo, NetState.DISCONNECTED)
+        self.servos.remove(servo)
+        if len(self.servos) == 0:
+            self.stop_status_listener()
+        # Notify that disconnect_from_slave has been called
+        servo._disconnect_event_publisher.notify(servo)
+
+    @staticmethod
+    def _close_socket(sock: socket.socket) -> None:
+        """Closes the established network socket."""
+        sock.shutdown(socket.SHUT_RDWR)
+        sock.close()
 
     def start_status_listener(self) -> None:
         """Start monitoring network events (CONNECTION/DISCONNECTION)."""
@@ -460,31 +480,6 @@ class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
             raise TypeError(f"Expected revision number type to be int, got {type(revision_number)}")
         self.disconnect_from_slave(servo)
         return SlaveInfo(product_code, revision_number)
-
-    def disconnect_from_slave(self, servo: EthernetServoT) -> None:  # type: ignore [override]
-        """Disconnects the slave from the network.
-
-        Args:
-            servo: Instance of the servo connected.
-
-        Raises:
-            ValueError: If the provided servo is not an Ethernet servo.
-
-        """
-        servo.stop_status_listener()
-        self.close_socket(servo.socket)
-        self._set_servo_state(servo, NetState.DISCONNECTED)
-        self.servos.remove(servo)
-        if len(self.servos) == 0:
-            self.stop_status_listener()
-        # Notify that disconnect_from_slave has been called
-        servo._disconnect_event_publisher.notify(servo)
-
-    @staticmethod
-    def close_socket(sock: socket.socket) -> None:
-        """Closes the established network socket."""
-        sock.shutdown(socket.SHUT_RDWR)
-        sock.close()
 
     @override
     def recover_from_disconnection(self, servo: Optional[Servo] = None) -> bool:

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -114,26 +114,12 @@ class NetStatusListener(Thread, Generic[EthernetServoT]):
 
 
 class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT, SDCPServo]]):
-    """Network for all Ethernet communications.
-
-    Args:
-        subnet: Optional subnet in CIDR notation used for IPv4 scanning.
-        interface: Optional network interface used for Ethernet communication.
-
-    """
+    """Base class  for all Ethernet communications."""
 
     def __init__(
         self,
-        subnet: Optional[str] = None,
-        interface: Optional[str] = None,
     ) -> None:
         super().__init__()
-        self.__subnet: Optional[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
-        if subnet is not None:
-            self.__subnet = ipaddress.ip_network(subnet, strict=False)
-        else:
-            self.__subnet = None
-        self.__interface = interface
         self.__listener_net_status: Optional[NetStatusListener[EthernetServoT]] = None
 
     @abstractmethod
@@ -260,7 +246,13 @@ class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
         subnet: Optional[str] = None,
         interface: Optional[str] = None,
     ) -> None:
-        super().__init__(subnet=subnet, interface=interface)
+        super().__init__()
+        self.__subnet: Optional[Union[ipaddress.IPv4Network, ipaddress.IPv6Network]]
+        if subnet is not None:
+            self.__subnet = ipaddress.ip_network(subnet, strict=False)
+        else:
+            self.__subnet = None
+        self.__interface = interface
         self._sdcp_nodes: dict[str, SDCPNode] = {}
 
     @staticmethod

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -136,6 +136,133 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT,
         self.__interface = interface
         self.__listener_net_status: Optional[NetStatusListener[EthernetServoT]] = None
 
+    @abstractmethod
+    def _create_servo(
+        self,
+        *,
+        target: str,
+        dictionary: str,
+        port: int,
+        connection_timeout: float,
+        servo_status_listener: bool,
+        is_eoe: bool,
+        disconnect_callback: Optional[Callable[[Servo], None]],
+    ) -> EthernetServoT:
+        """Create a servo for this Ethernet network implementation."""
+        raise NotImplementedError
+
+    def connect_to_slave(
+        self,
+        target: str,
+        dictionary: str,
+        port: int = 1061,
+        connection_timeout: float = DEFAULT_ETH_CONNECTION_TIMEOUT,
+        servo_status_listener: bool = False,
+        net_status_listener: bool = False,
+        is_eoe: bool = False,
+        disconnect_callback: Optional[Callable[[Servo], None]] = None,
+    ) -> EthernetServoT:
+        """Connects to a slave through the given network settings.
+
+        Args:
+            target: IP of the target slave.
+            dictionary: Path to the target dictionary file.
+            port: Port to connect to the slave.
+            connection_timeout: Time in seconds of the connection timeout.
+            servo_status_listener: Toggle the listener of the servo for
+                its status, errors, faults, etc.
+            net_status_listener: Toggle the listener of the network
+                status, connection and disconnection.
+            is_eoe: True if communication is EoE. ``False`` by default.
+            disconnect_callback: Callback function to be called when the servo is disconnected.
+                If not specified, no callback will be called.
+
+        Returns:
+            EthernetServo: Instance of the servo connected.
+
+        Raises:
+            ILError: If the drive is not found.
+        """
+        servo = self._create_servo(
+            target=target,
+            dictionary=dictionary,
+            port=port,
+            connection_timeout=connection_timeout,
+            servo_status_listener=servo_status_listener,
+            is_eoe=is_eoe,
+            disconnect_callback=disconnect_callback,
+        )
+        try:
+            servo.get_state()
+        except ILError as e:
+            servo.stop_status_listener()
+            raise ILError(f"Drive not found in IP {target}.") from e
+        self.servos.append(servo)
+        self._set_servo_state(target, NetState.CONNECTED)
+
+        if net_status_listener:
+            self.start_status_listener()
+        return servo
+
+    def start_status_listener(self) -> None:
+        """Start monitoring network events (CONNECTION/DISCONNECTION)."""
+        if self.__listener_net_status is None:
+            listener = NetStatusListener[EthernetServoT](self)
+            listener.start()
+            self.__listener_net_status = listener
+
+    def stop_status_listener(self) -> None:
+        """Stops the NetStatusListener from listening to the drive."""
+        if self.__listener_net_status is not None:
+            self.__listener_net_status.stop()
+            self.__listener_net_status.join()
+        self.__listener_net_status = None
+
+    def get_servo_state(self, servo_id: ServoTarget) -> NetState:
+        """Get the state of a servo that's a part of network.
+
+        The state indicates if the servo is connected or disconnected.
+
+        Args:
+            servo_id: The servo target or servo instance.
+
+        Returns:
+            The servo's state.
+
+        Raises:
+            ValueError: if the servo ID is not a string or a servo instance.
+        """
+        if not isinstance(servo_id, (str, Servo)):
+            raise ValueError("The servo ID must be a string or an instance of Servo.")
+        return super().get_servo_state(servo_id)
+
+    @property
+    def protocol(self) -> NetProt:
+        """Obtain network protocol."""
+        return NetProt.ETH
+
+
+class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
+    """Network for all Ethernet communications.
+
+    Args:
+        subnet: Optional subnet in CIDR notation used for IPv4 scanning.
+        interface: Optional network interface used to derive the IPv4 subnet
+            and perform IPv6 discovery.
+
+    The interface is required for SDCP because link-local IPv6 subnets can
+    exist on multiple network interfaces. The interface identifies the network
+    link used for SDCP communication.
+    """
+
+    def __init__(
+        self,
+        subnet: Optional[str] = None,
+        interface: Optional[str] = None,
+    ) -> None:
+        super().__init__(subnet=subnet, interface=interface)
+        self._sdcp_nodes: dict[str, SDCPNode] = {}
+
     @staticmethod
     def load_firmware(
         fw_file: str, target: str = "192.168.2.22", ftp_user: str = "", ftp_pwd: str = ""
@@ -246,6 +373,25 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT,
                 logger.error(e)
                 raise ILFirmwareLoadError("Error during bootloader process.")
 
+    def scan_slaves(self) -> list[str]:  # type: ignore [override]
+        """Scan drives connected to the network.
+
+        Returns:
+            List containing the IPs of the detected drives.
+
+        """
+        detected_slaves = self.scan_slaves_info()
+        return list(detected_slaves.keys())
+
+    @override
+    def scan_slaves_info(self) -> OrderedDict[str, SlaveInfo]:  # type: ignore [override]
+        slave_info: OrderedDict[str, SlaveInfo] = OrderedDict()
+        slaves = self._scan_slaves()
+        for slave_id in slaves:
+            with contextlib.suppress(ILError):
+                slave_info[slave_id] = self._get_servo_info_for_scan(slave_id)
+        return slave_info
+
     def _scan_slaves(self) -> list[str]:
         """Ping all IPv4 addresses in the configured network.
 
@@ -290,177 +436,6 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT,
 
         return get_interface_ipv4_subnet(interface)
 
-    @abstractmethod
-    def _create_servo(
-        self,
-        *,
-        target: str,
-        dictionary: str,
-        port: int,
-        connection_timeout: float,
-        servo_status_listener: bool,
-        is_eoe: bool,
-        disconnect_callback: Optional[Callable[[Servo], None]],
-    ) -> EthernetServoT:
-        """Create a servo for this Ethernet network implementation."""
-        raise NotImplementedError
-
-    def scan_slaves(self) -> list[str]:  # type: ignore [override]
-        """Scan drives connected to the network.
-
-        Returns:
-            List containing the IPs of the detected drives.
-
-        """
-        detected_slaves = self.scan_slaves_info()
-        return list(detected_slaves.keys())
-
-    @override
-    def scan_slaves_info(self) -> OrderedDict[str, SlaveInfo]:  # type: ignore [override]
-        slave_info: OrderedDict[str, SlaveInfo] = OrderedDict()
-        slaves = self._scan_slaves()
-        for slave_id in slaves:
-            with contextlib.suppress(ILError):
-                slave_info[slave_id] = self._get_servo_info_for_scan(slave_id)
-        return slave_info
-
-    def connect_to_slave(
-        self,
-        target: str,
-        dictionary: str,
-        port: int = 1061,
-        connection_timeout: float = DEFAULT_ETH_CONNECTION_TIMEOUT,
-        servo_status_listener: bool = False,
-        net_status_listener: bool = False,
-        is_eoe: bool = False,
-        disconnect_callback: Optional[Callable[[Servo], None]] = None,
-    ) -> EthernetServoT:
-        """Connects to a slave through the given network settings.
-
-        Args:
-            target: IP of the target slave.
-            dictionary: Path to the target dictionary file.
-            port: Port to connect to the slave.
-            connection_timeout: Time in seconds of the connection timeout.
-            servo_status_listener: Toggle the listener of the servo for
-                its status, errors, faults, etc.
-            net_status_listener: Toggle the listener of the network
-                status, connection and disconnection.
-            is_eoe: True if communication is EoE. ``False`` by default.
-            disconnect_callback: Callback function to be called when the servo is disconnected.
-                If not specified, no callback will be called.
-
-        Returns:
-            EthernetServo: Instance of the servo connected.
-
-        Raises:
-            ILError: If the drive is not found.
-        """
-        servo = self._create_servo(
-            target=target,
-            dictionary=dictionary,
-            port=port,
-            connection_timeout=connection_timeout,
-            servo_status_listener=servo_status_listener,
-            is_eoe=is_eoe,
-            disconnect_callback=disconnect_callback,
-        )
-        try:
-            servo.get_state()
-        except ILError as e:
-            servo.stop_status_listener()
-            raise ILError(f"Drive not found in IP {target}.") from e
-        self.servos.append(servo)
-        self._set_servo_state(target, NetState.CONNECTED)
-
-        if net_status_listener:
-            self.start_status_listener()
-        return servo
-
-    def disconnect_from_slave(self, servo: EthernetServoT) -> None:  # type: ignore [override]
-        """Disconnects the slave from the network.
-
-        Args:
-            servo: Instance of the servo connected.
-
-        Raises:
-            ValueError: If the provided servo is not an Ethernet servo.
-
-        """
-        servo.stop_status_listener()
-        self.close_socket(servo.socket)
-        self._set_servo_state(servo, NetState.DISCONNECTED)
-        self.servos.remove(servo)
-        if len(self.servos) == 0:
-            self.stop_status_listener()
-        # Notify that disconnect_from_slave has been called
-        servo._disconnect_event_publisher.notify(servo)
-
-    @staticmethod
-    def close_socket(sock: socket.socket) -> None:
-        """Closes the established network socket."""
-        sock.shutdown(socket.SHUT_RDWR)
-        sock.close()
-
-    def start_status_listener(self) -> None:
-        """Start monitoring network events (CONNECTION/DISCONNECTION)."""
-        if self.__listener_net_status is None:
-            listener = NetStatusListener[EthernetServoT](self)
-            listener.start()
-            self.__listener_net_status = listener
-
-    def stop_status_listener(self) -> None:
-        """Stops the NetStatusListener from listening to the drive."""
-        if self.__listener_net_status is not None:
-            self.__listener_net_status.stop()
-            self.__listener_net_status.join()
-        self.__listener_net_status = None
-
-    @override
-    def recover_from_disconnection(self, servo: Optional[Servo] = None) -> bool:
-        """Recover the communication with a servo after a disconnection.
-
-        This method attempts to re-establish communication with a servo
-        that has been previously disconnected. It checks if the servo
-        is responding again.
-
-        Args:
-            servo: The servo to recover communication with.
-
-        Returns:
-            True if communication with the servo is recovered, False otherwise.
-
-        Raises:
-            ValueError: If the servo argument is None or not an Ethernet or SDCP Servo instance.
-        """
-        if servo is None or not isinstance(servo, (EthernetServo, SDCPServo)):
-            raise ValueError("An Ethernet or SDCP Servo instance must be provided for recovery.")
-
-        if servo.is_alive(attemps=MAX_NUM_UNSUCCESSFUL_PINGS):
-            logger.info(f"Communication with servo at {servo.target} recovered.")
-            return True
-
-        logger.warning(f"Failed to recover communication with servo at {servo.target}.")
-        return False
-
-    def get_servo_state(self, servo_id: ServoTarget) -> NetState:
-        """Get the state of a servo that's a part of network.
-
-        The state indicates if the servo is connected or disconnected.
-
-        Args:
-            servo_id: The servo target or servo instance.
-
-        Returns:
-            The servo's state.
-
-        Raises:
-            ValueError: if the servo ID is not a string or a servo instance.
-        """
-        if not isinstance(servo_id, (str, Servo)):
-            raise ValueError("The servo ID must be a string or an instance of Servo.")
-        return super().get_servo_state(servo_id)
-
     def _get_servo_info_for_scan(self, ip_address: str) -> SlaveInfo:
         """Get the product code and revision number of a drive.
 
@@ -494,37 +469,57 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Union[EthernetServoT,
         self.disconnect_from_slave(servo)
         return SlaveInfo(product_code, revision_number)
 
-    @property
-    def protocol(self) -> NetProt:
-        """Obtain network protocol."""
-        return NetProt.ETH
+    def disconnect_from_slave(self, servo: EthernetServoT) -> None:  # type: ignore [override]
+        """Disconnects the slave from the network.
 
-    @property
-    def interface(self) -> Optional[str]:
-        """Obtain network interface."""
-        return self.__interface
+        Args:
+            servo: Instance of the servo connected.
 
+        Raises:
+            ValueError: If the provided servo is not an Ethernet servo.
 
-class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
-    """Network for all Ethernet communications.
+        """
+        servo.stop_status_listener()
+        self.close_socket(servo.socket)
+        self._set_servo_state(servo, NetState.DISCONNECTED)
+        self.servos.remove(servo)
+        if len(self.servos) == 0:
+            self.stop_status_listener()
+        # Notify that disconnect_from_slave has been called
+        servo._disconnect_event_publisher.notify(servo)
 
-    Args:
-        subnet: Optional subnet in CIDR notation used for IPv4 scanning.
-        interface: Optional network interface used to derive the IPv4 subnet
-            and perform IPv6 discovery.
+    @staticmethod
+    def close_socket(sock: socket.socket) -> None:
+        """Closes the established network socket."""
+        sock.shutdown(socket.SHUT_RDWR)
+        sock.close()
 
-    The interface is required for SDCP because link-local IPv6 subnets can
-    exist on multiple network interfaces. The interface identifies the network
-    link used for SDCP communication.
-    """
+    @override
+    def recover_from_disconnection(self, servo: Optional[Servo] = None) -> bool:
+        """Recover the communication with a servo after a disconnection.
 
-    def __init__(
-        self,
-        subnet: Optional[str] = None,
-        interface: Optional[str] = None,
-    ) -> None:
-        super().__init__(subnet=subnet, interface=interface)
-        self._sdcp_nodes: dict[str, SDCPNode] = {}
+        This method attempts to re-establish communication with a servo
+        that has been previously disconnected. It checks if the servo
+        is responding again.
+
+        Args:
+            servo: The servo to recover communication with.
+
+        Returns:
+            True if communication with the servo is recovered, False otherwise.
+
+        Raises:
+            ValueError: If the servo argument is None or not an Ethernet or SDCP Servo instance.
+        """
+        if servo is None or not isinstance(servo, (EthernetServo, SDCPServo)):
+            raise ValueError("An Ethernet or SDCP Servo instance must be provided for recovery.")
+
+        if servo.is_alive(attemps=MAX_NUM_UNSUCCESSFUL_PINGS):
+            logger.info(f"Communication with servo at {servo.target} recovered.")
+            return True
+
+        logger.warning(f"Failed to recover communication with servo at {servo.target}.")
+        return False
 
     def scan_sdcp_nodes(
         self,
@@ -675,3 +670,8 @@ class EthernetNetwork(EthernetNetworkBase[EthernetServo]):
             is_eoe,
             disconnect_callback=disconnect_callback,
         )
+
+    @property
+    def interface(self) -> Optional[str]:
+        """Obtain network interface."""
+        return self.__interface

--- a/ingenialink/ethernet/network.py
+++ b/ingenialink/ethernet/network.py
@@ -36,6 +36,7 @@ from ingenialink.network import (
     NetProt,
     NetState,
     Network,
+    ServoT,
     ServoTarget,
     SlaveInfo,
 )
@@ -60,7 +61,7 @@ SCAN_CONNECTION_TIMEOUT = 0.5
 EthernetServoT = TypeVar("EthernetServoT", bound=EthernetServoBase, default=EthernetServoBase)
 
 
-class NetStatusListener(Thread, Generic[EthernetServoT]):
+class NetStatusListener(Thread, Generic[ServoT]):
     """Network status listener thread to check if the drive is alive.
 
     Args:
@@ -68,9 +69,7 @@ class NetStatusListener(Thread, Generic[EthernetServoT]):
 
     """
 
-    def __init__(
-        self, network: "EthernetNetworkBase[EthernetServoT]", refresh_time: float = 0.25
-    ) -> None:
+    def __init__(self, network: "Network[ServoT]", refresh_time: float = 0.25) -> None:
         super().__init__()
         self.__network = network
         self.__refresh_time = refresh_time
@@ -115,7 +114,7 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Servo]):
         self,
     ) -> None:
         super().__init__()
-        self.__listener_net_status: Optional[NetStatusListener[EthernetServoT]] = None
+        self.__listener_net_status: Optional[NetStatusListener[Servo]] = None
 
     @abstractmethod
     def _create_servo(
@@ -213,7 +212,7 @@ class EthernetNetworkBase(Generic[EthernetServoT], Network[Servo]):
     def start_status_listener(self) -> None:
         """Start monitoring network events (CONNECTION/DISCONNECTION)."""
         if self.__listener_net_status is None:
-            listener = NetStatusListener[EthernetServoT](self)
+            listener = NetStatusListener(self)
             listener.start()
             self.__listener_net_status = listener
 

--- a/ingenialink/virtual/canopen/network.py
+++ b/ingenialink/virtual/canopen/network.py
@@ -1,7 +1,5 @@
 import socket
-import time
 from collections import OrderedDict
-from threading import Thread
 from typing import Any, Callable, Optional
 
 import ingenialogger
@@ -9,56 +7,14 @@ from typing_extensions import override
 
 from ingenialink.canopen.network import CanopenNetworkBase
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
+from ingenialink.ethernet.network import NetStatusListener
 from ingenialink.exceptions import ILError
-from ingenialink.network import NetDevEvt, NetProt, NetState, SlaveInfo
+from ingenialink.network import NetProt, NetState, SlaveInfo
 from ingenialink.servo import Servo
 from ingenialink.virtual.base_network import VirtualNetworkBase
 from ingenialink.virtual.canopen.servo import VirtualCanopenServo
 
 logger = ingenialogger.get_logger(__name__)
-
-
-class VirtualCanopenNetStatusListener(Thread):
-    """Network status listener for virtual CANopen servos.
-
-    Periodically checks whether each servo is alive and emits
-    connection/disconnection events when the state changes.
-
-    Args:
-        network: The virtual CANopen network instance.
-        refresh_time: How often to poll servo status, in seconds.
-
-    """
-
-    def __init__(self, network: "VirtualCanopenNetwork", refresh_time: float = 0.25) -> None:
-        super().__init__()
-        self.__network = network
-        self.__refresh_time = refresh_time
-        self.__stop = False
-
-    def run(self) -> None:
-        """Continuously check the status of all servos in the network."""
-        while not self.__stop:
-            try:
-                for servo in self.__network.servos:
-                    target = servo.target
-                    servo_state = self.__network.get_servo_state(target)
-                    is_servo_alive = servo.is_alive()
-                    if servo_state == NetState.CONNECTED and not is_servo_alive:
-                        self.__network._transition_servo_state(target, NetDevEvt.REMOVED)
-                    if (
-                        servo_state == NetState.DISCONNECTED
-                        and is_servo_alive
-                        and self.__network.recover_from_disconnection(servo)
-                    ):
-                        self.__network._transition_servo_state(target, NetDevEvt.ADDED)
-            except Exception as e:
-                logger.exception(f"Exception during virtual CANopen status check: {e}")
-            time.sleep(self.__refresh_time)
-
-    def stop(self) -> None:
-        """Stop the listener."""
-        self.__stop = True
 
 
 class VirtualCanopenNetwork(CanopenNetworkBase[VirtualCanopenServo]):
@@ -67,7 +23,7 @@ class VirtualCanopenNetwork(CanopenNetworkBase[VirtualCanopenServo]):
     def __init__(self) -> None:
         super().__init__()
         self._virtual_base = VirtualNetworkBase()
-        self.__listener_net_status: Optional[VirtualCanopenNetStatusListener] = None
+        self.__listener_net_status: Optional[NetStatusListener[VirtualCanopenServo]] = None
 
     @property
     def protocol(self) -> NetProt:
@@ -171,7 +127,7 @@ class VirtualCanopenNetwork(CanopenNetworkBase[VirtualCanopenServo]):
     def start_status_listener(self) -> None:
         """Start monitoring network events (CONNECTION/DISCONNECTION)."""
         if self.__listener_net_status is None:
-            listener = VirtualCanopenNetStatusListener(self)
+            listener = NetStatusListener(self)
             listener.start()
             self.__listener_net_status = listener
 

--- a/ingenialink/virtual/ethercat/network.py
+++ b/ingenialink/virtual/ethercat/network.py
@@ -1,7 +1,5 @@
 import socket
-import time
 from collections import OrderedDict
-from threading import Thread
 from typing import Any, Callable, Optional
 
 import ingenialogger
@@ -9,56 +7,14 @@ from typing_extensions import override
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.ethercat.network import EthercatNetworkBase
+from ingenialink.ethernet.network import NetStatusListener
 from ingenialink.exceptions import ILError
-from ingenialink.network import NetDevEvt, NetState, SlaveInfo
+from ingenialink.network import NetState, SlaveInfo
 from ingenialink.servo import Servo
 from ingenialink.virtual.base_network import VirtualNetworkBase
 from ingenialink.virtual.ethercat.servo import VirtualEthercatServo
 
 logger = ingenialogger.get_logger(__name__)
-
-
-class VirtualNetStatusListener(Thread):
-    """Network status listener for virtual EtherCAT servos.
-
-    Periodically checks whether each servo is alive and emits
-    connection/disconnection events when the state changes.
-
-    Args:
-        network: The virtual EtherCAT network instance.
-        refresh_time: How often to poll servo status, in seconds.
-
-    """
-
-    def __init__(self, network: "VirtualEthercatNetwork", refresh_time: float = 0.25) -> None:
-        super().__init__()
-        self.__network = network
-        self.__refresh_time = refresh_time
-        self.__stop = False
-
-    def run(self) -> None:
-        """Continuously check the status of all servos in the network."""
-        while not self.__stop:
-            try:
-                for servo in self.__network.servos:
-                    slave_id = servo.slave_id
-                    servo_state = self.__network.get_servo_state(slave_id)
-                    is_servo_alive = servo.is_alive()
-                    if servo_state == NetState.CONNECTED and not is_servo_alive:
-                        self.__network._transition_servo_state(slave_id, NetDevEvt.REMOVED)
-                    if (
-                        servo_state == NetState.DISCONNECTED
-                        and is_servo_alive
-                        and self.__network.recover_from_disconnection(servo)
-                    ):
-                        self.__network._transition_servo_state(slave_id, NetDevEvt.ADDED)
-            except Exception as e:
-                logger.exception(f"Exception during virtual EtherCAT status check: {e}")
-            time.sleep(self.__refresh_time)
-
-    def stop(self) -> None:
-        """Stop the listener."""
-        self.__stop = True
 
 
 class VirtualEthercatNetwork(EthercatNetworkBase[VirtualEthercatServo]):
@@ -67,7 +23,7 @@ class VirtualEthercatNetwork(EthercatNetworkBase[VirtualEthercatServo]):
     def __init__(self) -> None:
         super().__init__()
         self._virtual_base = VirtualNetworkBase()
-        self.__listener_net_status: Optional[VirtualNetStatusListener] = None
+        self.__listener_net_status: Optional[NetStatusListener[VirtualEthercatServo]] = None
 
     def scan_slaves(self) -> list[int]:
         """Scan for virtual EtherCAT drives.
@@ -168,7 +124,7 @@ class VirtualEthercatNetwork(EthercatNetworkBase[VirtualEthercatServo]):
     def start_status_listener(self) -> None:
         """Start monitoring network events (CONNECTION/DISCONNECTION)."""
         if self.__listener_net_status is None:
-            listener = VirtualNetStatusListener(self)
+            listener = NetStatusListener(self)
             listener.start()
             self.__listener_net_status = listener
 

--- a/ingenialink/virtual/ethernet/network.py
+++ b/ingenialink/virtual/ethernet/network.py
@@ -92,7 +92,7 @@ class VirtualEthernetNetwork(EthernetNetworkBase[VirtualEthernetServo]):
         return True
 
     @override
-    def load_firmware(*_args: Any, **_kwargs: Any) -> None:
+    def load_firmware(self, *_args: Any, **_kwargs: Any) -> None:
         """Load firmware to a virtual Ethernet drive.
 
         Raises:

--- a/ingenialink/virtual/ethernet/network.py
+++ b/ingenialink/virtual/ethernet/network.py
@@ -1,9 +1,11 @@
-from typing import Callable, Optional
+from collections import OrderedDict
+from typing import Any, Callable, Optional
+
+from typing_extensions import override
 
 from ingenialink.constants import DEFAULT_ETH_CONNECTION_TIMEOUT
 from ingenialink.ethernet.network import EthernetNetworkBase
-from ingenialink.exceptions import ILError
-from ingenialink.network import NetState
+from ingenialink.network import SlaveInfo
 from ingenialink.servo import Servo
 from ingenialink.virtual.base_network import VirtualNetworkBase
 from ingenialink.virtual.ethernet.servo import VirtualEthernetServo
@@ -65,29 +67,59 @@ class VirtualEthernetNetwork(EthernetNetworkBase[VirtualEthernetServo]):
         Raises:
             ILError: if the drive is not found in IP.
         """
-        servo = VirtualEthernetServo(
-            self._virtual_base.virtual_drive_ip_address,
-            dictionary,
-            port,
-            connection_timeout,
-            servo_status_listener,
+        return super().connect_to_slave(
+            target=self._virtual_base.virtual_drive_ip_address,
+            dictionary=dictionary,
+            port=port,
+            connection_timeout=connection_timeout,
+            servo_status_listener=servo_status_listener,
+            net_status_listener=net_status_listener,
             disconnect_callback=disconnect_callback,
         )
-        try:
-            servo.get_state()
-        except ILError as e:
-            servo.stop_status_listener()
-            raise ILError(
-                f"Drive not found in IP {self._virtual_base.virtual_drive_ip_address}."
-            ) from e
-        self.servos.append(servo)
-        self._set_servo_state(self._virtual_base.virtual_drive_ip_address, NetState.CONNECTED)
 
-        if net_status_listener:
-            self.start_status_listener()
-        else:
-            self.stop_status_listener()
-        return servo
+    @override
+    def recover_from_disconnection(self, servo: Optional[Servo] = None) -> bool:
+        """The virtual Ethernet network does not need to perform any action on disconnection.
+
+        Args:
+            servo: The servo that was disconnected, if applicable.
+
+        Returns:
+            True, indicating that the network is ready to accept new connections.
+
+
+        """
+        return True
+
+    @override
+    def load_firmware(*_args: Any, **_kwargs: Any) -> None:
+        """Load firmware to a virtual Ethernet drive.
+
+        Raises:
+            NotImplementedError: Firmware loading is not supported by this network.
+
+        """
+        raise NotImplementedError("Firmware loading is not supported for Virtual Ethernet.")
+
+    def scan_slaves(self) -> list[str]:  # type: ignore [override]
+        """Scan for virtual Ethernet drives.
+
+        Returns:
+            List of discovered slave IDs.
+
+        """
+        if self.servos:
+            return [servo.target for servo in self.servos if isinstance(servo.target, str)]
+        return []
+
+    def scan_slaves_info(self) -> OrderedDict[str, SlaveInfo]:  # type: ignore [override]
+        """Scan for virtual Ethernet drives and retrieve basic info.
+
+        Returns:
+            Ordered dictionary of slave IDs and their basic information.
+
+        """
+        return OrderedDict((slave_id, SlaveInfo()) for slave_id in self.scan_slaves())
 
 
 __all__ = ["VirtualEthernetNetwork"]

--- a/ingenialink/virtual/ethernet/network.py
+++ b/ingenialink/virtual/ethernet/network.py
@@ -108,9 +108,7 @@ class VirtualEthernetNetwork(EthernetNetworkBase[VirtualEthernetServo]):
             List of discovered slave IDs.
 
         """
-        if self.servos:
-            return [servo.target for servo in self.servos if isinstance(servo.target, str)]
-        return []
+        return [servo.target for servo in self.servos if isinstance(servo.target, str)]
 
     def scan_slaves_info(self) -> OrderedDict[str, SlaveInfo]:  # type: ignore [override]
         """Scan for virtual Ethernet drives and retrieve basic info.


### PR DESCRIPTION
## Summary

Reorganize the Ethernet network hierarchy so that `EthernetNetworkBase` contains only behavior shared by physical and virtual Ethernet networks, while `EthernetNetwork` owns functionality specific to physical devices.

The existing `NetStatusListener` has also been generalized and reused by the virtual network implementations, removing duplicated status-monitoring logic.

## Changes

- Moved physical-device responsibilities from `EthernetNetworkBase` to `EthernetNetwork`, including:
  - IPv4 subnet and slave information scanning.
  - FTP and MOCO firmware loading.
  - Network interface and subnet ownership.
  - Physical-device recovery.
  - SDCP node discovery and management.
- Kept shared behavior in `EthernetNetworkBase`, including:
  - Servo creation and connection workflow.
  - Socket-based disconnection.
  - Network status listener lifecycle.
  - Servo state management.
- Updated `VirtualEthernetNetwork` to reuse the connection workflow provided by `EthernetNetworkBase`.
- Generalized `NetStatusListener` and reused it across virtual network implementations, removing protocol-specific listener duplication.

## Validation

Verified the shared network status listener behavior with:

- `test_virtual_canopen_servo_and_network_status_listeners`
- `test_virtual_ethercat_servo_and_network_status_listeners`
- `test_virtual_ethernet_servo_and_network_status_listeners`