### PR TITLE
INGK-1294 Prevent unexpected output when applying SDCP capture filter

### DIFF
--- a/ingenialink/ethernet/tsn/ipv6_pcap_capture.py
+++ b/ingenialink/ethernet/tsn/ipv6_pcap_capture.py
@@ -27,7 +27,11 @@ class PcapCapture:
             self._capture.activate()
             if self._capture.datalink() != cypcap.DatalinkType.EN10MB:
                 raise OSError("Pcap discovery requires an Ethernet interface.")
-            self._capture.setfilter("ip6 or (vlan and ip6)")
+            # The IPv4 netmask is not required for this IPv6-only filter, so avoid its lookup.
+            self._capture.setfilter(
+                "ip6 or (vlan and ip6)",
+                netmask=cypcap.NETMASK_UNKNOWN,
+            )
         except cypcap.Error as error:
             self.close()
             raise OSError(f"Unable to configure pcap capture: {error}") from error

--- a/tests/ethernet/tsn/test_ipv6_pcap_capture.py
+++ b/tests/ethernet/tsn/test_ipv6_pcap_capture.py
@@ -20,7 +20,9 @@ def test_pcap_capture_applies_ipv6_filter(mocker):
     capture.set_promisc.assert_called_once_with(False)
     capture.set_timeout.assert_called_once_with(0.01)
     capture.activate.assert_called_once_with()
-    capture.setfilter.assert_called_once_with("ip6 or (vlan and ip6)")
+    capture.setfilter.assert_called_once_with(
+        "ip6 or (vlan and ip6)", netmask=cypcap.NETMASK_UNKNOWN
+    )
     pcap_capture.close()
 
 


### PR DESCRIPTION
## Description

Prevent an unexpected number from being printed when applying the SDCP packet capture filter.

When no netmask is provided, [cypcap](https://github.com/segevfiner/cypcap/blob/v0.6.2/cypcap/_cypcap.pyx#L875) looks up and prints the interface netmask while compiling the filter. Since the SDCP capture filter only targets IPv6 traffic, the IPv4 netmask is not required.

## Changes

- Compile the SDCP capture filter with `cypcap.NETMASK_UNKNOWN`.
- Add a comment explaining why the IPv4 netmask is not required.

## Validation
- Verified that SDCP node scanning completes successfully.
- Verified that the unexpected number is no longer printed.