### PR TITLE
INGK-1279 Parse ETH-SDCP dictionary on ingenialink

### DIFF
--- a/ingenialink/dictionary.py
+++ b/ingenialink/dictionary.py
@@ -23,7 +23,7 @@ from ingenialink.enums.register import (
     RegDtype,
 )
 from ingenialink.ethercat.register import EthercatRegister
-from ingenialink.ethernet.register import EthernetRegister
+from ingenialink.ethernet.register import EthernetRegister, SDCPRegister
 from ingenialink.exceptions import ILDictionaryParseError
 from ingenialink.register import MonDistV3, Register
 from ingenialink.utils._utils import weak_lru
@@ -74,6 +74,8 @@ class Interface(enum.Enum):
     """EtherCAT"""
     EoE = enum.auto()
     """Ethernet over EtherCAT"""
+    SDCP = enum.auto()
+    """SDCP"""
 
 
 class SubnodeType(enum.Enum):
@@ -999,6 +1001,8 @@ class DictionaryV3(Dictionary):
             return "ECATDevice"
         if interface is Interface.EoE:
             return "EoEDevice"
+        if interface is Interface.SDCP:
+            return "ETH-SDCP"
         raise ILDictionaryParseError(f"{interface=} has no device element associated.")
 
     @staticmethod
@@ -1244,6 +1248,8 @@ class DictionaryV3(Dictionary):
         if self.interface == Interface.ETH:
             self.__read_device_eth(device_element)
         if self.interface == Interface.CAN:
+            self.__read_device_can(device_element)
+        if self.interface == Interface.SDCP:
             self.__read_device_can(device_element)
         if self.interface == Interface.ECAT:
             self.__read_device_ecat(device_element)
@@ -1618,6 +1624,8 @@ class DictionaryV3(Dictionary):
             register_instance = CanopenRegister
         elif self.interface == Interface.ECAT:
             register_instance = EthercatRegister
