### PR TITLE
INGK-1297 Support configurable UDP port for virtual SDCP drives

### DIFF
--- a/ingenialink/ethernet/tsn/sdcp/connection.py
+++ b/ingenialink/ethernet/tsn/sdcp/connection.py
@@ -41,7 +41,6 @@ class SDCPConnection:
     """
 
     _MAX_RESPONSE_SIZE = 65_535
-    _ACYCLIC_PORT = DEFAULT_SDCP_PORT
 
     def __init__(
         self,

--- a/ingenialink/ethernet/tsn/sdcp/connection.py
+++ b/ingenialink/ethernet/tsn/sdcp/connection.py
@@ -21,6 +21,7 @@ from .messages import (
 )
 
 DEFAULT_SDCP_TIMEOUT_S = 1.0
+DEFAULT_SDCP_PORT = 22_334
 
 
 class SDCPConnection:
@@ -31,6 +32,7 @@ class SDCPConnection:
         interface: Network interface in the same format as
             :func:`ingenialink.ethernet.tsn.ipv6_discovery.discover_ipv6_devices`.
         timeout: Timeout in seconds for SDCP requests and responses.
+        port: UDP port used for SDCP requests.
 
     Raises:
         OSError: If the interface cannot be resolved.
@@ -39,13 +41,14 @@ class SDCPConnection:
     """
 
     _MAX_RESPONSE_SIZE = 65_535
