### PR TITLE
INGK-1306 Use SDCPRegister in SDCPServo

### DIFF
--- a/ingenialink/ethernet/tsn/sdcp/servo.py
+++ b/ingenialink/ethernet/tsn/sdcp/servo.py
@@ -3,8 +3,8 @@
 from threading import Lock
 from typing import Any, Callable, Optional
 
-from ingenialink.canopen.register import CanopenRegister
 from ingenialink.dictionary import Interface
+from ingenialink.ethernet.register import SDCPRegister
 from ingenialink.ethernet.tsn.servo import TSNServoBase
 from ingenialink.exceptions import ILIOError
 from ingenialink.servo import Servo
@@ -79,7 +79,7 @@ class SDCPServo(TSNServoBase):
         self._disconnected = True
         self._disconnect_event_publisher.notify(self)
 
-    def _write_raw(self, reg: CanopenRegister, data: bytes, **_kwargs: Any) -> None:  # type: ignore[override]
+    def _write_raw(self, reg: SDCPRegister, data: bytes, **_kwargs: Any) -> None:  # type: ignore[override]
         """Write raw register bytes through SDCP.
 
         Args:
@@ -98,7 +98,7 @@ class SDCPServo(TSNServoBase):
             if not isinstance(response, SDCPWriteResponse):
                 raise ILIOError(f"Unexpected SDCP write response: {response}")
 
-    def _read_raw(self, reg: CanopenRegister, **_kwargs: Any) -> bytes:  # type: ignore[override]
+    def _read_raw(self, reg: SDCPRegister, **_kwargs: Any) -> bytes:  # type: ignore[override]
         """Read raw register bytes through SDCP.
 
         Args:


### PR DESCRIPTION
## Summary
Use `SDCPRegister` in `SDCPServo` raw register access methods.

## Changes
- Replaced the generic `CanopenRegister` annotations with `SDCPRegister` for SDCP reads and writes.