+        elif self.interface == Interface.SDCP:
+            register_instance = SDCPRegister
         else:
             raise ValueError(
                 f"Cannot create Canopen/Ethercat register for interface {self.interface}"

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -4,6 +4,7 @@ from xml.etree import ElementTree
 
 import ingenialogger
 
+from ingenialink.canopen.dictionary import CanopenDictionary
 from ingenialink.constants import MAP_ADDRESS_OFFSET
 from ingenialink.dictionary import (
     Dictionary,
@@ -151,3 +152,14 @@ class EoEDictionaryV3(EoEDictionary, DictionaryV3):
         dictionary_path: Path to the Ingenia dictionary.
 
     """
+
+
+class SDCPDictionaryV3(CanopenDictionary, DictionaryV3):
+    """Contains all registers and information of a SDCP dictionary.
+
+    Args:
+        dictionary_path: Path to the Ingenia dictionary.
+
+    """
+
+    interface = Interface.SDCP

--- a/ingenialink/ethernet/dictionary.py
+++ b/ingenialink/ethernet/dictionary.py
@@ -155,7 +155,7 @@ class EoEDictionaryV3(EoEDictionary, DictionaryV3):
 
 
 class SDCPDictionaryV3(CanopenDictionary, DictionaryV3):
-    """Contains all registers and information of a SDCP dictionary.
+    """Contains all registers and information of an SDCP dictionary.
 
     Args:
         dictionary_path: Path to the Ingenia dictionary.

--- a/ingenialink/ethernet/register.py
+++ b/ingenialink/ethernet/register.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Union
 
 from ingenialink.bitfield import BitField
+from ingenialink.canopen.register import CanopenRegister
 from ingenialink.enums.register import (
     RegAccess,
     RegAddressType,
@@ -97,3 +98,7 @@ class EthernetRegister(Register):
     def address(self) -> int:
         """Register address."""
         return self.__address
+
+
+class SDCPRegister(CanopenRegister):
+    """Class to represent an SDCP register."""

--- a/ingenialink/ethernet/tsn/sdcp/__init__.py
+++ b/ingenialink/ethernet/tsn/sdcp/__init__.py
@@ -65,6 +65,4 @@ __all__ = [
     "SDCPOpcode",
     "identify_sdcp_node",
     "DEFAULT_SDCP_TIMEOUT_S",
-    "SDCPNode",
-    "SDCPServo",
 ]

--- a/ingenialink/ethernet/tsn/sdcp/__init__.py
+++ b/ingenialink/ethernet/tsn/sdcp/__init__.py
@@ -65,4 +65,6 @@ __all__ = [
     "SDCPOpcode",
     "identify_sdcp_node",
     "DEFAULT_SDCP_TIMEOUT_S",
+    "SDCPNode",
+    "SDCPServo",
 ]

--- a/ingenialink/ethernet/tsn/sdcp/servo.py
+++ b/ingenialink/ethernet/tsn/sdcp/servo.py
@@ -35,8 +35,7 @@ class SDCPServo(TSNServoBase):
 
     """
 
-    # Temporary use of the CAN interface until TSN dictionary support is available (INGK-1279).
-    interface = Interface.CAN
+    interface = Interface.SDCP
 
     _CONNECTION_TIMEOUT_S = 1.0
     _INITIAL_TRANSACTION_ID = 0x0000

--- a/ingenialink/servo.py
+++ b/ingenialink/servo.py
@@ -46,6 +46,7 @@ from ingenialink.ethernet.dictionary import (
     EoEDictionaryV3,
     EthernetDictionaryV2,
     EthernetDictionaryV3,
+    SDCPDictionaryV3,
 )
 from ingenialink.exceptions import (
     ILAccessError,
@@ -115,6 +116,8 @@ class DictionaryFactory:
                 return EoEDictionaryV3(dictionary_path)
             if interface == Interface.ETH:
                 return EthernetDictionaryV3(dictionary_path)
+            if interface == Interface.SDCP:
+                return SDCPDictionaryV3(dictionary_path)
         if major_version == 2:
             if interface == Interface.CAN:
                 return CanopenDictionaryV2(dictionary_path)

--- a/tests/resources/ethernet/__init__.py
+++ b/tests/resources/ethernet/__init__.py
@@ -4,3 +4,4 @@ resources_path = absolute_module_path = Path(__file__).parent
 
 TEST_DICT_ETHERNET = (resources_path / "test_dict_eth.xdf").as_posix()
 TEST_DICT_ETHERNET_AXIS = (resources_path / "test_dict_eth_axis.xdf").as_posix()
+TEST_DICT_SDCP_v3 = (resources_path / "sdcp_example.xdf3").as_posix()

--- a/tests/resources/ethernet/sdcp_example.xdf3
+++ b/tests/resources/ethernet/sdcp_example.xdf3
@@ -14,9 +14,6 @@
     </Categories>
     <Devices>
       <ETH-SDCP firmwareVersion="2.11.0" ProductCode="57745409" PartNumber="EVS-NET" RevisionNumber="196635">
-        <Subnodes>
-          <Subnode index="0">Communication</Subnode>
-        </Subnodes>
         <CANopenObjects>
           <CANopenObject id="PRODUCT_CODE" index="0x1000" datatype="VAR">
             <Labels>

--- a/tests/resources/ethernet/sdcp_example.xdf3
+++ b/tests/resources/ethernet/sdcp_example.xdf3
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<IngeniaDictionary>
+  <Header>
+    <Version>3.1</Version>
+    <DefaultLanguage>en_US</DefaultLanguage>
+  </Header>
+  <Body>
+    <Categories>
+      <Category id="IDENTIFICATION">
+        <Labels>
+          <Label lang="en_US">Product Identification</Label>
+        </Labels>
+      </Category>
+    </Categories>
+    <Devices>
+      <ETH-SDCP firmwareVersion="2.11.0" ProductCode="57745409" PartNumber="EVS-NET" RevisionNumber="196635">
+        <Subnodes>
+          <Subnode index="0">Communication</Subnode>
+        </Subnodes>
+        <CANopenObjects>
+          <CANopenObject id="PRODUCT_CODE" index="0x1000" datatype="VAR">
+            <Labels>
+              <Label lang="en_US">Product code</Label>
+            </Labels>
+            <Subitems>
+              <Subitem subindex="0" address_type="NVM_NONE" access="r" dtype="u32" id="PRODUCT_CODE" pdo_access="CONFIG" desc="This object shall provide information about the device type. The object describes the type of the logical device and its functionality." units="-" default="00000000" cat_id="IDENTIFICATION">
+                <Labels>
+                  <Label lang="en_US">Product code</Label>
+                </Labels>
+              </Subitem>
+            </Subitems>
+          </CANopenObject>
+        </CANopenObjects>
+        <Errors>
+          <Error id="0x00003280" affected_module="Power stage" error_type="cyclic">
+            <Labels>
+              <Label lang="en_US">STO Active and Power stage is shutdown</Label>
+            </Labels>
+          </Error>
+        </Errors>
+      </ETH-SDCP>
+    </Devices>
+  </Body>
+  <DriveImage encoding="xs:base64Binary"></DriveImage>
+</IngeniaDictionary>

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -27,6 +27,7 @@ from ingenialink.ethercat.dictionary import EthercatDictionaryV2, EthercatDictio
 from ingenialink.ethernet.dictionary import (
     EoEDictionaryV3,
     EthernetDictionaryV2,
+    SDCPDictionaryV3,
 )
 from ingenialink.servo import DictionaryFactory
 
@@ -231,6 +232,7 @@ def test_dictionary_v2_image_none(dictionary_class, dictionary_path):
         (tests.resources.TEST_DICT_ECAT_EOE_v3, Interface.EoE, EoEDictionaryV3),
         (tests.resources.TEST_DICT_ECAT_EOE_SAFE_v3, Interface.ECAT, EthercatDictionaryV3),
         (tests.resources.TEST_DICT_ECAT_EOE_SAFE_v3, Interface.EoE, EoEDictionaryV3),
+        (tests.resources.ethernet.TEST_DICT_SDCP_v3, Interface.SDCP, SDCPDictionaryV3),
     ],
 )
 def test_dictionary_factory(dict_path, interface, dict_class):


### PR DESCRIPTION
Adds support for parsing Ethernet SDCP dictionaries in IngeniaLink.

**Changes**

- Adds Interface.SDCP and maps it to the ETH-SDCP dictionary element.
- Introduces SDCPDictionaryV3 and SDCPRegister.
- Updates SDCPServo to use the SDCP interface.
- Extends DictionaryFactory to create SDCP dictionaries.
- Adds an SDCP .xdf3 fixture and factory regression coverage.