-    _ACYCLIC_PORT = 22_334
+    _ACYCLIC_PORT = DEFAULT_SDCP_PORT
 
     def __init__(
         self,
         address: str,
         interface: str,
         timeout: float,
+        port: int = DEFAULT_SDCP_PORT,
     ) -> None:
         interface_index = (
             0 if ipaddress.IPv6Address(address).is_loopback else get_interface_index(interface)
@@ -53,7 +56,7 @@ class SDCPConnection:
 
         self._destination = IPv6SocketAddress(
             address,
-            self._ACYCLIC_PORT,
+            port,
             0,
             interface_index,
         )

--- a/ingenialink/ethernet/tsn/sdcp/servo.py
+++ b/ingenialink/ethernet/tsn/sdcp/servo.py
@@ -9,7 +9,7 @@ from ingenialink.ethernet.tsn.servo import TSNServoBase
 from ingenialink.exceptions import ILIOError
 from ingenialink.servo import Servo
 
-from .connection import SDCPConnection
+from .connection import DEFAULT_SDCP_PORT, SDCPConnection
 from .messages import (
     SDCPReadRequest,
     SDCPReadResponse,
@@ -53,10 +53,23 @@ class SDCPServo(TSNServoBase):
         super().__init__(
             target, dictionary_path, servo_status_listener, disconnect_callback=disconnect_callback
         )
-        self._connection = SDCPConnection(target, interface, connection_timeout)
+        self._connection = self._create_connection(target, interface, connection_timeout)
         self._transaction_id = self._INITIAL_TRANSACTION_ID
         self._request_lock = Lock()
         self._disconnected = False
+
+    def _create_connection(
+        self,
+        target: str,
+        interface: str,
+        connection_timeout: float,
+    ) -> SDCPConnection:
+        """Create the fixed-port connection used by physical SDCP servos.
+
+        Returns:
+            Connection to the physical SDCP servo.
+        """
+        return SDCPConnection(target, interface, connection_timeout, DEFAULT_SDCP_PORT)
 
     def disconnect(self) -> None:
         """Close the SDCP connection and publish the disconnection event."""

--- a/ingenialink/virtual/sdcp/network.py
+++ b/ingenialink/virtual/sdcp/network.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from typing import Any, Callable, Optional
 
 from ingenialink.ethernet.network import NetStatusListener
-from ingenialink.ethernet.tsn.sdcp.connection import DEFAULT_SDCP_TIMEOUT_S
+from ingenialink.ethernet.tsn.sdcp.connection import DEFAULT_SDCP_PORT, DEFAULT_SDCP_TIMEOUT_S
 from ingenialink.exceptions import ILError, ILStateError
 from ingenialink.network import NetProt, NetState, Network, ServoTarget, SlaveInfo
 from ingenialink.servo import Servo
@@ -34,12 +34,24 @@ class VirtualSDCPNetwork(Network[VirtualSDCPServo]):
     def connect_to_slave(
         self,
         dictionary: str,
+        port: int = DEFAULT_SDCP_PORT,
         connection_timeout: float = DEFAULT_SDCP_TIMEOUT_S,
         servo_status_listener: bool = False,
         net_status_listener: bool = False,
         disconnect_callback: Optional[Callable[[Servo], None]] = None,
     ) -> VirtualSDCPServo:
         """Connect to the virtual SDCP drive without performing discovery.
+
+        Args:
+            dictionary: Path to the target dictionary file.
+            port: UDP port to connect to the virtual SDCP drive.
+            connection_timeout: Timeout in seconds for SDCP requests and responses.
+            servo_status_listener: Toggle the listener of the servo for
+                its status, errors, faults, etc.
+            net_status_listener: Toggle the listener of the network
+                status, connection and disconnection.
+            disconnect_callback: Callback function to be called when the servo is disconnected.
+                If not specified, no callback will be called.
 
         Returns:
             The connected virtual SDCP servo.
@@ -57,6 +69,7 @@ class VirtualSDCPNetwork(Network[VirtualSDCPServo]):
             connection_timeout=connection_timeout,
             servo_status_listener=servo_status_listener,
             disconnect_callback=disconnect_callback,
+            port=port,
         )
         try:
             servo.get_state()

--- a/ingenialink/virtual/sdcp/servo.py
+++ b/ingenialink/virtual/sdcp/servo.py
@@ -1,6 +1,7 @@
 from typing import Callable, Optional
 
 from ingenialink import Servo
+from ingenialink.ethernet.tsn.sdcp.connection import DEFAULT_SDCP_PORT, SDCPConnection
 from ingenialink.ethernet.tsn.sdcp.servo import SDCPServo
 
 VIRTUAL_SDCP_INTERFACE = "loopback"
@@ -16,7 +17,9 @@ class VirtualSDCPServo(SDCPServo):
         connection_timeout: float = SDCPServo._CONNECTION_TIMEOUT_S,
         servo_status_listener: bool = False,
         disconnect_callback: Optional[Callable[[Servo], None]] = None,
+        port: int = DEFAULT_SDCP_PORT,
     ) -> None:
+        self._port = port
         super().__init__(
             target=target,
             interface=VIRTUAL_SDCP_INTERFACE,
@@ -25,6 +28,19 @@ class VirtualSDCPServo(SDCPServo):
             servo_status_listener=servo_status_listener,
             disconnect_callback=disconnect_callback,
         )
+
+    def _create_connection(
+        self,
+        target: str,
+        interface: str,
+        connection_timeout: float,
+    ) -> SDCPConnection:
+        """Create a connection using the virtual drive's configured port.
+
+        Returns:
+            Connection to the virtual SDCP servo.
+        """
+        return SDCPConnection(target, interface, connection_timeout, self._port)
 
 
 __all__ = ["VIRTUAL_SDCP_INTERFACE", "VirtualSDCPServo"]

--- a/tests/virtual/test_virtual_sdcp_network.py
+++ b/tests/virtual/test_virtual_sdcp_network.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from ingenialink.ethernet.network import NetStatusListener
+from ingenialink.ethernet.tsn.sdcp.connection import DEFAULT_SDCP_PORT
 from ingenialink.exceptions import ILError
 from ingenialink.network import NetDevEvt, NetState
 from ingenialink.virtual.sdcp.network import VIRTUAL_SDCP_TARGET, VirtualSDCPNetwork
@@ -56,7 +57,25 @@ def test_connect_to_slave_uses_loopback_target(
         connection_timeout=TIMEOUT_S,
         servo_status_listener=False,
         disconnect_callback=None,
+        port=DEFAULT_SDCP_PORT,
     )
+
+
+def test_connect_to_slave_uses_configured_port(
+    network: VirtualSDCPNetwork,
+    mocker,
+) -> None:
+    """Pass the configured port to the virtual SDCP servo."""
+    servo_mock = MagicMock(spec=VirtualSDCPServo)
+    servo_mock.target = VIRTUAL_SDCP_TARGET
+    servo_class_mock = mocker.patch(
+        "ingenialink.virtual.sdcp.network.VirtualSDCPServo",
+        return_value=servo_mock,
+    )
+
+    network.connect_to_slave(dictionary=DICTIONARY_PATH, port=22_335)
+
+    assert servo_class_mock.call_args.kwargs["port"] == 22_335
 
 
 def test_connects_to_virtual_sdcp_drive(virtual_drive_sdcp) -> None:

--- a/tests/virtual/test_virtual_sdcp_servo.py
+++ b/tests/virtual/test_virtual_sdcp_servo.py
@@ -7,6 +7,7 @@ from ingenialink.virtual.sdcp.servo import VIRTUAL_SDCP_INTERFACE, VirtualSDCPSe
 
 DICTIONARY_PATH = "test_dictionary.xdf"
 TARGET = "::1"
+PORT = 22_335
 TIMEOUT_S = 2.0
 
 
@@ -16,7 +17,7 @@ def test_virtual_servo_creates_loopback_connection() -> None:
 
     with (
         patch(
-            "ingenialink.ethernet.tsn.sdcp.servo.SDCPConnection",
+            "ingenialink.virtual.sdcp.servo.SDCPConnection",
             return_value=connection_mock,
         ) as connection_class_mock,
         patch(
@@ -28,10 +29,16 @@ def test_virtual_servo_creates_loopback_connection() -> None:
             target=TARGET,
             dictionary_path=DICTIONARY_PATH,
             connection_timeout=TIMEOUT_S,
+            port=PORT,
         )
 
     assert servo._connection is connection_mock
-    connection_class_mock.assert_called_once_with(TARGET, VIRTUAL_SDCP_INTERFACE, TIMEOUT_S)
+    connection_class_mock.assert_called_once_with(
+        TARGET,
+        VIRTUAL_SDCP_INTERFACE,
+        TIMEOUT_S,
+        PORT,
+    )
 
     servo._disconnect_event_publisher = MagicMock()
     servo.disconnect()


### PR DESCRIPTION
## Description

The virtual SDCP network always connected to UDP port `22_334`. Add support for configurable port.

This change makes virtual SDCP connections behave consistently with the other virtual network implementations:

- Add an optional `port` argument to `VirtualSDCPNetwork.connect_to_slave`.
- Keep physical `SDCPServo` connections on the standard port.
