### PR TITLE
INGK-1301 Fix race condition in virtual status listener tests

### DIFF
--- a/tests/virtual/test_virtual_canopen_network.py
+++ b/tests/virtual/test_virtual_canopen_network.py
@@ -37,11 +37,8 @@ def test_virtual_canopen_servo_and_network_status_listeners(mocker):
             servo_status_listener=True,
             net_status_listener=True,
         )
-
-        servo_events: list[tuple[ServoState, int]] = []
-        net_events: list[object] = []
-        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
-        net.subscribe_to_status(servo.target, net_events.append)
+        # Prevent the listener from consuming states before the mock and subscriptions are ready.
+        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 
@@ -49,6 +46,13 @@ def test_virtual_canopen_servo_and_network_status_listeners(mocker):
             return next(state_sequence)
 
         mocker.patch.object(servo, "get_state", side_effect=mocked_get_state)
+
+        servo_events: list[tuple[ServoState, int]] = []
+        net_events: list[object] = []
+        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
+        net.subscribe_to_status(servo.target, net_events.append)
+        # Start state polling only after the status observers have been registered.
+        servo.start_status_listener()
 
         # Wait until the servo listener has reported the first disabled
         # and subsequent enabled events.

--- a/tests/virtual/test_virtual_canopen_network.py
+++ b/tests/virtual/test_virtual_canopen_network.py
@@ -34,11 +34,9 @@ def test_virtual_canopen_servo_and_network_status_listeners(mocker):
             1,
             VIRTUAL_DRIVE_CAN_V2_XDF,
             server.port,
-            servo_status_listener=True,
+            servo_status_listener=False,
             net_status_listener=True,
         )
-        # Prevent the listener from consuming states before the mock and subscriptions are ready.
-        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 

--- a/tests/virtual/test_virtual_ethercat_network.py
+++ b/tests/virtual/test_virtual_ethercat_network.py
@@ -37,11 +37,9 @@ def test_virtual_ethercat_servo_and_network_status_listeners(mocker):
             1,
             dictionary,
             server.port,
-            servo_status_listener=True,
+            servo_status_listener=False,
             net_status_listener=True,
         )
-        # Prevent the listener from consuming states before the mock and subscriptions are ready.
-        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 

--- a/tests/virtual/test_virtual_ethercat_network.py
+++ b/tests/virtual/test_virtual_ethercat_network.py
@@ -40,11 +40,8 @@ def test_virtual_ethercat_servo_and_network_status_listeners(mocker):
             servo_status_listener=True,
             net_status_listener=True,
         )
-
-        servo_events: list[tuple[ServoState, int]] = []
-        net_events: list[object] = []
-        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
-        net.subscribe_to_status(servo.slave_id, net_events.append)
+        # Prevent the listener from consuming states before the mock and subscriptions are ready.
+        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 
@@ -52,6 +49,13 @@ def test_virtual_ethercat_servo_and_network_status_listeners(mocker):
             return next(state_sequence)
 
         mocker.patch.object(servo, "get_state", side_effect=mocked_get_state)
+
+        servo_events: list[tuple[ServoState, int]] = []
+        net_events: list[object] = []
+        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
+        net.subscribe_to_status(servo.slave_id, net_events.append)
+        # Start state polling only after the status observers have been registered.
+        servo.start_status_listener()
 
         timeout = time.time() + 4
         while len(servo_events) < 2 and time.time() < timeout:

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -97,11 +97,8 @@ def test_virtual_ethernet_servo_and_network_status_listeners(mocker):
             servo_status_listener=True,
             net_status_listener=True,
         )
-
-        servo_events = []
-        net_events = []
-        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
-        net.subscribe_to_status(server.ip, net_events.append)
+        # Prevent the listener from consuming states before the mock and subscriptions are ready.
+        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 
@@ -109,6 +106,13 @@ def test_virtual_ethernet_servo_and_network_status_listeners(mocker):
             return next(state_sequence)
 
         mocker.patch.object(servo, "get_state", side_effect=mocked_get_state)
+
+        servo_events = []
+        net_events = []
+        servo.subscribe_to_status(lambda state, subnode: servo_events.append((state, subnode)))
+        net.subscribe_to_status(server.ip, net_events.append)
+        # Start state polling only after the status observers have been registered.
+        servo.start_status_listener()
 
         timeout = time.time() + 4
         while len(servo_events) < 2 and time.time() < timeout:

--- a/tests/virtual/test_virtual_network.py
+++ b/tests/virtual/test_virtual_network.py
@@ -94,11 +94,9 @@ def test_virtual_ethernet_servo_and_network_status_listeners(mocker):
         servo = net.connect_to_slave(
             dictionary,
             server.port,
-            servo_status_listener=True,
+            servo_status_listener=False,
             net_status_listener=True,
         )
-        # Prevent the listener from consuming states before the mock and subscriptions are ready.
-        servo.stop_status_listener()
 
         state_sequence = iter([ServoState.DISABLED, ServoState.ENABLED, ServoState.ENABLED])
 


### PR DESCRIPTION
## Summary

Fix a race condition in the virtual status-listener tests.

## Changes

- Connect to the virtual servo without starting its status listener.
- Mock the servo states and register the status observers.
- Start state polling only after the mock and observers are ready.

## Why

The tests expected `DISABLED` to be the first reported servo state, but an intermittent Jenkins failure received `NRDY` instead.

The servo status listener previously started during connection, so it could poll and report a state before the mock and subscriptions were configured. The updated setup prevents the listener from starting until everything required by the test is ready.

## Testing

The failure could not be reproduced locally or in subsequent Jenkins runs. The race condition was identified by analyzing the listener setup and the unexpected `NRDY` state reported in the original Jenkins failure.