### PR TITLE
INGK-1300 Verify an Ethernet adapter address is found

### DIFF
--- a/tests/test_get_adapters_addresses.py
+++ b/tests/test_get_adapters_addresses.py
@@ -1,5 +1,4 @@
 import platform
-import re
 
 import pytest
 
@@ -19,11 +18,8 @@ def adapters_module():
 
 
 @pytest.mark.ethercat
-def test_get_adapters_addresses(adapters_module, setup_descriptor):
-    ifname_match = re.search(r"\{[^}]*\}", setup_descriptor.ifname)
-    expected_adapter_address = ifname_match.group(0) if ifname_match else None
-    assert expected_adapter_address is not None
-
+def test_get_adapters_addresses(adapters_module):
+    """Verify that at least one Ethernet adapter with a unicast address is found."""
     adapters = adapters_module.get_adapters_addresses(
         adapter_families=adapters_module.AdapterFamily.INET,
         scan_flags=[
@@ -37,9 +33,7 @@ def test_get_adapters_addresses(adapters_module, setup_descriptor):
         # https://learn.microsoft.com/en-us/windows/win32/api/ifdef/ns-ifdef-net_luid_lh
         if adapter.IfType != 6 or not len(adapter.FirstUnicastAddress):
             continue
-
-        if adapter.AdapterName == expected_adapter_address:
-            expected_adapter_address_found = True
-            break
+        expected_adapter_address_found = True
+        break
 
     assert expected_adapter_address_found is True


### PR DESCRIPTION
## Description

Updates `test_get_adapters_addresses` to verify that the adapters module works by checking that it returns at least one Ethernet adapter with a unicast address, instead of expecting the adapter configured in `setup_descriptor`.

The test machine's network adapter was configured with only the Npcap filter enabled. With this configuration, the specific adapter expected by the test is no longer returned.

Since the purpose of the test is to verify the functionality of the adapters module, the test should not depend on a specific adapter or network configuration.